### PR TITLE
vendor: Update virtcontainers vendoring and fix the build

### DIFF
--- a/create.go
+++ b/create.go
@@ -21,6 +21,7 @@ import (
 
 	vc "github.com/containers/virtcontainers"
 	"github.com/containers/virtcontainers/pkg/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
 
@@ -70,7 +71,7 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 		return err
 	}
 
-	podConfig, shimConfig, err := getConfigs(bundlePath, containerID, console)
+	podConfig, shimConfig, _, err := getConfigs(bundlePath, containerID, console)
 	if err != nil {
 		return err
 	}
@@ -101,18 +102,18 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 	return nil
 }
 
-func getConfigs(bundlePath, containerID, console string) (vc.PodConfig, ShimConfig, error) {
+func getConfigs(bundlePath, containerID, console string) (vc.PodConfig, ShimConfig, specs.Spec, error) {
 	runtimeConfig, shimConfig, err := loadConfiguration("")
 	if err != nil {
-		return vc.PodConfig{}, ShimConfig{}, err
+		return vc.PodConfig{}, ShimConfig{}, specs.Spec{}, err
 	}
 
-	podConfig, err := oci.PodConfig(runtimeConfig, bundlePath, containerID, console)
+	podConfig, ociSpec, err := oci.PodConfig(runtimeConfig, bundlePath, containerID, console)
 	if err != nil {
-		return vc.PodConfig{}, ShimConfig{}, err
+		return vc.PodConfig{}, ShimConfig{}, specs.Spec{}, err
 	}
 
-	return *podConfig, shimConfig, nil
+	return *podConfig, shimConfig, *ociSpec, nil
 }
 
 func createPIDFile(pidFilePath string, pid int) error {

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "b492a98662a87358b60f2e6b4ab8b0c8cdec241c5537f63ce9af79ad79f0d40d",
+    "memo": "2d9f29c02e2dd296c3d318cc574e782b0810407de675fe914b64e8b7667a14fa",
     "projects": [
         {
             "name": "github.com/01org/cc-oci-runtime",
@@ -55,7 +55,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "361ae58ac333beb1b45af7ce76de967aa3ff4cef",
+            "revision": "795b17e9eb24719a0dceebfa077b5ae108a6dc6c",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "361ae58ac333beb1b45af7ce76de967aa3ff4cef"
+            "revision": "795b17e9eb24719a0dceebfa077b5ae108a6dc6c"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -98,9 +98,11 @@ func TestMinimalPodConfig(t *testing.T) {
 		NetworkConfig: expectedNetworkConfig,
 
 		Containers: []vc.ContainerConfig{expectedContainerConfig},
+
+		Annotations: map[string]string{ociConfigPathKey: configPath},
 	}
 
-	podConfig, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)
+	podConfig, _, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)
 	if err != nil {
 		t.Fatalf("Could not create Pod configuration %v", err)
 	}

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -269,6 +269,12 @@ type PodConfig struct {
 	// This list can be empty and populated by adding containers
 	// to the Pod a posteriori.
 	Containers []ContainerConfig
+
+	// Annotations is a reserved field and can be filled with various
+	// different data by each user. This means that virtcontainers will
+	// never try to interpret those data, it is only providing a way to
+	// save some data for users.
+	Annotations map[string]string
 }
 
 // valid checks that the pod configuration is valid.
@@ -346,6 +352,20 @@ type Pod struct {
 // ID returns the pod identifier string.
 func (p *Pod) ID() string {
 	return p.id
+}
+
+// Annotations returns any annotation that a user could have stored through the pod.
+func (p *Pod) Annotations(key string) (string, error) {
+	if len(p.config.Annotations) == 0 {
+		return "", fmt.Errorf("Annotations map is empty")
+	}
+
+	value, exist := p.config.Annotations[key]
+	if exist == false {
+		return "", fmt.Errorf("Annotations key %s does not exist", key)
+	}
+
+	return value, nil
 }
 
 // URL returns the pod URL for any runtime to connect to the proxy.


### PR DESCRIPTION
Need latest changes from virtcontainers:
- New "Annotations" field in PodConfig to store user specific data.
- OCI package update relying on this new Annotations field and providing new function to retrieve these annotations.
- OCI package returning OCI spec structure from PodConfig().

Fix build after the new vendoring.