### PR TITLE
config: Retrieve shim path from configuration

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -30,7 +30,7 @@ const hypervisorPath = "/foo/qemu-lite-system-x86_64"
 const kernelPath = "/foo/clear-containers/vmlinux.container"
 const imagePath = "/foo/clear-containers/clear-containers.img"
 const runtimePath = "/foo/clear-containers/runtime.sock"
-const shimPath = "/foo/clear-containers/shim.sock"
+const shimPath = "/foo/clear-containers/cc-shim"
 
 const runtimeConfig = `
 # Clear Containers runtime configuration file
@@ -42,7 +42,9 @@ image = "` + imagePath + `"
 
 [proxy.cc]
 runtime_sock = "` + runtimePath + `"
-shim_sock = "` + shimPath + `"
+
+[shim.cc]
+path = "` + shimPath + `"
 `
 
 const runtimeMinimalConfig = `
@@ -73,7 +75,7 @@ func TestRuntimeConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := loadConfiguration(configPath)
+	config, shimConfig, err := loadConfiguration(configPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,8 +100,16 @@ func TestRuntimeConfig(t *testing.T) {
 		ProxyConfig: expectedProxyConfig,
 	}
 
+	expectedShimConfig := ShimConfig{
+		Path: shimPath,
+	}
+
 	if reflect.DeepEqual(config, expectedConfig) == false {
 		t.Fatalf("Got %v\n expecting %v", config, expectedConfig)
+	}
+
+	if reflect.DeepEqual(shimConfig, expectedShimConfig) == false {
+		t.Fatalf("Got %v\n expecting %v", shimConfig, expectedShimConfig)
 	}
 
 	if err := os.Remove(configPath); err != nil {
@@ -113,7 +123,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := loadConfiguration(configPath)
+	config, shimConfig, err := loadConfiguration(configPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,8 +148,16 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		ProxyConfig: expectedProxyConfig,
 	}
 
+	expectedShimConfig := ShimConfig{
+		Path: defaultShimPath,
+	}
+
 	if reflect.DeepEqual(config, expectedConfig) == false {
 		t.Fatalf("Got %v\n expecting %v", config, expectedConfig)
+	}
+
+	if reflect.DeepEqual(shimConfig, expectedShimConfig) == false {
+		t.Fatalf("Got %v\n expecting %v", shimConfig, expectedShimConfig)
 	}
 
 	if err := os.Remove(configPath); err != nil {

--- a/create.go
+++ b/create.go
@@ -70,7 +70,7 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 		return err
 	}
 
-	podConfig, err := getPodConfig(bundlePath, containerID, console)
+	podConfig, shimConfig, err := getConfigs(bundlePath, containerID, console)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 		return fmt.Errorf("BUG: Container list from pod is wrong, expecting only one container, found %d containers", len(containers))
 	}
 
-	pid, err := startContainerShim(containers[0], pod.URL())
+	pid, err := startContainerShim(containers[0], shimConfig, pod.URL())
 	if err != nil {
 		return err
 	}
@@ -101,18 +101,18 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 	return nil
 }
 
-func getPodConfig(bundlePath, containerID, console string) (vc.PodConfig, error) {
-	runtimeConfig, err := loadConfiguration("")
+func getConfigs(bundlePath, containerID, console string) (vc.PodConfig, ShimConfig, error) {
+	runtimeConfig, shimConfig, err := loadConfiguration("")
 	if err != nil {
-		return vc.PodConfig{}, err
+		return vc.PodConfig{}, ShimConfig{}, err
 	}
 
 	podConfig, err := oci.PodConfig(runtimeConfig, bundlePath, containerID, console)
 	if err != nil {
-		return vc.PodConfig{}, err
+		return vc.PodConfig{}, ShimConfig{}, err
 	}
 
-	return *podConfig, nil
+	return *podConfig, shimConfig, nil
 }
 
 func createPIDFile(pidFilePath string, pid int) error {

--- a/exec.go
+++ b/exec.go
@@ -203,13 +203,18 @@ func execute(params execParams) error {
 		User:    params.ociProcess.User.Username,
 	}
 
+	_, shimConfig, err := loadConfiguration("")
+	if err != nil {
+		return err
+	}
+
 	pod, _, process, err := vc.EnterContainer(params.cID, podStatus.ContainersStatus[0].ID, cmd)
 	if err != nil {
 		return err
 	}
 
 	// Start the shim to retrieve its PID.
-	pid, err := startShim(process, pod.URL())
+	pid, err := startShim(process, shimConfig, pod.URL())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We don't want the shim binary path to be hardcoded into the code.
That's why we rely on the configuration file to provide this data.