### PR TITLE
cli: Fix arguments retrieval from CLI

### DIFF
--- a/create.go
+++ b/create.go
@@ -57,7 +57,7 @@ var createCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return create(context.String("container-id"),
+		return create(context.Args().First(),
 			context.String("bundle"),
 			context.String("console"),
 			context.String("pid-file"))

--- a/delete.go
+++ b/delete.go
@@ -43,7 +43,19 @@ EXAMPLE:
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return delete(context.String("container-id"), context.Bool("force"))
+		args := context.Args()
+		if args.Present() == false {
+			return fmt.Errorf("Missing container ID, should at least provide one")
+		}
+
+		force := context.Bool("force")
+		for _, cID := range []string(args) {
+			if err := delete(cID, force); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	},
 }
 

--- a/kill.go
+++ b/kill.go
@@ -43,7 +43,18 @@ EXAMPLE:
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return kill(context.String("container-id"), context.String("signal"))
+		args := context.Args()
+		if args.Present() == false {
+			return fmt.Errorf("Missing container ID")
+		}
+
+		// If signal is provided, it has to be the second argument.
+		signal := args.Get(1)
+		if signal == "" {
+			signal = "SIGTERM"
+		}
+
+		return kill(args.First(), signal, context.Bool("all"))
 	},
 }
 
@@ -85,7 +96,7 @@ var signals = map[string]syscall.Signal{
 	"SIGXFSZ":   syscall.SIGXFSZ,
 }
 
-func kill(containerID, signal string) error {
+func kill(containerID, signal string, all bool) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	if err := validContainer(containerID); err != nil {
 		return err

--- a/start.go
+++ b/start.go
@@ -16,6 +16,8 @@
 package main
 
 import (
+	"fmt"
+
 	vc "github.com/containers/virtcontainers"
 	"github.com/urfave/cli"
 )
@@ -30,7 +32,18 @@ var startCommand = cli.Command{
    unique bon your host.`,
 	Description: `The start command executes the user defined process in a created container .`,
 	Action: func(context *cli.Context) error {
-		return start(context.String("container-id"))
+		args := context.Args()
+		if args.Present() == false {
+			return fmt.Errorf("Missing container ID, should at least provide one")
+		}
+
+		for _, cID := range []string(args) {
+			if err := start(cID); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	},
 }
 

--- a/state.go
+++ b/state.go
@@ -34,7 +34,12 @@ var stateCommand = cli.Command{
 	Description: `The state command outputs current state information for the
 instance of a container.`,
 	Action: func(context *cli.Context) error {
-		return state(context.String("container-id"))
+		args := context.Args()
+		if len(args) != 1 {
+			return fmt.Errorf("Expecting only one container ID, got %d: %v", len(args), []string(args))
+		}
+
+		return state(args.First())
 	},
 }
 


### PR DESCRIPTION
The way to get arguments from the CLI was not functional. This patch
fixes it for create, delete, kill, start and state actions.