### PR TITLE
config: Update proxy config according to virtcontainers

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,7 +72,7 @@ type hypervisor struct {
 }
 
 type proxy struct {
-	RuntimeSockPath string `toml:"runtime_sock"`
+	URL string `toml:"url"`
 }
 
 type shim struct {
@@ -101,6 +101,14 @@ func (h hypervisor) image() string {
 	}
 
 	return h.Image
+}
+
+func (p proxy) url() string {
+	if p.URL == "" {
+		return defaultProxyURL
+	}
+
+	return p.URL
 }
 
 func (s shim) path() string {
@@ -178,8 +186,10 @@ func loadConfiguration(configPath string) (oci.RuntimeConfig, ShimConfig, error)
 		switch k {
 		case ccProxy:
 			pConfig := vc.CCProxyConfig{
-				URL: proxy.RuntimeSockPath,
+				URL: proxy.url(),
 			}
+
+			config.ProxyType = vc.CCProxyType
 			config.ProxyConfig = pConfig
 			break
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -29,7 +29,7 @@ import (
 const hypervisorPath = "/foo/qemu-lite-system-x86_64"
 const kernelPath = "/foo/clear-containers/vmlinux.container"
 const imagePath = "/foo/clear-containers/clear-containers.img"
-const runtimePath = "/foo/clear-containers/runtime.sock"
+const proxyURL = "foo:///foo/clear-containers/proxy.sock"
 const shimPath = "/foo/clear-containers/cc-shim"
 
 const runtimeConfig = `
@@ -41,7 +41,7 @@ kernel = "` + kernelPath + `"
 image = "` + imagePath + `"
 
 [proxy.cc]
-runtime_sock = "` + runtimePath + `"
+url = "` + proxyURL + `"
 
 [shim.cc]
 path = "` + shimPath + `"
@@ -51,8 +51,7 @@ const runtimeMinimalConfig = `
 # Clear Containers runtime configuration file
 
 [proxy.cc]
-runtime_sock = "` + runtimePath + `"
-shim_sock = "` + shimPath + `"
+url = "` + proxyURL + `"
 `
 
 const tempRuntimePath = "/tmp/cc-runtime/"
@@ -87,7 +86,7 @@ func TestRuntimeConfig(t *testing.T) {
 	}
 
 	expectedProxyConfig := vc.CCProxyConfig{
-		URL: runtimePath,
+		URL: proxyURL,
 	}
 
 	expectedConfig := oci.RuntimeConfig{
@@ -135,7 +134,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 	}
 
 	expectedProxyConfig := vc.CCProxyConfig{
-		URL: runtimePath,
+		URL: proxyURL,
 	}
 
 	expectedConfig := oci.RuntimeConfig{


### PR DESCRIPTION
Proxy config now relies only on a URL provided to the library so
that it can connect to the proxy.