### PR TITLE
Update container's state if stopped

### DIFF
--- a/oci.go
+++ b/oci.go
@@ -99,3 +99,18 @@ func processRunning(pid int) (bool, error) {
 
 	return true, nil
 }
+
+func stopContainer(podStatus vc.PodStatus) error {
+	if len(podStatus.ContainersStatus) != 1 {
+		return fmt.Errorf("ContainerStatus list from PodStatus is wrong, expecting only one ContainerStatus")
+	}
+
+	// Calling StopContainer allows to make sure the container is properly
+	// stopped and removed from the pod. That way, the container's state is
+	// updated to the expected "stopped" state.
+	if _, err := vc.StopContainer(podStatus.ID, podStatus.ContainersStatus[0].ID); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/state.go
+++ b/state.go
@@ -61,6 +61,10 @@ func state(containerID string) error {
 		return err
 	}
 	if running == false {
+		if err := stopContainer(podStatus); err != nil {
+			return err
+		}
+
 		state.Status = "stopped"
 	}
 


### PR DESCRIPTION
The runtime implementation has to check if the process running inside the
container is still running. In case it is not running anymore, we want to
call StopContainer API from virtcontainers so that it removes the container
from the pod, and it gets the container status updated.