### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "ce0e0bdaf8d2746e88c45a8ff3a38ea009c3fad10bd3f012d70be2fa9b5fe7a3",
+    "memo": "a3d121d57f89505ef56628087ec162da37657e31bce41c6018e51003975d4431",
     "projects": [
         {
             "name": "github.com/01org/ciao",
@@ -46,7 +46,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "a49af6834700cdfdbcfd8d572ea20fec6f347fd9",
+            "revision": "049cdcba85b917d235d6315ecfdfdc2693c0f0e1",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "a49af6834700cdfdbcfd8d572ea20fec6f347fd9"
+            "revision": "049cdcba85b917d235d6315ecfdfdc2693c0f0e1"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/cc_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/cc_proxy.go
@@ -17,7 +17,6 @@
 package virtcontainers
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -203,15 +202,10 @@ func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("Wrong command type, should be hyperstartProxyCmd type")
 	}
 
-	data, err := json.Marshal(proxyCmd.message)
-	if err != nil {
-		return nil, err
-	}
-
 	var tokens []string
 	if proxyCmd.token != "" {
 		tokens = append(tokens, proxyCmd.token)
 	}
 
-	return nil, p.client.HyperWithTokens(proxyCmd.cmd, tokens, json.RawMessage(data))
+	return nil, p.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message)
 }

--- a/vendor/github.com/containers/virtcontainers/virtcontainers_test.go
+++ b/vendor/github.com/containers/virtcontainers/virtcontainers_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Sirupsen/logrus"
 )
 
 const testPodID = "7f49d00d-1995-4156-8c79-5f5ab24ce138"
@@ -70,6 +72,13 @@ func TestMain(m *testing.M) {
 	var err error
 
 	flag.Parse()
+
+	virtLog.Level = logrus.ErrorLevel
+	for _, arg := range flag.Args() {
+		if arg == "debug-logs" {
+			virtLog.Level = logrus.DebugLevel
+		}
+	}
 
 	testDir, err = ioutil.TempDir("", "virtcontainers-tmp-")
 	if err != nil {


### PR DESCRIPTION
Include one important fix:
- cc_proxy implementation was marshalling the message sent to the proxy while the proxy was also marshalling it. This error was not detected before because Go 1.8 was working fine with a double
marshalling.