### PR TITLE
logging: Disable logfile access for "other".

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 			ccLog.Level = logrus.DebugLevel
 		}
 		if path := context.GlobalString("log"); path != "" {
-			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0640)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Set logfile mode to 0640 rather than 0666 for safety.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>