### PR TITLE
Update virtcontainers vendoring

### DIFF
--- a/config.go
+++ b/config.go
@@ -154,8 +154,7 @@ func loadConfiguration(configPath string) (oci.RuntimeConfig, error) {
 		switch k {
 		case ccProxy:
 			pConfig := vc.CCProxyConfig{
-				RuntimeSocketPath: proxy.RuntimeSockPath,
-				ShimSocketPath:    proxy.ShimSockPath,
+				URL: proxy.RuntimeSockPath,
 			}
 			config.ProxyConfig = pConfig
 			break

--- a/config_test.go
+++ b/config_test.go
@@ -85,8 +85,7 @@ func TestRuntimeConfig(t *testing.T) {
 	}
 
 	expectedProxyConfig := vc.CCProxyConfig{
-		RuntimeSocketPath: runtimePath,
-		ShimSocketPath:    shimPath,
+		URL: runtimePath,
 	}
 
 	expectedConfig := oci.RuntimeConfig{
@@ -126,8 +125,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 	}
 
 	expectedProxyConfig := vc.CCProxyConfig{
-		RuntimeSocketPath: runtimePath,
-		ShimSocketPath:    shimPath,
+		URL: runtimePath,
 	}
 
 	expectedConfig := oci.RuntimeConfig{

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "489e6fc99ad82fdfe658415cf4037718700e451c04aef33db414984ed2b928fa",
+    "memo": "b492a98662a87358b60f2e6b4ab8b0c8cdec241c5537f63ce9af79ad79f0d40d",
     "projects": [
         {
             "name": "github.com/01org/cc-oci-runtime",
@@ -55,7 +55,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "ff4df67c04ec1dd2da39ad9a6d36d7b4595c7386",
+            "revision": "361ae58ac333beb1b45af7ce76de967aa3ff4cef",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "ff4df67c04ec1dd2da39ad9a6d36d7b4595c7386"
+            "revision": "361ae58ac333beb1b45af7ce76de967aa3ff4cef"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -124,7 +124,7 @@ type agent interface {
 	stop(pod Pod) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod Pod, c Container, cmd Cmd) (*Process, error)
+	exec(pod *Pod, c Container, cmd Cmd) (*Process, error)
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(pod Pod) error
@@ -133,7 +133,7 @@ type agent interface {
 	stopPod(pod Pod) error
 
 	// createContainer will tell the agent to create a container related to a Pod.
-	createContainer(pod Pod, c *Container) error
+	createContainer(pod *Pod, c *Container) error
 
 	// startContainer will tell the agent to start a container related to a Pod.
 	startContainer(pod Pod, c Container) error

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -516,7 +516,7 @@ func TestCreateContainerSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -550,7 +550,7 @@ func TestCreateContainerFailingNoPod(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c != nil || err == nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -637,7 +637,7 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 	}
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -731,7 +731,7 @@ func TestStopContainerNoopAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -778,7 +778,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -888,7 +888,7 @@ func TestStopContainerFailingContNotStarted(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -916,7 +916,7 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -934,7 +934,7 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err = EnterContainer(p.id, contID, cmd)
+	_, c, _, err = EnterContainer(p.id, contID, cmd)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -965,7 +965,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	_, err = CreateContainer(p.id, contConfig)
+	_, _, err = CreateContainer(p.id, contConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +983,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	_, _, err = EnterContainer(p.id, contID, cmd)
+	_, _, _, err = EnterContainer(p.id, contID, cmd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1008,7 +1008,7 @@ func TestEnterContainerFailingNoPod(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err := EnterContainer(testPodID, contID, cmd)
+	_, c, _, err := EnterContainer(testPodID, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1031,7 +1031,7 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err := EnterContainer(p.id, contID, cmd)
+	_, c, _, err := EnterContainer(p.id, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1048,7 +1048,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1061,7 +1061,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err = EnterContainer(p.id, contID, cmd)
+	_, c, _, err = EnterContainer(p.id, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1084,7 +1084,7 @@ func TestStatusContainerSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1236,7 +1236,7 @@ func createStartStopDeleteContainers(b *testing.B, podConfig PodConfig, contConf
 
 	// Create containers
 	for _, contConfig := range contConfigs {
-		_, err := CreateContainer(p.id, contConfig)
+		_, _, err := CreateContainer(p.id, contConfig)
 		if err != nil {
 			b.Logf("Could not create container %s: %s", contConfig.ID, err)
 		}

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -251,7 +251,7 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	// specific case.
 	pod.containers = append(pod.containers, c)
 
-	if err := c.pod.agent.createContainer(*pod, c); err != nil {
+	if err := c.pod.agent.createContainer(pod, c); err != nil {
 		return nil, err
 	}
 
@@ -378,7 +378,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 		return nil, fmt.Errorf("Container not running, impossible to enter")
 	}
 
-	process, err := c.pod.agent.exec(*(c.pod), *c, cmd)
+	process, err := c.pod.agent.exec(c.pod, *c, cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -41,7 +41,7 @@ func (n *noopAgent) stop(pod Pod) error {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
+func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	return nil, nil
 }
 
@@ -56,7 +56,7 @@ func (n *noopAgent) stopPod(pod Pod) error {
 }
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
-func (n *noopAgent) createContainer(pod Pod, c *Container) error {
+func (n *noopAgent) createContainer(pod *Pod, c *Container) error {
 	return nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/noop_agent_test.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent_test.go
@@ -42,7 +42,7 @@ func TestNoopAgentStartAgent(t *testing.T) {
 
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	pod := &Pod{}
 	container := Container{}
 	cmd := Cmd{}
 
@@ -83,7 +83,7 @@ func TestNoopAgentStopAgent(t *testing.T) {
 
 func TestNoopAgentCreateContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	pod := &Pod{}
 	container := &Container{}
 
 	err := n.createContainer(pod, container)

--- a/vendor/github.com/containers/virtcontainers/noop_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/noop_proxy.go
@@ -18,9 +18,11 @@ package virtcontainers
 
 type noopProxy struct{}
 
+var noopProxyURL = "noopProxyURL"
+
 // register is the proxy register implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) register(pod Pod) ([]ProxyInfo, error) {
+func (p *noopProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 	var proxyInfos []ProxyInfo
 
 	for i := 0; i < len(pod.containers); i++ {
@@ -29,7 +31,7 @@ func (p *noopProxy) register(pod Pod) ([]ProxyInfo, error) {
 		proxyInfos = append(proxyInfos, proxyInfo)
 	}
 
-	return proxyInfos, nil
+	return proxyInfos, noopProxyURL, nil
 }
 
 // unregister is the proxy unregister implementation for testing purpose.
@@ -40,8 +42,8 @@ func (p *noopProxy) unregister(pod Pod) error {
 
 // connect is the proxy connect implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) connect(pod Pod, createToken bool) (ProxyInfo, error) {
-	return ProxyInfo{}, nil
+func (p *noopProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	return ProxyInfo{}, noopProxyURL, nil
 }
 
 // disconnect is the proxy disconnect implementation for testing purpose.

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -336,7 +336,7 @@ type Pod struct {
 	runPath    string
 	configPath string
 
-	controlSocket string
+	url string
 
 	state State
 
@@ -346,6 +346,11 @@ type Pod struct {
 // ID returns the pod identifier string.
 func (p *Pod) ID() string {
 	return p.id
+}
+
+// URL returns the pod URL for any runtime to connect to the proxy.
+func (p *Pod) URL() string {
+	return p.url
 }
 
 // GetContainers returns a container config list.

--- a/vendor/github.com/containers/virtcontainers/proxy.go
+++ b/vendor/github.com/containers/virtcontainers/proxy.go
@@ -92,7 +92,6 @@ func newProxyConfig(config PodConfig) interface{} {
 // Each ProxyInfo relates to a process running inside a container.
 type ProxyInfo struct {
 	Token string
-	URL   string
 
 	// Keep for legacy, will be removed when new proxy is ready.
 	StdioID  uint64
@@ -103,7 +102,7 @@ type ProxyInfo struct {
 type proxy interface {
 	// register connects and registers the proxy to the given VM.
 	// It also returns information related to containers workloads.
-	register(pod Pod) ([]ProxyInfo, error)
+	register(pod Pod) ([]ProxyInfo, string, error)
 
 	// unregister unregisters and disconnects the proxy from the given VM.
 	unregister(pod Pod) error
@@ -114,7 +113,7 @@ type proxy interface {
 	// createToken is intended to be true in case we don't want
 	// the proxy to create a new token, but instead only get a handle
 	// to be able to communicate with the agent inside the VM.
-	connect(pod Pod, createToken bool) (ProxyInfo, error)
+	connect(pod Pod, createToken bool) (ProxyInfo, string, error)
 
 	// disconnect disconnects from the proxy.
 	disconnect() error

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -135,7 +135,7 @@ func (s *sshd) stop(pod Pod) error {
 }
 
 // exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
+func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	session, err := s.client.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create session")
@@ -165,7 +165,7 @@ func (s *sshd) stopPod(pod Pod) error {
 }
 
 // createContainer is the agent Container creation implementation for sshd.
-func (s *sshd) createContainer(pod Pod, c *Container) error {
+func (s *sshd) createContainer(pod *Pod, c *Container) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR updates virtcontainers vendoring for following reasons:
- EnterContainer() now returns a Pod pointer.
- Pod has a new public method URL() returning the proxy URL specific to the pod.
- CCProxyConfig contains now only one field: URL.

Then it fixes the build which is broken by this new vendoring.