### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "2f92ae7a44bbadfbe4d06c0db49a8ea150780f05678f65b1809c55ab9cb9e5ed",
+    "memo": "ce0e0bdaf8d2746e88c45a8ff3a38ea009c3fad10bd3f012d70be2fa9b5fe7a3",
     "projects": [
         {
             "name": "github.com/01org/ciao",
@@ -46,7 +46,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "9c9e19090764e5808268dffc43f7fa53c1064a41",
+            "revision": "a49af6834700cdfdbcfd8d572ea20fec6f347fd9",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "9c9e19090764e5808268dffc43f7fa53c1064a41"
+            "revision": "a49af6834700cdfdbcfd8d572ea20fec6f347fd9"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/.travis.yml
+++ b/vendor/github.com/containers/virtcontainers/.travis.yml
@@ -37,7 +37,7 @@ script:
 - gocyclo -over 15 $go_files
 - go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
 - gofmt -s -l $go_files | wc -l | xargs -I % bash -c "test % -eq 0"
-- go build $go_packages
+- make
 - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin:/tmp/cni/bin $GOPATH/bin/test-cases
   -v -timeout 9 -short -coverprofile /tmp/cover.out $go_packages
 

--- a/vendor/github.com/containers/virtcontainers/Makefile
+++ b/vendor/github.com/containers/virtcontainers/Makefile
@@ -1,5 +1,5 @@
 all: binaries
-	go build ./...
+	go build $(go list ./... | grep -v /vendor/)
 	cd hack/virtc && go build
 
 pause:

--- a/vendor/github.com/containers/virtcontainers/README.md
+++ b/vendor/github.com/containers/virtcontainers/README.md
@@ -70,34 +70,41 @@ The high level `virtcontainers` API is the following one:
 ### Pod API
 
 * `CreatePod(podConfig PodConfig)` creates a Pod.
-The Pod is prepared and will run into a virtual machine. It is not started, i.e. the VM is not running after `CreatePod()` is called.
+The virtual machine is started and the Pod is prepared.
 
 * `DeletePod(podID string)` deletes a Pod.
-The function will fail if the Pod is running. In that case `StopPod()` needs to be called first.
+The virtual machine is shut down and all information related to the Pod are removed.
+The function will fail if the Pod is running. In that case `StopPod()` has to be called first.
 
 * `StartPod(podID string)` starts an already created Pod.
+The Pod and all its containers are started.
+
+* `RunPod(podConfig PodConfig)` creates and starts a Pod.
+This performs `CreatePod()` + `StartPod()`.
 
 * `StopPod(podID string)` stops an already running Pod.
+The Pod and all its containers are stopped.
 
-* `ListPod()` lists all running Pods on the host.
+* `StatusPod(podID string)` returns a detailed Pod status.
 
-* `EnterPod(cmd Cmd)` enters a Pod root filesystem and runs a given command.
-
-* `PodStatus(podID string)` returns a detailed Pod status.
+* `ListPod()` lists all Pods on the host.
+It returns a detailed status for every Pod.
 
 ### Container API
 
-* `CreateContainer(podID string, container ContainerConfig)` creates a Container on a given Pod.
+* `CreateContainer(podID string, containerConfig ContainerConfig)` creates a Container on an existing Pod.
 
-* `DeleteContainer(podID, containerID string)` deletes a Container from a Pod. If the container is running it needs to be stopped first.
+* `DeleteContainer(podID, containerID string)` deletes a Container from a Pod.
+If the Container is running it has to be stopped first.
 
-* `StartContainer(podID, containerID string)` starts an already created container.
+* `StartContainer(podID, containerID string)` starts an already created Container.
+The Pod has to be running.
 
-* `StopContainer(podID, containerID string)` stops an already running container.
+* `StopContainer(podID, containerID string)` stops an already running Container.
 
-* `EnterContainer(podID, containerID string, cmd Cmd)` enters an already running container and runs a given command.
+* `EnterContainer(podID, containerID string, cmd Cmd)` enters an already running Container and runs a given command.
 
-* `ContainerStatus(podID, containerID string)` returns a detailed container status.
+* `StatusContainer(podID, containerID string)` returns a detailed Container status.
 
 
 An example tool using the `virtcontainers` API is provided in the `hack/virtc` package.

--- a/vendor/github.com/containers/virtcontainers/api.go
+++ b/vendor/github.com/containers/virtcontainers/api.go
@@ -18,10 +18,15 @@ package virtcontainers
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
 )
+
+func init() {
+	runtime.LockOSThread()
+}
 
 var virtLog = logrus.New()
 
@@ -88,6 +93,10 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 // DeletePod is the virtcontainers pod deletion entry point.
 // DeletePod will stop an already running container and then delete it.
 func DeletePod(podID string) (*Pod, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -137,6 +146,10 @@ func DeletePod(podID string) (*Pod, error) {
 // pod and all its containers.
 // It returns the pod ID.
 func StartPod(podID string) (*Pod, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -180,6 +193,10 @@ func StartPod(podID string) (*Pod, error) {
 // StopPod is the virtcontainers pod stopping entry point.
 // StopPod will talk to the given agent to stop an existing pod and destroy all containers within that pod.
 func StopPod(podID string) (*Pod, error) {
+	if podID == "" {
+		return nil, ErrNeedPod
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -328,6 +345,10 @@ func ListPod() ([]PodStatus, error) {
 
 // StatusPod is the virtcontainers pod status entry point.
 func StatusPod(podID string) (PodStatus, error) {
+	if podID == "" {
+		return PodStatus{}, ErrNeedPodID
+	}
+
 	pod, err := fetchPod(podID)
 	if err != nil {
 		return PodStatus{}, err
@@ -359,6 +380,10 @@ func StatusPod(podID string) (PodStatus, error) {
 // CreateContainer is the virtcontainers container creation entry point.
 // CreateContainer creates a container on a given pod.
 func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Container, error) {
+	if podID == "" {
+		return nil, nil, ErrNeedPodID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, nil, err
@@ -401,6 +426,14 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Cont
 // DeleteContainer deletes a Container from a Pod. If the container is running,
 // it needs to be stopped first.
 func DeleteContainer(podID, containerID string) (*Container, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -447,6 +480,14 @@ func DeleteContainer(podID, containerID string) (*Container, error) {
 // StartContainer is the virtcontainers container starting entry point.
 // StartContainer starts an already created container.
 func StartContainer(podID, containerID string) (*Container, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -482,6 +523,14 @@ func StartContainer(podID, containerID string) (*Container, error) {
 // StopContainer is the virtcontainers container stopping entry point.
 // StopContainer stops an already running container.
 func StopContainer(podID, containerID string) (*Container, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -517,6 +566,14 @@ func StopContainer(podID, containerID string) (*Container, error) {
 // EnterContainer is the virtcontainers container command execution entry point.
 // EnterContainer enters an already running container and runs a given command.
 func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Process, error) {
+	if podID == "" {
+		return nil, nil, nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, nil, nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, nil, nil, err
@@ -551,6 +608,14 @@ func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Proc
 // StatusContainer is the virtcontainers container status entry point.
 // StatusContainer returns a detailed container status.
 func StatusContainer(podID, containerID string) (ContainerStatus, error) {
+	if podID == "" {
+		return ContainerStatus{}, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return ContainerStatus{}, ErrNeedContainerID
+	}
+
 	var contStatus ContainerStatus
 
 	pod, err := fetchPod(podID)
@@ -575,6 +640,14 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 // KillContainer is the virtcontainers entry point to send a signal
 // to a container running inside a pod.
 func KillContainer(podID, containerID string, signal syscall.Signal) error {
+	if podID == "" {
+		return ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return err

--- a/vendor/github.com/containers/virtcontainers/cc_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/cc_proxy.go
@@ -209,9 +209,7 @@ func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
 	}
 
 	var tokens []string
-	if proxyCmd.token == "" {
-		tokens = nil
-	} else {
+	if proxyCmd.token != "" {
 		tokens = append(tokens, proxyCmd.token)
 	}
 

--- a/vendor/github.com/containers/virtcontainers/cnm.go
+++ b/vendor/github.com/containers/virtcontainers/cnm.go
@@ -159,6 +159,10 @@ func (n *cnm) createEndpointsFromScan(networkNSPath string) ([]Endpoint, error) 
 
 // init initializes the network, setting a new network namespace for the CNM network.
 func (n *cnm) init(config *NetworkConfig) error {
+	if config == nil {
+		return fmt.Errorf("config cannot be empty")
+	}
+
 	if config.NetNSPath == "" {
 		path, err := createNetNS()
 		if err != nil {
@@ -173,7 +177,11 @@ func (n *cnm) init(config *NetworkConfig) error {
 
 // run runs a callback in the specified network namespace.
 func (n *cnm) run(networkNSPath string, cb func() error) error {
-	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
+	if networkNSPath == "" {
+		return fmt.Errorf("networkNSPath cannot be empty")
+	}
+
+	return safeDoNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})
 }

--- a/vendor/github.com/containers/virtcontainers/errors.go
+++ b/vendor/github.com/containers/virtcontainers/errors.go
@@ -22,6 +22,9 @@ import (
 
 // common error objects used for argument checking
 var (
+	ErrNeedPod         = errors.New("Pod must be specified")
 	ErrNeedPodID       = errors.New("Pod ID cannot be empty")
 	ErrNeedContainerID = errors.New("Container ID cannot be empty")
+	ErrNeedFile        = errors.New("File cannot be empty")
+	ErrNeedState       = errors.New("State cannot be empty")
 )

--- a/vendor/github.com/containers/virtcontainers/filesystem_test.go
+++ b/vendor/github.com/containers/virtcontainers/filesystem_test.go
@@ -326,25 +326,31 @@ func TestFilesystemFetchContainerConfigFailingPodIDEmpty(t *testing.T) {
 }
 
 func TestFilesystemResourceDirFailingPodIDEmpty(t *testing.T) {
-	_, err := resourceDir("", "", configFileType)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, err := resourceDir(b, "", "", configFileType)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
 func TestFilesystemResourceDirFailingInvalidResource(t *testing.T) {
-	_, err := resourceDir(testPodID, "100", podResource(-1))
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, err := resourceDir(b, testPodID, "100", podResource(-1))
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
 func TestFilesystemResourceURIFailingResourceDir(t *testing.T) {
 	fs := &filesystem{}
 
-	_, _, err := fs.resourceURI(testPodID, "100", podResource(-1))
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, _, err := fs.resourceURI(b, testPodID, "100", podResource(-1))
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -352,9 +358,11 @@ func TestFilesystemStoreResourceFailingPodConfigStateFileType(t *testing.T) {
 	fs := &filesystem{}
 	data := PodConfig{}
 
-	err := fs.storeResource(testPodID, "100", stateFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", stateFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -362,9 +370,11 @@ func TestFilesystemStoreResourceFailingContainerConfigStateFileType(t *testing.T
 	fs := &filesystem{}
 	data := ContainerConfig{}
 
-	err := fs.storeResource(testPodID, "100", stateFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", stateFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -372,9 +382,11 @@ func TestFilesystemStoreResourceFailingPodConfigResourceURI(t *testing.T) {
 	fs := &filesystem{}
 	data := PodConfig{}
 
-	err := fs.storeResource("", "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, "", "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -382,9 +394,11 @@ func TestFilesystemStoreResourceFailingContainerConfigResourceURI(t *testing.T) 
 	fs := &filesystem{}
 	data := ContainerConfig{}
 
-	err := fs.storeResource("", "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, "", "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -392,9 +406,11 @@ func TestFilesystemStoreResourceFailingStateConfigFileType(t *testing.T) {
 	fs := &filesystem{}
 	data := State{}
 
-	err := fs.storeResource(testPodID, "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -402,9 +418,11 @@ func TestFilesystemStoreResourceFailingStateResourceURI(t *testing.T) {
 	fs := &filesystem{}
 	data := State{}
 
-	err := fs.storeResource("", "100", stateFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, "", "100", stateFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -412,17 +430,21 @@ func TestFilesystemStoreResourceFailingWrongDataType(t *testing.T) {
 	fs := &filesystem{}
 	data := TestNoopStructure{}
 
-	err := fs.storeResource(testPodID, "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
 func TestFilesystemFetchResourceFailingWrongResourceType(t *testing.T) {
 	fs := &filesystem{}
 
-	_, err := fs.fetchResource(testPodID, "100", lockFileType)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, err := fs.fetchResource(b, testPodID, "100", lockFileType)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }

--- a/vendor/github.com/containers/virtcontainers/hack/virtc/README.md
+++ b/vendor/github.com/containers/virtcontainers/hack/virtc/README.md
@@ -1,11 +1,11 @@
 # virtc
 
-`virtc` is a simple command-line tool that serves to demonstrate typical usage of the `virt` API.
-This is example software; unlike other projects like runc, runv, or rkt, `virt` is not a full container runtime.
+`virtc` is a simple command-line tool that serves to demonstrate typical usage of the virtcontainers API.
+This is example software; unlike other projects like runc, runv, or rkt, virtcontainers is not a full container runtime.
 
 ## Virtc example
 
-Here we explain how to use the pod API from __virtc__ command line.
+Here we explain how to use the pod and container API from `virtc` command line.
 
 ### Prepare your environment
 
@@ -13,92 +13,131 @@ Here we explain how to use the pod API from __virtc__ command line.
 
 _Fedora_
 ```
-$ sudo -E dnf config-manager --add-repo http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.0/Fedora_24/home:clearlinux:preview:clear-containers-2.0.repo
+$ sudo -E dnf config-manager --add-repo http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.1/Fedora_25/home:clearlinux:preview:clear-containers-2.1.repo
 $ sudo dnf install linux-container 
 ```
 
 _Ubuntu_
 ```
-$ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.0/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/cc-oci-runtime.list"
+$ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.1/xUbuntu_16.10/ /' >> /etc/apt/sources.list.d/cc-oci-runtime.list"
 $ sudo apt install linux-container
 ```
 
 #### Get your image
 
-It has to be a recent Clear Linux image to make sure it contains hyperstart binary.
-You can dowload the following tested [image](https://download.clearlinux.org/releases/12210/clear/clear-12210-containers.img.xz), or any version more recent.
+Retrieve a recent Clear Containers image to make sure it contains a recent version of hyperstart agent.
+
+To download and install the latest image:
 
 ```
-$ wget https://download.clearlinux.org/releases/12210/clear/clear-12210-containers.img.xz
-$ unxz clear-12210-containers.img.xz
-$ sudo cp clear-12210-containers.img /usr/share/clear-containers/clear-containers.img
+$ latest_version=$(curl -sL https://download.clearlinux.org/latest)
+$ curl -LO "https://download.clearlinux.org/current/clear-${latest_version}-containers.img.xz"
+$ unxz clear-${latest_version}-containers.img.xz
+$ sudo mkdir -p /usr/share/clear-containers/
+$ sudo install --owner root --group root --mode 0644 clear-${latest_version}-containers.img /usr/share/clear-containers/
+$ sudo ln -fs /usr/share/clear-containers/clear-${latest_version}-containers.img /usr/share/clear-containers/clear-containers.img
 ```
 
 #### Get virtc
 
-_Download virtc_
+_Download virtcontainers project_
 ```
 $ go get github.com/containers/virtcontainers
 ```
 
-_Build and install pause binary_
+_Build and setup your environment_
 ```
 $ cd $GOPATH/src/github.com/containers/virtcontainers
-$ make
-$ make install
+$ go build -o virtc hack/virtc/main.go
+$ sudo ./utils/virtcontainers-setup.sh
 ```
 
-_Go to virtc_
+`virtcontainers-setup.sh` setup your environment performing different tasks. Particularly, it creates a __busybox__ bundle, and it creates CNI configuration files needed to run `virtc` with CNI plugins.
+
+### Get cc-proxy (optional)
+
+If you plan to start `virtc` with the hyperstart agent, you will have to use [cc-proxy](https://github.com/clearcontainers/proxy) as a proxy, meaning you have to perform extra steps to setup your environment.
+
 ```
-$ cd hack/virtc
+$ go get github.com/clearcontainers/proxy
+$ make
+$ sudo make install
 ```
+If you want to see the traces from the proxy when `virtc` will run, you can manually start it with appropriate debug level:
+
+```
+$ sudo /usr/libexec/clearcontainers/cc-proxy -v 3
+```
+This will generate output similar to the following:
+```
+I0410 08:58:49.058881    5384 proxy.go:521] listening on /var/run/clearcontainers/proxy.sock
+I0410 08:58:49.059044    5384 proxy.go:566] proxy started
+```
+The proxy socket specified in the example log output has to be used as `virtc`'s `--proxy-url` option.
+
+### Get cc-shim (optional)
+
+If you plan to start `virtc` with the hyperstart agent (implying the use of `cc-proxy` as a proxy), you will have the possibility to enable [cc-shim](https://github.com/clearcontainers/shim) in order to interact with the process running inside your container. First, you will have to perform extra steps to setup your environment.
+
+```
+$ go get github.com/clearcontainers/shim
+$ make
+$ sudo make install
+```
+
+The shim will be installed at the following location: `/usr/libexec/cc-shim`. There will be two cases where you will be able to enable `cc-shim`:
+
+_Start a new container_
+
+```
+# ./virtc container start --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cc-shim --cc-shim-path="/usr/libexec/cc-shim"
+```
+_Execute a new process on a running container_
+```
+# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ifconfig" --cc-shim --cc-shim-path="/usr/libexec/cc-shim"
+```
+Notice that in both cases, the `--pod-id` and `--id` options have been defined when creating a pod and a container respectively. 
 
 ### Run virtc
 
-All following commands needs to be run as root. Currently, __virtc__ only starts single container pods.
-
-_Create your container bundle_
-
-As an example we will create a busybox bundle:
-
-```
-$ mkdir -p /tmp/bundles/busybox/
-$ docker pull busybox
-$ cd /tmp/bundles/busybox/
-$ mkdir rootfs
-$ docker export $(docker create busybox) | tar -C rootfs -xvf -
-$ echo -e '#!/bin/sh\ncd "\"\n"sh"' > rootfs/.containerexec
-$ echo -e 'HOME=/root\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nTERM=xterm' > rootfs/.containerenv
-```
+All following commands __MUST__ be run as root. By default, and unless you decide to modify it and rebuild it, `virtc` starts empty pods (no container started).
 
 #### Run a new pod (Create + Start)
 ```
-./virtc pod run --agent="hyperstart" --network="CNI" --proxy="ccProxy"
+# ./virtc pod run --agent="hyperstart" --network="CNI" --proxy="ccProxy" --proxy-url="unix:///var/run/clearcontainers/proxy.sock" --pause-path="/tmp/bundles/pause_bundle/rootfs/bin/pause"
 ```
 #### Create a new pod
 ```
-./virtc pod create --agent="hyperstart" --network="CNI" --proxy="ccProxy"
+# ./virtc pod run --agent="hyperstart" --network="CNI" --proxy="ccProxy" --proxy-url="unix:///var/run/clearcontainers/proxy.sock" --pause-path="/tmp/bundles/pause_bundle/rootfs/bin/pause"
 ```
-This should generate that kind of output
+This will generate output similar to the following:
 ```
-Created pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 created
 ```
 
 #### Start an existing pod
 ```
-./virtc pod start --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc pod start --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following:
+```
+Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 started
 ```
 
 #### Stop an existing pod
 ```
-./virtc pod stop --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc pod stop --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following:
+```
+Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 stopped
 ```
 
 #### Get the status of an existing pod and its containers
 ```
-./virtc pod status --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc pod status --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
-This should generate the following output:
+This will generate output similar to the following (assuming the pod has been started):
 ```
 POD ID                                  STATE   HYPERVISOR      AGENT
 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8    running qemu            hyperstart
@@ -108,12 +147,16 @@ CONTAINER ID    STATE
 
 #### Delete an existing pod
 ```
-./virtc pod delete --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc pod delete --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following:
+```
+Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 deleted
 ```
 
 #### List all existing pods
 ```
-./virtc pod list
+# ./virtc pod list
 ```
 This should generate that kind of output
 ```
@@ -122,4 +165,59 @@ POD ID                                  STATE   HYPERVISOR      AGENT
 92d73f74-4514-4a0d-81df-db1cc4c59100    running qemu            hyperstart
 7088148c-049b-4be7-b1be-89b3ae3c551c    ready   qemu            hyperstart
 6d57654e-4804-4a91-b72d-b5fe375ed3e1    ready   qemu            hyperstart
+```
+
+#### Create a new container
+```
+# ./virtc container create --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --rootfs="/tmp/bundles/busybox/rootfs" --cmd="/bin/ifconfig"
+```
+This will generate output similar to the following:
+```
+Container 1 created
+```
+
+#### Start an existing container
+```
+# ./virtc container start --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following:
+```
+Container 1 started
+```
+
+#### Run a new process on an existing container
+```
+# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps"
+```
+This will generate output similar to the following:
+```
+Container 1 entered
+```
+
+#### Stop an existing container
+```
+# ./virtc container stop --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following:
+```
+Container 1 stopped
+```
+
+#### Delete an existing container
+```
+# ./virtc container delete --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following:
+```
+Container 1 deleted
+```
+
+#### Get the status of an existing container
+```
+# ./virtc container status --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+```
+This will generate output similar to the following (assuming the container has been started):
+```
+CONTAINER ID    STATE
+1               running
 ```

--- a/vendor/github.com/containers/virtcontainers/hook_test.go
+++ b/vendor/github.com/containers/virtcontainers/hook_test.go
@@ -70,6 +70,8 @@ func testRunHook(t *testing.T, timeout int) {
 }
 
 func TestRunHook(t *testing.T) {
+	cleanUp()
+
 	testRunHook(t, 0)
 }
 

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -151,7 +151,10 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 		return nil, nil, err
 	}
 
-	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
+	rootfs := ocispec.Root.Path
+	if !filepath.IsAbs(rootfs) {
+		rootfs = filepath.Join(bundlePath, ocispec.Root.Path)
+	}
 	ociLog.Debugf("container rootfs: %s", rootfs)
 
 	cmd := vc.Cmd{
@@ -164,7 +167,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 
 	containerConfig := vc.ContainerConfig{
 		ID:          cid,
-		RootFs:      ocispec.Root.Path,
+		RootFs:      rootfs,
 		Interactive: ocispec.Process.Terminal,
 		Console:     console,
 		Cmd:         cmd,

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -78,7 +78,7 @@ func TestMinimalPodConfig(t *testing.T) {
 
 	expectedContainerConfig := vc.ContainerConfig{
 		ID:          containerID,
-		RootFs:      "rootfs",
+		RootFs:      path.Join(tempBundlePath, "rootfs"),
 		Interactive: true,
 		Console:     consolePath,
 		Cmd:         expectedCmd,

--- a/vendor/github.com/containers/virtcontainers/pod_test.go
+++ b/vendor/github.com/containers/virtcontainers/pod_test.go
@@ -94,11 +94,9 @@ func TestCreatePodEmtpyID(t *testing.T) {
 	hConfig := newHypervisorConfig(nil, nil)
 
 	p, err := testCreatePod(t, "", MockHypervisor, hConfig, NoopAgentType, NoopNetworkModel, NetworkConfig{}, nil, nil)
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatalf("Expected pod with empty ID to fail, but got pod %v", p)
 	}
-
-	t.Logf("Got new ID %s", p.id)
 }
 
 func testPodStateTransition(t *testing.T, state stateString, newState stateString) error {
@@ -455,7 +453,8 @@ func TestPodSetPodStateFailingStorePodResource(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.setPodState(StateReady)
+	pod.state.State = StateReady
+	err := pod.setPodState(pod.state)
 	if err == nil {
 		t.Fatal()
 	}

--- a/vendor/github.com/containers/virtcontainers/proxy.go
+++ b/vendor/github.com/containers/virtcontainers/proxy.go
@@ -114,6 +114,14 @@ type proxy interface {
 	// disconnect disconnects from the proxy.
 	disconnect() error
 
-	// sendCmd sends a command to the agent inside the VM through the proxy.
+	// sendCmd sends a command to the agent inside the VM through the
+	// proxy.
+	// This function will always be used from a specific agent
+	// implementation because a proxy type is always tied to an agent
+	// type. That's the reason why it takes an interface as parameter
+	// and it returns another interface.
+	// Those interfaces allows consumers (agent implementations) of this
+	// proxy interface to be able to use specific structures that can only
+	// be understood by a specific agent<=>proxy pair.
 	sendCmd(cmd interface{}) (interface{}, error)
 }

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -51,6 +51,10 @@ func (c SshdConfig) validate() bool {
 }
 
 func publicKeyAuth(file string) (ssh.AuthMethod, error) {
+	if file == "" {
+		return nil, ErrNeedFile
+	}
+
 	privateBytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load private key")
@@ -65,6 +69,10 @@ func publicKeyAuth(file string) (ssh.AuthMethod, error) {
 }
 
 func execCmd(session *ssh.Session, cmd string) error {
+	if session == nil {
+		return fmt.Errorf("session cannot be empty")
+	}
+
 	stdout, err := session.CombinedOutput(cmd)
 
 	if err != nil {
@@ -78,6 +86,14 @@ func execCmd(session *ssh.Session, cmd string) error {
 
 // init is the agent initialization implementation for sshd.
 func (s *sshd) init(pod *Pod, config interface{}) error {
+	if pod == nil {
+		return ErrNeedPod
+	}
+
+	if config == nil {
+		return fmt.Errorf("config cannot be empty")
+	}
+
 	c := config.(SshdConfig)
 	if c.validate() == false {
 		return fmt.Errorf("Invalid configuration")
@@ -91,6 +107,10 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 
 // start is the agent starting implementation for sshd.
 func (s *sshd) start(pod *Pod) error {
+	if pod == nil {
+		return ErrNeedPod
+	}
+
 	if s.client != nil {
 		session, err := s.client.NewSession()
 		if err == nil {
@@ -136,6 +156,10 @@ func (s *sshd) stop(pod Pod) error {
 
 // exec is the agent command execution implementation for sshd.
 func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
+	if pod == nil {
+		return nil, ErrNeedPod
+	}
+
 	session, err := s.client.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create session")

--- a/vendor/github.com/containers/virtcontainers/virtcontainers_test.go
+++ b/vendor/github.com/containers/virtcontainers/virtcontainers_test.go
@@ -47,6 +47,23 @@ var testQemuPath = ""
 var testHyperstartCtlSocket = ""
 var testHyperstartTtySocket = ""
 
+// cleanUp Removes any stale pod/container state that can affect
+// the next test to run.
+func cleanUp() {
+	for _, dir := range []string{testDir, defaultSharedDir} {
+		os.RemoveAll(dir)
+		os.MkdirAll(dir, dirMode)
+	}
+
+	os.Mkdir(filepath.Join(testDir, testBundle), dirMode)
+
+	_, err := os.Create(filepath.Join(testDir, testImage))
+	if err != nil {
+		fmt.Println("Could not recreate test image:", err)
+		os.Exit(1)
+	}
+}
+
 // TestMain is the common main function used by ALL the test functions
 // for this package.
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Virtcontainers recently changed to include 2 important fixes:
- Proxy does not need a token for pause container
- Add LockOSThread() in an init() function, to ensure the main thread is not executed in a thread ID different from the process ID.