### PR TITLE
vendor: virtcontainers vendoring update

### DIFF
--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "da977598e9bab2e610652947dc618e138e15e6919e0674a23e20157140538cb1",
+    "memo": "f27ea05dba1ac0eef600373c238e12e89236ac77a637fb2b0e0e6f5bd67c9377",
     "projects": [
         {
             "name": "github.com/01org/cc-oci-runtime",
@@ -55,7 +55,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "9ac05ca6a4c9072c6555414ad05452f20e12fb04",
+            "revision": "242a130215ca7705907bfb3ae9f5ffb0ef805f47",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "9ac05ca6a4c9072c6555414ad05452f20e12fb04"
+            "revision": "242a130215ca7705907bfb3ae9f5ffb0ef805f47"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -514,8 +514,7 @@ func TestListPodFailingFetchPodState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	path := filepath.Join(runStoragePath, p.id)
-	os.RemoveAll(path)
+	os.RemoveAll(p.configPath)
 
 	_, err = StatusPod(p.id)
 	if err == nil {
@@ -1222,11 +1221,7 @@ func TestStatusContainerFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.id)
-	_, err = os.Stat(podDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	os.RemoveAll(p.configPath)
 
 	_, err = StatusContainer(p.id, contID)
 	if err == nil {

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -332,7 +332,7 @@ func (h *hyper) stopPod(pod Pod) error {
 			return err
 		}
 
-		if state.State != stateRunning {
+		if state.State != StateRunning {
 			continue
 		}
 

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -43,14 +43,14 @@ const monitorSocket = "monitor.sock"
 type stateString string
 
 const (
-	// stateReady represents a pod/container that's ready to be run
-	stateReady stateString = "ready"
+	// StateReady represents a pod/container that's ready to be run
+	StateReady stateString = "ready"
 
-	// stateRunning represents a pod/container that's currently running.
-	stateRunning stateString = "running"
+	// StateRunning represents a pod/container that's currently running.
+	StateRunning stateString = "running"
 
-	// stateStopped represents a pod/container that has been stopped.
-	stateStopped stateString = "stopped"
+	// StateStopped represents a pod/container that has been stopped.
+	StateStopped stateString = "stopped"
 )
 
 // State is a pod state structure.
@@ -60,7 +60,7 @@ type State struct {
 
 // valid checks that the pod state is valid.
 func (state *State) valid() bool {
-	for _, validState := range []stateString{stateReady, stateRunning, stateStopped} {
+	for _, validState := range []stateString{StateReady, StateRunning, StateStopped} {
 		if state.State == validState {
 			return true
 		}
@@ -77,18 +77,18 @@ func (state *State) validTransition(oldState stateString, newState stateString) 
 	}
 
 	switch state.State {
-	case stateReady:
-		if newState == stateRunning {
+	case StateReady:
+		if newState == StateRunning {
 			return nil
 		}
 
-	case stateRunning:
-		if newState == stateStopped {
+	case StateRunning:
+		if newState == StateStopped {
 			return nil
 		}
 
-	case stateStopped:
-		if newState == stateRunning {
+	case StateStopped:
+		if newState == StateRunning {
 			return nil
 		}
 	}
@@ -351,12 +351,12 @@ func (p *Pod) GetContainers() []*Container {
 }
 
 func (p *Pod) createSetStates() error {
-	err := p.setPodState(stateReady)
+	err := p.setPodState(StateReady)
 	if err != nil {
 		return err
 	}
 
-	err = p.setContainersState(stateReady)
+	err = p.setContainersState(StateReady)
 	if err != nil {
 		return err
 	}
@@ -490,7 +490,7 @@ func (p *Pod) delete() error {
 		return err
 	}
 
-	if state.State != stateReady && state.State != stateStopped {
+	if state.State != StateReady && state.State != StateStopped {
 		return fmt.Errorf("Pod not ready or stopped, impossible to delete")
 	}
 
@@ -508,17 +508,17 @@ func (p *Pod) startCheckStates() error {
 		return err
 	}
 
-	err = state.validTransition(stateReady, stateRunning)
+	err = state.validTransition(StateReady, StateRunning)
 	if err != nil {
-		err = state.validTransition(stateStopped, stateRunning)
+		err = state.validTransition(StateStopped, StateRunning)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = p.checkContainersState(stateReady)
+	err = p.checkContainersState(StateReady)
 	if err != nil {
-		err = p.checkContainersState(stateStopped)
+		err = p.checkContainersState(StateStopped)
 		if err != nil {
 			return err
 		}
@@ -528,12 +528,12 @@ func (p *Pod) startCheckStates() error {
 }
 
 func (p *Pod) startSetStates() error {
-	err := p.setPodState(stateRunning)
+	err := p.setPodState(StateRunning)
 	if err != nil {
 		return err
 	}
 
-	err = p.setContainersState(stateRunning)
+	err = p.setContainersState(StateRunning)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func (p *Pod) stopCheckStates() error {
 		return err
 	}
 
-	err = state.validTransition(stateRunning, stateStopped)
+	err = state.validTransition(StateRunning, StateStopped)
 	if err != nil {
 		return err
 	}
@@ -612,12 +612,12 @@ func (p *Pod) stopCheckStates() error {
 }
 
 func (p *Pod) stopSetStates() error {
-	err := p.setContainersState(stateStopped)
+	err := p.setContainersState(StateStopped)
 	if err != nil {
 		return err
 	}
 
-	err = p.setPodState(stateStopped)
+	err = p.setPodState(StateStopped)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/virtcontainers/pod_test.go
+++ b/vendor/github.com/containers/virtcontainers/pod_test.go
@@ -125,42 +125,42 @@ func testPodStateTransition(t *testing.T, state stateString, newState stateStrin
 }
 
 func TestPodStateReadyRunning(t *testing.T) {
-	err := testPodStateTransition(t, stateReady, stateRunning)
+	err := testPodStateTransition(t, StateReady, StateRunning)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPodStateRunningPaused(t *testing.T) {
-	err := testPodStateTransition(t, stateRunning, stateStopped)
+	err := testPodStateTransition(t, StateRunning, StateStopped)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPodStatePausedRunning(t *testing.T) {
-	err := testPodStateTransition(t, stateStopped, stateRunning)
+	err := testPodStateTransition(t, StateStopped, StateRunning)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPodStateRunningStopped(t *testing.T) {
-	err := testPodStateTransition(t, stateRunning, stateStopped)
+	err := testPodStateTransition(t, StateRunning, StateStopped)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPodStateReadyPaused(t *testing.T) {
-	err := testPodStateTransition(t, stateReady, stateStopped)
+	err := testPodStateTransition(t, StateReady, StateStopped)
 	if err == nil {
 		t.Fatal("Invalid transition from Ready to Paused")
 	}
 }
 
 func TestPodStatePausedReady(t *testing.T) {
-	err := testPodStateTransition(t, stateStopped, stateReady)
+	err := testPodStateTransition(t, StateStopped, StateReady)
 	if err == nil {
 		t.Fatal("Invalid transition from Ready to Paused")
 	}
@@ -276,9 +276,9 @@ func testStateValid(t *testing.T, stateStr stateString, expected bool) {
 }
 
 func TestStateValidSuccessful(t *testing.T) {
-	testStateValid(t, stateReady, true)
-	testStateValid(t, stateRunning, true)
-	testStateValid(t, stateStopped, true)
+	testStateValid(t, StateReady, true)
+	testStateValid(t, StateRunning, true)
+	testStateValid(t, StateStopped, true)
 }
 
 func TestStateValidFailing(t *testing.T) {
@@ -287,10 +287,10 @@ func TestStateValidFailing(t *testing.T) {
 
 func TestValidTransitionFailingOldStateMismatch(t *testing.T) {
 	state := &State{
-		State: stateReady,
+		State: StateReady,
 	}
 
-	err := state.validTransition(stateRunning, stateStopped)
+	err := state.validTransition(StateRunning, StateStopped)
 	if err == nil {
 		t.Fatal()
 	}
@@ -475,7 +475,7 @@ func TestPodSetPodStateFailingStorePodResource(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.setPodState(stateReady)
+	err := pod.setPodState(StateReady)
 	if err == nil {
 		t.Fatal()
 	}
@@ -487,7 +487,7 @@ func TestPodSetContainerStateFailingStoreContainerResource(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.setContainerState("100", stateReady)
+	err := pod.setContainerState("100", StateReady)
 	if err == nil {
 		t.Fatal()
 	}
@@ -510,7 +510,7 @@ func TestPodSetContainersStateFailingEmptyPodID(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.setContainersState(stateReady)
+	err := pod.setContainersState(StateReady)
 	if err == nil {
 		t.Fatal()
 	}
@@ -659,7 +659,7 @@ func TestPodCheckContainerStateFailingEmptyPodID(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.checkContainerState(contID, stateReady)
+	err := pod.checkContainerState(contID, StateReady)
 	if err == nil {
 		t.Fatal()
 	}
@@ -702,7 +702,7 @@ func TestPodCheckContainerStateFailingNotExpectedState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = pod.checkContainerState(contID, stateStopped)
+	err = pod.checkContainerState(contID, StateStopped)
 	if err == nil {
 		t.Fatal()
 	}
@@ -725,7 +725,7 @@ func TestPodCheckContainersStateFailingEmptyPodID(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.checkContainersState(stateReady)
+	err := pod.checkContainersState(StateReady)
 	if err == nil {
 		t.Fatal()
 	}


### PR DESCRIPTION
In order to implement the OCI runtime relying on virtcontainers, we need
to rely on latest changes:
- Pod and containers state are now public to perform the translation to
OCI specific states.
- PID and RootFs stored inside the Pod object are copied to the PodStatus,
making those info available from "state" command using StatusPod() API.