### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/create.go
+++ b/create.go
@@ -88,7 +88,7 @@ func create(containerID, bundlePath, console, pidFilePath string) error {
 		return fmt.Errorf("BUG: Container list from pod is wrong, expecting only one container, found %d containers", len(containers))
 	}
 
-	pid, err := startContainerShim(containers[0], shimConfig, pod.URL())
+	pid, err := startContainerShim(containers[0], shimConfig)
 	if err != nil {
 		return err
 	}

--- a/exec.go
+++ b/exec.go
@@ -208,13 +208,13 @@ func execute(params execParams) error {
 		return err
 	}
 
-	pod, _, process, err := vc.EnterContainer(params.cID, podStatus.ContainersStatus[0].ID, cmd)
+	_, _, process, err := vc.EnterContainer(params.cID, podStatus.ContainersStatus[0].ID, cmd)
 	if err != nil {
 		return err
 	}
 
 	// Start the shim to retrieve its PID.
-	pid, err := startShim(process, shimConfig, pod.URL())
+	pid, err := startShim(process, shimConfig)
 	if err != nil {
 		return err
 	}

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "2f92ae7a44bbadfbe4d06c0db49a8ea150780f05678f65b1809c55ab9cb9e5ed",
+    "memo": "7280d1e6fff2eab1ed2c10baf000130b1d75b11ad16faa61f76b331615bab87a",
     "projects": [
         {
             "name": "github.com/01org/ciao",
@@ -46,7 +46,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "9c9e19090764e5808268dffc43f7fa53c1064a41",
+            "revision": "ab79f0844b2ab761ae2e85b2907fa36faacb8ed7",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "9c9e19090764e5808268dffc43f7fa53c1064a41"
+            "revision": "ab79f0844b2ab761ae2e85b2907fa36faacb8ed7"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/shim.go
+++ b/shim.go
@@ -27,12 +27,12 @@ type ShimConfig struct {
 	Path string
 }
 
-func startShim(process *vc.Process, config ShimConfig, url string) (int, error) {
+func startShim(process *vc.Process, config ShimConfig) (int, error) {
 	if process.Token == "" {
 		return -1, fmt.Errorf("Token cannot be empty")
 	}
 
-	if url == "" {
+	if process.URL == "" {
 		return -1, fmt.Errorf("URL cannot be empty")
 	}
 
@@ -41,7 +41,7 @@ func startShim(process *vc.Process, config ShimConfig, url string) (int, error) 
 	}
 	ccLog.Infof("Shim binary path: %s", config.Path)
 
-	cmd := exec.Command(config.Path, "-t", process.Token, "-u", url)
+	cmd := exec.Command(config.Path, "-t", process.Token, "-u", process.URL)
 	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -54,10 +54,10 @@ func startShim(process *vc.Process, config ShimConfig, url string) (int, error) 
 	return cmd.Process.Pid, nil
 }
 
-func startContainerShim(container *vc.Container, config ShimConfig, url string) (int, error) {
+func startContainerShim(container *vc.Container, config ShimConfig) (int, error) {
 	process := container.Process()
 
-	pid, err := startShim(&process, config, url)
+	pid, err := startShim(&process, config)
 	if err != nil {
 		return -1, err
 	}

--- a/shim_test.go
+++ b/shim_test.go
@@ -28,7 +28,11 @@ var testToken = "test-token"
 var testURL = "sheme://ipAddress:8080/path"
 
 func TestStartShimTokenEmptyFailure(t *testing.T) {
-	if _, err := startShim(&vc.Process{}, ShimConfig{}, testURL); err == nil {
+	process := &vc.Process{
+		URL: testURL,
+	}
+
+	if _, err := startShim(process, ShimConfig{}); err == nil {
 		t.Fatalf("This test should fail because process.Token is empty")
 	}
 }
@@ -38,13 +42,13 @@ func TestStartShimURLEmptyFailure(t *testing.T) {
 		Token: testToken,
 	}
 
-	if _, err := startShim(process, ShimConfig{}, ""); err == nil {
+	if _, err := startShim(process, ShimConfig{}); err == nil {
 		t.Fatalf("This test should fail because process.Token is empty")
 	}
 }
 
-func testStartShimSuccessful(t *testing.T, process *vc.Process, shimConfig ShimConfig, url string) {
-	pid, err := startShim(process, shimConfig, url)
+func testStartShimSuccessful(t *testing.T, process *vc.Process, shimConfig ShimConfig) {
+	pid, err := startShim(process, shimConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,14 +71,16 @@ func TestStartShimDefaultShimPathSuccessful(t *testing.T) {
 	defaultShimPath = mockShimPath
 
 	process := &vc.Process{
+		URL:   testURL,
 		Token: testToken,
 	}
 
-	testStartShimSuccessful(t, process, ShimConfig{}, testURL)
+	testStartShimSuccessful(t, process, ShimConfig{})
 }
 
 func TestStartShimSuccessful(t *testing.T) {
 	process := &vc.Process{
+		URL:   testURL,
 		Token: testToken,
 	}
 
@@ -82,11 +88,11 @@ func TestStartShimSuccessful(t *testing.T) {
 		Path: mockShimPath,
 	}
 
-	testStartShimSuccessful(t, process, shimConfig, testURL)
+	testStartShimSuccessful(t, process, shimConfig)
 }
 
 func TestStartContainerShimContainerEmptyFailure(t *testing.T) {
-	if _, err := startContainerShim(&vc.Container{}, ShimConfig{}, testURL); err == nil {
+	if _, err := startContainerShim(&vc.Container{}, ShimConfig{}); err == nil {
 		t.Fatal("This test should fail because container is empty")
 	}
 }

--- a/vendor/github.com/containers/virtcontainers/.travis.yml
+++ b/vendor/github.com/containers/virtcontainers/.travis.yml
@@ -37,7 +37,7 @@ script:
 - gocyclo -over 15 $go_files
 - go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
 - gofmt -s -l $go_files | wc -l | xargs -I % bash -c "test % -eq 0"
-- go build $go_packages
+- make
 - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin:/tmp/cni/bin $GOPATH/bin/test-cases
   -v -timeout 9 -short -coverprofile /tmp/cover.out $go_packages
 

--- a/vendor/github.com/containers/virtcontainers/Makefile
+++ b/vendor/github.com/containers/virtcontainers/Makefile
@@ -1,5 +1,5 @@
 all: binaries
-	go build ./...
+	go build $(go list ./... | grep -v /vendor/)
 	cd hack/virtc && go build
 
 pause:

--- a/vendor/github.com/containers/virtcontainers/README.md
+++ b/vendor/github.com/containers/virtcontainers/README.md
@@ -70,34 +70,41 @@ The high level `virtcontainers` API is the following one:
 ### Pod API
 
 * `CreatePod(podConfig PodConfig)` creates a Pod.
-The Pod is prepared and will run into a virtual machine. It is not started, i.e. the VM is not running after `CreatePod()` is called.
+The virtual machine is started and the Pod is prepared.
 
 * `DeletePod(podID string)` deletes a Pod.
-The function will fail if the Pod is running. In that case `StopPod()` needs to be called first.
+The virtual machine is shut down and all information related to the Pod are removed.
+The function will fail if the Pod is running. In that case `StopPod()` has to be called first.
 
 * `StartPod(podID string)` starts an already created Pod.
+The Pod and all its containers are started.
+
+* `RunPod(podConfig PodConfig)` creates and starts a Pod.
+This performs `CreatePod()` + `StartPod()`.
 
 * `StopPod(podID string)` stops an already running Pod.
+The Pod and all its containers are stopped.
 
-* `ListPod()` lists all running Pods on the host.
+* `StatusPod(podID string)` returns a detailed Pod status.
 
-* `EnterPod(cmd Cmd)` enters a Pod root filesystem and runs a given command.
-
-* `PodStatus(podID string)` returns a detailed Pod status.
+* `ListPod()` lists all Pods on the host.
+It returns a detailed status for every Pod.
 
 ### Container API
 
-* `CreateContainer(podID string, container ContainerConfig)` creates a Container on a given Pod.
+* `CreateContainer(podID string, containerConfig ContainerConfig)` creates a Container on an existing Pod.
 
-* `DeleteContainer(podID, containerID string)` deletes a Container from a Pod. If the container is running it needs to be stopped first.
+* `DeleteContainer(podID, containerID string)` deletes a Container from a Pod.
+If the Container is running it has to be stopped first.
 
-* `StartContainer(podID, containerID string)` starts an already created container.
+* `StartContainer(podID, containerID string)` starts an already created Container.
+The Pod has to be running.
 
-* `StopContainer(podID, containerID string)` stops an already running container.
+* `StopContainer(podID, containerID string)` stops an already running Container.
 
-* `EnterContainer(podID, containerID string, cmd Cmd)` enters an already running container and runs a given command.
+* `EnterContainer(podID, containerID string, cmd Cmd)` enters an already running Container and runs a given command.
 
-* `ContainerStatus(podID, containerID string)` returns a detailed container status.
+* `StatusContainer(podID, containerID string)` returns a detailed Container status.
 
 
 An example tool using the `virtcontainers` API is provided in the `hack/virtc` package.

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -27,6 +27,7 @@ import (
 
 // Process gathers data related to a container process.
 type Process struct {
+	URL   string
 	Token string
 	Pid   int
 }

--- a/vendor/github.com/containers/virtcontainers/hack/virtc/main.go
+++ b/vendor/github.com/containers/virtcontainers/hack/virtc/main.go
@@ -19,15 +19,18 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"strings"
 	"text/tabwriter"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 
 	vc "github.com/containers/virtcontainers"
 )
+
+var virtcLog = logrus.New()
 
 var listFormat = "%s\t%s\t%s\t%s\n"
 var statusFormat = "%s\t%s\n"
@@ -330,7 +333,7 @@ func createPod(context *cli.Context) error {
 		return fmt.Errorf("Could not create pod: %s", err)
 	}
 
-	fmt.Printf("Created pod %s\n", p.ID())
+	fmt.Printf("Pod %s created\n", p.ID())
 
 	return nil
 }
@@ -352,28 +355,34 @@ func checkContainerArgs(context *cli.Context, f func(context *cli.Context) error
 }
 
 func deletePod(context *cli.Context) error {
-	_, err := vc.DeletePod(context.String("id"))
+	p, err := vc.DeletePod(context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not delete pod: %s", err)
 	}
+
+	fmt.Printf("Pod %s deleted\n", p.ID())
 
 	return nil
 }
 
 func startPod(context *cli.Context) error {
-	_, err := vc.StartPod(context.String("id"))
+	p, err := vc.StartPod(context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not start pod: %s", err)
 	}
+
+	fmt.Printf("Pod %s started\n", p.ID())
 
 	return nil
 }
 
 func stopPod(context *cli.Context) error {
-	_, err := vc.StopPod(context.String("id"))
+	p, err := vc.StopPod(context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not stop pod: %s", err)
 	}
+
+	fmt.Printf("Pod %s stopped\n", p.ID())
 
 	return nil
 }
@@ -540,7 +549,7 @@ func createContainer(context *cli.Context) error {
 		return fmt.Errorf("Could not create container: %s", err)
 	}
 
-	fmt.Printf("Created container %s\n", c.ID())
+	fmt.Printf("Container %s created\n", c.ID())
 
 	return nil
 }
@@ -563,6 +572,12 @@ func startContainer(context *cli.Context) error {
 	}
 
 	fmt.Printf("Container %s started\n", c.ID())
+
+	if context.Bool("cc-shim") == true {
+		// Start cc-shim and wait for the end of it.
+		process := c.Process()
+		return startCCShim(&process, context.String("cc-shim-path"))
+	}
 
 	return nil
 }
@@ -592,12 +607,17 @@ func enterContainer(context *cli.Context) error {
 		WorkDir: "/",
 	}
 
-	_, c, _, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
+	_, c, process, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
 	if err != nil {
 		return fmt.Errorf("Could not enter container: %s", err)
 	}
 
 	fmt.Printf("Container %s entered\n", c.ID())
+
+	if context.Bool("cc-shim") == true {
+		// Start cc-shim and wait for the end of it.
+		return startCCShim(process, context.String("cc-shim-path"))
+	}
 
 	return nil
 }
@@ -686,6 +706,15 @@ var startContainerCommand = cli.Command{
 			Value: "",
 			Usage: "the pod identifier",
 		},
+		cli.BoolFlag{
+			Name:  "cc-shim",
+			Usage: "enable cc-shim",
+		},
+		cli.StringFlag{
+			Name:  "cc-shim-path",
+			Value: "",
+			Usage: "the cc-shim binary path",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		return checkContainerArgs(context, startContainer)
@@ -731,6 +760,15 @@ var enterContainerCommand = cli.Command{
 			Value: "echo",
 			Usage: "the command executed inside the container",
 		},
+		cli.BoolFlag{
+			Name:  "cc-shim",
+			Usage: "enable cc-shim",
+		},
+		cli.StringFlag{
+			Name:  "cc-shim-path",
+			Value: "",
+			Usage: "the cc-shim binary path",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		return checkContainerArgs(context, enterContainer)
@@ -757,6 +795,32 @@ var statusContainerCommand = cli.Command{
 	},
 }
 
+func startCCShim(process *vc.Process, shimPath string) error {
+	if process.Token == "" {
+		return fmt.Errorf("Token cannot be empty")
+	}
+
+	if process.URL == "" {
+		return fmt.Errorf("URL cannot be empty")
+	}
+
+	if shimPath == "" {
+		return fmt.Errorf("Shim path cannot be empty")
+	}
+
+	cmd := exec.Command(shimPath, "-t", process.Token, "-u", process.URL)
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func main() {
 	cli.VersionFlag = cli.BoolFlag{
 		Name:  "version",
@@ -766,6 +830,23 @@ func main() {
 	virtc := cli.NewApp()
 	virtc.Name = "VirtContainers CLI"
 	virtc.Version = "0.0.1"
+
+	virtc.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "enable debug output for logging",
+		},
+		cli.StringFlag{
+			Name:  "log",
+			Value: "",
+			Usage: "set the log file path where internal debug information is written",
+		},
+		cli.StringFlag{
+			Name:  "log-format",
+			Value: "text",
+			Usage: "set the format used by logs ('text' (default), or 'json')",
+		},
+	}
 
 	virtc.Commands = []cli.Command{
 		{
@@ -795,8 +876,38 @@ func main() {
 		},
 	}
 
+	virtc.Before = func(context *cli.Context) error {
+		if context.GlobalBool("debug") {
+			virtcLog.Level = logrus.DebugLevel
+		}
+
+		if path := context.GlobalString("log"); path != "" {
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0640)
+			if err != nil {
+				return err
+			}
+			virtcLog.Out = f
+		}
+
+		switch context.GlobalString("log-format") {
+		case "text":
+			// retain logrus's default.
+		case "json":
+			virtcLog.Formatter = new(logrus.JSONFormatter)
+		default:
+			return fmt.Errorf("unknown log-format %q", context.GlobalString("log-format"))
+		}
+
+		// Set virtcontainers logger.
+		vc.SetLog(virtcLog)
+
+		return nil
+	}
+
 	err := virtc.Run(os.Args)
 	if err != nil {
-		log.Fatal(err)
+		virtcLog.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -295,10 +295,9 @@ func (h *hyper) start(pod *Pod) error {
 		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(pod.containers))
 	}
 
-	pod.url = url
-
 	for idx := range pod.containers {
 		pod.containers[idx].process = Process{
+			URL:   url,
 			Token: proxyInfos[idx].Token,
 		}
 
@@ -330,8 +329,6 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		return nil, err
 	}
 
-	pod.url = url
-
 	process, err := h.buildHyperContainerProcess(cmd, c.config.Interactive)
 	if err != nil {
 		return nil, err
@@ -357,6 +354,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	}
 
 	processInfo := &Process{
+		URL:   url,
 		Token: proxyInfo.Token,
 	}
 
@@ -516,9 +514,8 @@ func (h *hyper) createContainer(pod *Pod, c *Container) error {
 		return err
 	}
 
-	pod.url = url
-
 	c.process = Process{
+		URL:   url,
 		Token: proxyInfo.Token,
 	}
 

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -339,8 +339,6 @@ type Pod struct {
 	runPath    string
 	configPath string
 
-	url string
-
 	state State
 
 	lockFile *os.File
@@ -359,11 +357,6 @@ func (p *Pod) Annotations(key string) (string, error) {
 	}
 
 	return value, nil
-}
-
-// URL returns the pod URL for any runtime to connect to the proxy.
-func (p *Pod) URL() string {
-	return p.url
 }
 
 // GetContainers returns a container config list.

--- a/vendor/github.com/containers/virtcontainers/proxy.go
+++ b/vendor/github.com/containers/virtcontainers/proxy.go
@@ -114,6 +114,14 @@ type proxy interface {
 	// disconnect disconnects from the proxy.
 	disconnect() error
 
-	// sendCmd sends a command to the agent inside the VM through the proxy.
+	// sendCmd sends a command to the agent inside the VM through the
+	// proxy.
+	// This function will always be used from a specific agent
+	// implementation because a proxy type is always tied to an agent
+	// type. That's the reason why it takes an interface as parameter
+	// and it returns another interface.
+	// Those interfaces allows consumers (agent implementations) of this
+	// proxy interface to be able to use specific structures that can only
+	// be understood by a specific agent<=>proxy pair.
 	sendCmd(cmd interface{}) (interface{}, error)
 }


### PR DESCRIPTION
This is a new update of the virtcontainers vendoring based on latest changes related to Pod and Process structures. Now the Pod structure does not hold the proxy URL anymore. The URL is duplicated in every
Process structure because it could be a different one from a container to another.