### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "2d9f29c02e2dd296c3d318cc574e782b0810407de675fe914b64e8b7667a14fa",
+    "memo": "25551798d7ad426d9e83e3513f41142f9ca38626308a495dcf46defa73fa378e",
     "projects": [
         {
             "name": "github.com/01org/cc-oci-runtime",
@@ -55,7 +55,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "795b17e9eb24719a0dceebfa077b5ae108a6dc6c",
+            "revision": "5c92f1f5efb746caf6c3d6986c86356affcfbfd6",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "795b17e9eb24719a0dceebfa077b5ae108a6dc6c"
+            "revision": "5c92f1f5efb746caf6c3d6986c86356affcfbfd6"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -270,10 +270,8 @@ type PodConfig struct {
 	// to the Pod a posteriori.
 	Containers []ContainerConfig
 
-	// Annotations is a reserved field and can be filled with various
-	// different data by each user. This means that virtcontainers will
-	// never try to interpret those data, it is only providing a way to
-	// save some data for users.
+	// Annotations keys must be unique strings an must be name-spaced
+	// with e.g. reverse domain notation (org.clearlinux.key).
 	Annotations map[string]string
 }
 
@@ -356,10 +354,6 @@ func (p *Pod) ID() string {
 
 // Annotations returns any annotation that a user could have stored through the pod.
 func (p *Pod) Annotations(key string) (string, error) {
-	if len(p.config.Annotations) == 0 {
-		return "", fmt.Errorf("Annotations map is empty")
-	}
-
 	value, exist := p.config.Annotations[key]
 	if exist == false {
 		return "", fmt.Errorf("Annotations key %s does not exist", key)

--- a/vendor/github.com/containers/virtcontainers/syscall.go
+++ b/vendor/github.com/containers/virtcontainers/syscall.go
@@ -38,9 +38,9 @@ func bindMount(source, destination string) error {
 	}
 
 	if err := ensureDestinationExists(absSource, destination); err != nil {
-		return fmt.Errorf("Could not create destination mount point: %v", destination)
+		return fmt.Errorf("Could not create destination mount point %v: %v", destination, err)
 	} else if err := syscall.Mount(absSource, destination, "bind", syscall.MS_BIND, ""); err != nil {
-		return fmt.Errorf("Could not bind mount %v to %v", absSource, destination)
+		return fmt.Errorf("Could not bind mount %v to %v: %v", absSource, destination, err)
 	}
 
 	return nil
@@ -51,12 +51,12 @@ func bindMount(source, destination string) error {
 func ensureDestinationExists(source, destination string) error {
 	fileInfo, err := os.Stat(source)
 	if err != nil {
-		return fmt.Errorf("could not stat source location: %v", source)
+		return fmt.Errorf("could not stat source location %v: %v", source, err)
 	}
 
 	targetPathParent, _ := filepath.Split(destination)
 	if err := os.MkdirAll(targetPathParent, mountPerm); err != nil {
-		return fmt.Errorf("could not create parent directory: %v", targetPathParent)
+		return fmt.Errorf("could not create parent directory %v: %v", targetPathParent, err)
 	}
 
 	if fileInfo.IsDir() {


### PR DESCRIPTION
Fix virtcontainers vendoring because it was based on an old commit
version instead of the most recent one.