### PR TITLE
create: Add missing O_CREATE flag to OpenFile()

### DIFF
--- a/create.go
+++ b/create.go
@@ -148,7 +148,7 @@ func createCgroupsFiles(cgroupsPath string, pid int) error {
 	pidStr := fmt.Sprintf("%d", pid)
 
 	for _, path := range []string{tasksFilePath, procsFilePath} {
-		f, err := os.OpenFile(path, os.O_RDWR, cgroupsFileMode)
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, cgroupsFileMode)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When calling createCgroupsFiles(), we were expecting files to be
created with a call to os.OpenFile() but we forgot to specify the
right flag O_CREATE to make sure the file is created in case it
does not exist.