### PR TITLE
[DEPRECATED] Add ShimConfig to be loaded from toml config file

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -31,6 +31,9 @@ const kernelPath = "/foo/clear-containers/vmlinux.container"
 const imagePath = "/foo/clear-containers/clear-containers.img"
 const runtimePath = "/foo/clear-containers/runtime.sock"
 const shimPath = "/foo/clear-containers/shim.sock"
+const shimBinPath = "/foo/clear-containers/bin/cc-shim"
+const shimIP = "127.0.0.1"
+const shimPort = "12345"
 
 const runtimeConfig = `
 # Clear Containers runtime configuration file
@@ -43,6 +46,11 @@ image = "` + imagePath + `"
 [proxy.cc]
 runtime_sock = "` + runtimePath + `"
 shim_sock = "` + shimPath + `"
+
+[shim.cc]
+path = "` + shimBinPath + `"
+ip = "` + shimIP + `"
+port = "` + shimPort + `"
 `
 
 const runtimeMinimalConfig = `
@@ -73,7 +81,7 @@ func TestRuntimeConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := loadConfiguration(configPath)
+	config, shimConfig, err := loadConfiguration(configPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,8 +107,18 @@ func TestRuntimeConfig(t *testing.T) {
 		ProxyConfig: expectedProxyConfig,
 	}
 
+	expectedShimConfig := ShimConfig{
+		Path: shimBinPath,
+		IP:   shimIP,
+		Port: shimPort,
+	}
+
 	if reflect.DeepEqual(config, expectedConfig) == false {
 		t.Fatalf("Got %v\n expecting %v", config, expectedConfig)
+	}
+
+	if reflect.DeepEqual(shimConfig, expectedShimConfig) == false {
+		t.Fatalf("Got %v\n expecting %v", shimConfig, expectedShimConfig)
 	}
 
 	if err := os.Remove(configPath); err != nil {
@@ -114,7 +132,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := loadConfiguration(configPath)
+	config, shimConfig, err := loadConfiguration(configPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,8 +158,18 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		ProxyConfig: expectedProxyConfig,
 	}
 
+	expectedShimConfig := ShimConfig{
+		Path: defaultShimBinPath,
+		IP:   defaultShimIP,
+		Port: defaultShimPort,
+	}
+
 	if reflect.DeepEqual(config, expectedConfig) == false {
 		t.Fatalf("Got %v\n expecting %v", config, expectedConfig)
+	}
+
+	if reflect.DeepEqual(shimConfig, expectedShimConfig) == false {
+		t.Fatalf("Got %v\n expecting %v", shimConfig, expectedShimConfig)
 	}
 
 	if err := os.Remove(configPath); err != nil {

--- a/create.go
+++ b/create.go
@@ -70,7 +70,7 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 		return err
 	}
 
-	podConfig, err := getPodConfig(bundlePath, containerID, console)
+	podConfig, shimConfig, err := getConfigs(bundlePath, containerID, console)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 	}
 
 	// Start the shim to retrieve its PID.
-	pid, err := startShim(pod)
+	pid, err := startShim(shimConfig, pod)
 	if err != nil {
 		return err
 	}
@@ -96,18 +96,18 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 	return nil
 }
 
-func getPodConfig(bundlePath, containerID, console string) (vc.PodConfig, error) {
-	runtimeConfig, err := loadConfiguration("")
+func getConfigs(bundlePath, containerID, console string) (vc.PodConfig, ShimConfig, error) {
+	runtimeConfig, shimConfig, err := loadConfiguration("")
 	if err != nil {
-		return vc.PodConfig{}, err
+		return vc.PodConfig{}, ShimConfig{}, err
 	}
 
 	podConfig, err := oci.PodConfig(runtimeConfig, bundlePath, containerID, console)
 	if err != nil {
-		return vc.PodConfig{}, err
+		return vc.PodConfig{}, ShimConfig{}, err
 	}
 
-	return *podConfig, nil
+	return *podConfig, shimConfig, nil
 }
 
 func createPIDFile(pidFilePath string, pid int) error {


### PR DESCRIPTION
In order to be consistent with the way we retrieve different configurations
related to the runtime, let's add a ShimConfig structure describing a config
for the shim. This configuration will be stored into the toml file where all
other configurations are stored and will be loaded at "create" time.