### PR TITLE
Allow exec command to specify a different console

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -197,10 +197,12 @@ func execute(params execParams) error {
 	}
 
 	cmd := vc.Cmd{
-		Args:    params.ociProcess.Args,
-		Envs:    envVars,
-		WorkDir: params.ociProcess.Cwd,
-		User:    params.ociProcess.User.Username,
+		Args:        params.ociProcess.Args,
+		Envs:        envVars,
+		WorkDir:     params.ociProcess.Cwd,
+		User:        params.ociProcess.User.Username,
+		Interactive: params.ociProcess.Terminal,
+		Console:     params.console,
 	}
 
 	if _, err := loadConfiguration(""); err != nil {

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "7d6af333d6570cb6eddf977e040df96220c1bd4eea9ee0378fcb661061721039",
+    "memo": "7b6c1dd6933a48d019dcb2b096b23132b7a6b399103a6c0a5b4ccade11482ae4",
     "projects": [
         {
             "name": "github.com/01org/ciao",
@@ -46,7 +46,7 @@
         },
         {
             "name": "github.com/containers/virtcontainers",
-            "revision": "ee0f7c6920be19d9dcad3c82cfe26e9bcb72459a",
+            "revision": "b988315d73cb6d306d322b8c3bc73724b28d82ff",
             "packages": [
                 ".",
                 "pkg/oci"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
             "branch": "master"
         },
         "github.com/containers/virtcontainers": {
-            "revision": "ee0f7c6920be19d9dcad3c82cfe26e9bcb72459a"
+            "revision": "b988315d73cb6d306d322b8c3bc73724b28d82ff"
         },
         "github.com/docker/libnetwork": {
             "branch": "master"

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -117,14 +117,8 @@ type agent interface {
 	// to handle all other Agent interface methods.
 	init(pod *Pod, config interface{}) error
 
-	// start will start the agent.
-	start(pod *Pod) error
-
-	// stop will stop the agent.
-	stop(pod Pod) error
-
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod *Pod, c Container, cmd Cmd) (*Process, error)
+	exec(pod *Pod, c Container, process Process, cmd Cmd) error
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(pod Pod) error

--- a/vendor/github.com/containers/virtcontainers/api.go
+++ b/vendor/github.com/containers/virtcontainers/api.go
@@ -82,6 +82,11 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
+	// Start shims
+	if err := p.startShims(); err != nil {
+		return nil, err
+	}
+
 	err = p.endSession()
 	if err != nil {
 		return nil, err
@@ -94,7 +99,7 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 // DeletePod will stop an already running container and then delete it.
 func DeletePod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -147,7 +152,7 @@ func DeletePod(podID string) (*Pod, error) {
 // It returns the pod ID.
 func StartPod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -194,7 +199,7 @@ func StartPod(podID string) (*Pod, error) {
 // StopPod will talk to the given agent to stop an existing pod and destroy all containers within that pod.
 func StopPod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPod
+		return nil, errNeedPod
 	}
 
 	lockFile, err := lockPod(podID)
@@ -292,6 +297,11 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
+	// Start shims
+	if err := p.startShims(); err != nil {
+		return nil, err
+	}
+
 	// Start the pod
 	err = p.start()
 	if err != nil {
@@ -346,7 +356,7 @@ func ListPod() ([]PodStatus, error) {
 // StatusPod is the virtcontainers pod status entry point.
 func StatusPod(podID string) (PodStatus, error) {
 	if podID == "" {
-		return PodStatus{}, ErrNeedPodID
+		return PodStatus{}, errNeedPodID
 	}
 
 	pod, err := fetchPod(podID)
@@ -381,7 +391,7 @@ func StatusPod(podID string) (PodStatus, error) {
 // CreateContainer creates a container on a given pod.
 func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Container, error) {
 	if podID == "" {
-		return nil, nil, ErrNeedPodID
+		return nil, nil, errNeedPodID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -427,11 +437,11 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Cont
 // it needs to be stopped first.
 func DeleteContainer(podID, containerID string) (*Container, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -481,11 +491,11 @@ func DeleteContainer(podID, containerID string) (*Container, error) {
 // StartContainer starts an already created container.
 func StartContainer(podID, containerID string) (*Container, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -524,11 +534,11 @@ func StartContainer(podID, containerID string) (*Container, error) {
 // StopContainer stops an already running container.
 func StopContainer(podID, containerID string) (*Container, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -567,11 +577,11 @@ func StopContainer(podID, containerID string) (*Container, error) {
 // EnterContainer enters an already running container and runs a given command.
 func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Process, error) {
 	if podID == "" {
-		return nil, nil, nil, ErrNeedPodID
+		return nil, nil, nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, nil, nil, ErrNeedContainerID
+		return nil, nil, nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -609,11 +619,11 @@ func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Proc
 // StatusContainer returns a detailed container status.
 func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 	if podID == "" {
-		return ContainerStatus{}, ErrNeedPodID
+		return ContainerStatus{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return ContainerStatus{}, ErrNeedContainerID
+		return ContainerStatus{}, errNeedContainerID
 	}
 
 	var contStatus ContainerStatus
@@ -641,11 +651,11 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 // to a container running inside a pod.
 func KillContainer(podID, containerID string, signal syscall.Signal) error {
 	if podID == "" {
-		return ErrNeedPodID
+		return errNeedPodID
 	}
 
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)

--- a/vendor/github.com/containers/virtcontainers/errors.go
+++ b/vendor/github.com/containers/virtcontainers/errors.go
@@ -22,9 +22,9 @@ import (
 
 // common error objects used for argument checking
 var (
-	ErrNeedPod         = errors.New("Pod must be specified")
-	ErrNeedPodID       = errors.New("Pod ID cannot be empty")
-	ErrNeedContainerID = errors.New("Container ID cannot be empty")
-	ErrNeedFile        = errors.New("File cannot be empty")
-	ErrNeedState       = errors.New("State cannot be empty")
+	errNeedPod         = errors.New("Pod must be specified")
+	errNeedPodID       = errors.New("Pod ID cannot be empty")
+	errNeedContainerID = errors.New("Container ID cannot be empty")
+	errNeedFile        = errors.New("File cannot be empty")
+	errNeedState       = errors.New("State cannot be empty")
 )

--- a/vendor/github.com/containers/virtcontainers/filesystem.go
+++ b/vendor/github.com/containers/virtcontainers/filesystem.go
@@ -150,7 +150,7 @@ func (fs *filesystem) createAllResources(pod Pod) (err error) {
 
 func (fs *filesystem) storeFile(file string, data interface{}) error {
 	if file == "" {
-		return ErrNeedFile
+		return errNeedFile
 	}
 
 	f, err := os.Create(file)
@@ -170,7 +170,7 @@ func (fs *filesystem) storeFile(file string, data interface{}) error {
 
 func (fs *filesystem) fetchFile(file string, data interface{}) error {
 	if file == "" {
-		return ErrNeedFile
+		return errNeedFile
 	}
 
 	fileData, err := ioutil.ReadFile(file)
@@ -204,11 +204,11 @@ func resourceNeedsContainerID(podSpecific bool, resource podResource) bool {
 
 func resourceDir(podSpecific bool, podID, containerID string, resource podResource) (string, error) {
 	if podID == "" {
-		return "", ErrNeedPodID
+		return "", errNeedPodID
 	}
 
 	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
-		return "", ErrNeedContainerID
+		return "", errNeedContainerID
 	}
 
 	var path string
@@ -235,7 +235,7 @@ func resourceDir(podSpecific bool, podID, containerID string, resource podResour
 // blank to resourceDIR()
 func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, resource podResource) (string, string, error) {
 	if podID == "" {
-		return "", "", ErrNeedPodID
+		return "", "", errNeedPodID
 	}
 
 	var filename string
@@ -269,11 +269,11 @@ func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, r
 
 func (fs *filesystem) containerURI(podID, containerID string, resource podResource) (string, string, error) {
 	if podID == "" {
-		return "", "", ErrNeedPodID
+		return "", "", errNeedPodID
 	}
 
 	if containerID == "" {
-		return "", "", ErrNeedContainerID
+		return "", "", errNeedContainerID
 	}
 
 	return fs.resourceURI(false, podID, containerID, resource)
@@ -287,11 +287,11 @@ func (fs *filesystem) podURI(podID string, resource podResource) (string, string
 // getting a podResource.
 func (fs *filesystem) commonResourceChecks(podSpecific bool, podID, containerID string, resource podResource) error {
 	if podID == "" {
-		return ErrNeedPodID
+		return errNeedPodID
 	}
 
 	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	return nil
@@ -490,11 +490,11 @@ func (fs *filesystem) deletePodResources(podID string, resources []podResource) 
 
 func (fs *filesystem) storeContainerResource(podID, containerID string, resource podResource, data interface{}) error {
 	if podID == "" {
-		return ErrNeedPodID
+		return errNeedPodID
 	}
 
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	return fs.storeResource(false, podID, containerID, resource, data)
@@ -502,11 +502,11 @@ func (fs *filesystem) storeContainerResource(podID, containerID string, resource
 
 func (fs *filesystem) fetchContainerConfig(podID, containerID string) (ContainerConfig, error) {
 	if podID == "" {
-		return ContainerConfig{}, ErrNeedPodID
+		return ContainerConfig{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return ContainerConfig{}, ErrNeedContainerID
+		return ContainerConfig{}, errNeedContainerID
 	}
 
 	data, err := fs.fetchResource(false, podID, containerID, configFileType)
@@ -524,11 +524,11 @@ func (fs *filesystem) fetchContainerConfig(podID, containerID string) (Container
 
 func (fs *filesystem) fetchContainerState(podID, containerID string) (State, error) {
 	if podID == "" {
-		return State{}, ErrNeedPodID
+		return State{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return State{}, ErrNeedContainerID
+		return State{}, errNeedContainerID
 	}
 
 	data, err := fs.fetchResource(false, podID, containerID, stateFileType)
@@ -546,11 +546,11 @@ func (fs *filesystem) fetchContainerState(podID, containerID string) (State, err
 
 func (fs *filesystem) fetchContainerProcess(podID, containerID string) (Process, error) {
 	if podID == "" {
-		return Process{}, ErrNeedPodID
+		return Process{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return Process{}, ErrNeedContainerID
+		return Process{}, errNeedContainerID
 	}
 
 	data, err := fs.fetchResource(false, podID, containerID, processFileType)

--- a/vendor/github.com/containers/virtcontainers/hack/virtc/README.md
+++ b/vendor/github.com/containers/virtcontainers/hack/virtc/README.md
@@ -197,12 +197,17 @@ Container 1 started
 
 #### Run a new process on an existing container
 ```
-# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps"
+# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps" --console="/dev/pts/30"
 ```
 This will generate output similar to the following:
 ```
 Container 1 entered
 ```
+__Note:__ The option `--console` can be any existing console.
+Don't try to provide `$(tty)` as it is your current console, and you would not be
+able to get your console back as the shim would be listening to this indefinitely.
+Instead, you would prefer to open a new shell and get the `$(tty)` from this shell.
+That way, you make sure you have a dedicated input/output terminal.
 
 #### Stop an existing container
 ```

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -30,19 +30,9 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// start is the Noop agent starting implementation. It does nothing.
-func (n *noopAgent) start(pod *Pod) error {
-	return nil
-}
-
-// stop is the Noop agent stopping implementation. It does nothing.
-func (n *noopAgent) stop(pod Pod) error {
-	return nil
-}
-
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
-	return nil, nil
+func (n *noopAgent) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
+	return nil
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.

--- a/vendor/github.com/containers/virtcontainers/noop_agent_test.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent_test.go
@@ -30,23 +30,14 @@ func TestNoopAgentInit(t *testing.T) {
 	}
 }
 
-func TestNoopAgentStartAgent(t *testing.T) {
-	n := &noopAgent{}
-	pod := &Pod{}
-
-	err := n.start(pod)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	pod := &Pod{}
 	container := Container{}
+	process := Process{}
 	cmd := Cmd{}
 
-	if _, err := n.exec(pod, container, cmd); err != nil {
+	if err := n.exec(pod, container, process, cmd); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -66,16 +57,6 @@ func TestNoopAgentStopPod(t *testing.T) {
 	pod := Pod{}
 
 	err := n.stopPod(pod)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestNoopAgentStopAgent(t *testing.T) {
-	n := &noopAgent{}
-	pod := Pod{}
-
-	err := n.stop(pod)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -161,19 +161,19 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	ociLog.Debugf("container rootfs: %s", rootfs)
 
 	cmd := vc.Cmd{
-		Args:    ocispec.Process.Args,
-		Envs:    cmdEnvs(ocispec, []vc.EnvVar{}),
-		WorkDir: ocispec.Process.Cwd,
-		User:    strconv.FormatUint(uint64(ocispec.Process.User.UID), 10),
-		Group:   strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
+		Args:        ocispec.Process.Args,
+		Envs:        cmdEnvs(ocispec, []vc.EnvVar{}),
+		WorkDir:     ocispec.Process.Cwd,
+		User:        strconv.FormatUint(uint64(ocispec.Process.User.UID), 10),
+		Group:       strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
+		Interactive: ocispec.Process.Terminal,
+		Console:     console,
 	}
 
 	containerConfig := vc.ContainerConfig{
-		ID:          cid,
-		RootFs:      rootfs,
-		Interactive: ocispec.Process.Terminal,
-		Console:     console,
-		Cmd:         cmd,
+		ID:     cid,
+		RootFs: rootfs,
+		Cmd:    cmd,
 	}
 
 	networkConfig, err := networkConfig(ocispec)

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -72,17 +72,17 @@ func TestMinimalPodConfig(t *testing.T) {
 				Value: "xterm",
 			},
 		},
-		WorkDir: "/",
-		User:    "0",
-		Group:   "0",
+		WorkDir:     "/",
+		User:        "0",
+		Group:       "0",
+		Interactive: true,
+		Console:     consolePath,
 	}
 
 	expectedContainerConfig := vc.ContainerConfig{
-		ID:          containerID,
-		RootFs:      path.Join(tempBundlePath, "rootfs"),
-		Interactive: true,
-		Console:     consolePath,
-		Cmd:         expectedCmd,
+		ID:     containerID,
+		RootFs: path.Join(tempBundlePath, "rootfs"),
+		Cmd:    expectedCmd,
 	}
 
 	expectedNetworkConfig := vc.NetworkConfig{

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -226,6 +226,9 @@ type Cmd struct {
 
 	User  string
 	Group string
+
+	Interactive bool
+	Console     string
 }
 
 // Resources describes VM resources configuration.
@@ -300,7 +303,7 @@ func (podConfig *PodConfig) valid() bool {
 // lock locks any pod to prevent it from being accessed by other processes.
 func lockPod(podID string) (*os.File, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	fs := filesystem{}
@@ -345,6 +348,8 @@ type Pod struct {
 
 	hypervisor hypervisor
 	agent      agent
+	proxy      proxy
+	shim       shim
 	storage    resourceStorage
 	network    network
 
@@ -419,7 +424,16 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	err = hypervisor.init(podConfig.HypervisorConfig)
+	if err := hypervisor.init(podConfig.HypervisorConfig); err != nil {
+		return nil, err
+	}
+
+	proxy, err := newProxy(podConfig.ProxyType)
+	if err != nil {
+		return nil, err
+	}
+
+	shim, err := newShim(podConfig.ShimType)
 	if err != nil {
 		return nil, err
 	}
@@ -430,6 +444,8 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		id:         podConfig.ID,
 		hypervisor: hypervisor,
 		agent:      agent,
+		proxy:      proxy,
+		shim:       shim,
 		storage:    &filesystem{},
 		network:    network,
 		config:     &podConfig,
@@ -446,32 +462,17 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 
 	p.containers = containers
 
-	err = p.storage.createAllResources(*p)
-	if err != nil {
+	if err := p.storage.createAllResources(*p); err != nil {
 		return nil, err
 	}
 
-	err = p.hypervisor.createPod(podConfig)
-	if err != nil {
+	if err := p.hypervisor.createPod(podConfig); err != nil {
 		p.storage.deletePodResources(p.id, nil)
 		return nil, err
 	}
 
-	var agentConfig interface{}
-
-	if podConfig.AgentConfig != nil {
-		switch podConfig.AgentConfig.(type) {
-		case (map[string]interface{}):
-			agentConfig = newAgentConfig(podConfig)
-		default:
-			agentConfig = podConfig.AgentConfig.(interface{})
-		}
-	} else {
-		agentConfig = nil
-	}
-
-	err = p.agent.init(p, agentConfig)
-	if err != nil {
+	agentConfig := newAgentConfig(podConfig)
+	if err := p.agent.init(p, agentConfig); err != nil {
 		p.storage.deletePodResources(p.id, nil)
 		return nil, err
 	}
@@ -482,8 +483,7 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return p, nil
 	}
 
-	err = p.createSetStates()
-	if err != nil {
+	if err := p.createSetStates(); err != nil {
 		p.storage.deletePodResources(p.id, nil)
 		return nil, err
 	}
@@ -511,7 +511,7 @@ func (p *Pod) storePod() error {
 // fetchPod fetches a pod config from a pod ID and returns a pod.
 func fetchPod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	fs := filesystem{}
@@ -606,13 +606,55 @@ func (p *Pod) startVM() error {
 		return fmt.Errorf("Did not receive the pod started notification")
 	}
 
-	err := p.agent.start(p)
+	virtLog.Infof("VM started")
+
+	return nil
+}
+
+// startShims starts registers all containers to the proxy and starts
+// one shim per container.
+func (p *Pod) startShims() error {
+	proxyInfos, url, err := p.proxy.register(*p)
 	if err != nil {
-		p.stop()
 		return err
 	}
 
-	virtLog.Infof("VM started")
+	if err := p.proxy.disconnect(); err != nil {
+		return err
+	}
+
+	if len(proxyInfos) != len(p.containers) {
+		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(p.containers))
+	}
+
+	p.state.URL = url
+	if err := p.setPodState(p.state); err != nil {
+		return err
+	}
+
+	for idx := range p.containers {
+		shimParams := ShimParams{
+			Token:   proxyInfos[idx].Token,
+			URL:     url,
+			Console: p.containers[idx].config.Cmd.Console,
+		}
+
+		pid, err := p.shim.start(*p, shimParams)
+		if err != nil {
+			return err
+		}
+
+		p.containers[idx].process = Process{
+			Token: proxyInfos[idx].Token,
+			Pid:   pid,
+		}
+
+		if err := p.containers[idx].storeProcess(); err != nil {
+			return err
+		}
+	}
+
+	virtLog.Infof("Shim(s) started")
 
 	return nil
 }
@@ -620,19 +662,20 @@ func (p *Pod) startVM() error {
 // start starts a pod. The containers that are making the pod
 // will be started.
 func (p *Pod) start() error {
-	err := p.startCheckStates()
-	if err != nil {
+	if err := p.startCheckStates(); err != nil {
 		return err
 	}
 
-	err = p.agent.startPod(*p)
-	if err != nil {
-		p.stop()
+	if _, _, err := p.proxy.connect(*p, false); err != nil {
+		return err
+	}
+	defer p.proxy.disconnect()
+
+	if err := p.agent.startPod(*p); err != nil {
 		return err
 	}
 
-	err = p.startSetStates()
-	if err != nil {
+	if err := p.startSetStates(); err != nil {
 		return err
 	}
 
@@ -672,13 +715,19 @@ func (p *Pod) stopSetStates() error {
 
 // stopVM stops the agent inside the VM and shut down the VM itself.
 func (p *Pod) stopVM() error {
-	err := p.agent.stop(*p)
-	if err != nil {
+	if _, _, err := p.proxy.connect(*p, false); err != nil {
 		return err
 	}
 
-	err = p.hypervisor.stopPod()
-	if err != nil {
+	if err := p.proxy.unregister(*p); err != nil {
+		return err
+	}
+
+	if err := p.proxy.disconnect(); err != nil {
+		return err
+	}
+
+	if err := p.hypervisor.stopPod(); err != nil {
 		return err
 	}
 
@@ -688,18 +737,20 @@ func (p *Pod) stopVM() error {
 // stop stops a pod. The containers that are making the pod
 // will be destroyed.
 func (p *Pod) stop() error {
-	err := p.stopCheckStates()
-	if err != nil {
+	if err := p.stopCheckStates(); err != nil {
 		return err
 	}
 
-	err = p.agent.stopPod(*p)
-	if err != nil {
+	if _, _, err := p.proxy.connect(*p, false); err != nil {
+		return err
+	}
+	defer p.proxy.disconnect()
+
+	if err := p.agent.stopPod(*p); err != nil {
 		return err
 	}
 
-	err = p.stopSetStates()
-	if err != nil {
+	if err := p.stopSetStates(); err != nil {
 		return err
 	}
 
@@ -732,7 +783,7 @@ func (p *Pod) endSession() error {
 
 func (p *Pod) setContainerState(containerID string, state stateString) error {
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	contState := State{
@@ -749,7 +800,7 @@ func (p *Pod) setContainerState(containerID string, state stateString) error {
 
 func (p *Pod) setContainersState(state stateString) error {
 	if state == "" {
-		return ErrNeedState
+		return errNeedState
 	}
 
 	for _, container := range p.config.Containers {
@@ -764,7 +815,7 @@ func (p *Pod) setContainersState(state stateString) error {
 
 func (p *Pod) deleteContainerState(containerID string) error {
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	err := p.storage.deleteContainerResources(p.id, containerID, []podResource{stateFileType})
@@ -788,7 +839,7 @@ func (p *Pod) deleteContainersState() error {
 
 func (p *Pod) checkContainerState(containerID string, expectedState stateString) error {
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	if expectedState == "" {
@@ -809,7 +860,7 @@ func (p *Pod) checkContainerState(containerID string, expectedState stateString)
 
 func (p *Pod) checkContainersState(state stateString) error {
 	if state == "" {
-		return ErrNeedState
+		return errNeedState
 	}
 
 	for _, container := range p.config.Containers {

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -259,31 +259,6 @@ func (q *qemu) appendConsoles(devices []ciaoQemu.Device, podConfig PodConfig) []
 
 	devices = append(devices, console)
 
-	for i, c := range podConfig.Containers {
-		// Need to add an offset of 1 because of the console created for the pod.
-		idx := i + 1
-
-		if c.Interactive == false || c.Console == "" {
-			console = ciaoQemu.CharDevice{
-				Driver:   ciaoQemu.Console,
-				Backend:  ciaoQemu.Socket,
-				DeviceID: fmt.Sprintf("console%d", idx),
-				ID:       fmt.Sprintf("charconsole%d", idx),
-				Path:     fmt.Sprintf("%s/%s/%s/%s", runStoragePath, podConfig.ID, c.ID, defaultConsole),
-			}
-		} else {
-			console = ciaoQemu.CharDevice{
-				Driver:   ciaoQemu.Console,
-				Backend:  ciaoQemu.Serial,
-				DeviceID: fmt.Sprintf("console%d", idx),
-				ID:       fmt.Sprintf("charconsole%d", idx),
-				Path:     c.Console,
-			}
-		}
-
-		devices = append(devices, console)
-	}
-
 	return devices
 }
 

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -244,9 +244,6 @@ func TestQemuAppendFSDevices(t *testing.T) {
 
 func TestQemuAppendConsoles(t *testing.T) {
 	podID := "testPodID"
-	cID1 := "100"
-	cID2 := "200"
-	contConsolePath := "testContConsolePath"
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.SerialDevice{
@@ -260,38 +257,11 @@ func TestQemuAppendConsoles(t *testing.T) {
 			ID:       "charconsole0",
 			Path:     filepath.Join(runStoragePath, podID, defaultConsole),
 		},
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.Console,
-			Backend:  ciaoQemu.Serial,
-			DeviceID: "console1",
-			ID:       "charconsole1",
-			Path:     contConsolePath,
-		},
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.Console,
-			Backend:  ciaoQemu.Socket,
-			DeviceID: "console2",
-			ID:       "charconsole2",
-			Path:     fmt.Sprintf("%s/%s/%s/%s", runStoragePath, podID, cID2, defaultConsole),
-		},
-	}
-
-	containers := []ContainerConfig{
-		{
-			ID:          cID1,
-			Interactive: true,
-			Console:     contConsolePath,
-		},
-		{
-			ID:          cID2,
-			Interactive: false,
-			Console:     "",
-		},
 	}
 
 	podConfig := PodConfig{
 		ID:         podID,
-		Containers: containers,
+		Containers: []ContainerConfig{},
 	}
 
 	testQemuAppend(t, podConfig, expectedOut, consoleDev)

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -52,7 +52,7 @@ func (c SshdConfig) validate() bool {
 
 func publicKeyAuth(file string) (ssh.AuthMethod, error) {
 	if file == "" {
-		return nil, ErrNeedFile
+		return nil, errNeedFile
 	}
 
 	privateBytes, err := ioutil.ReadFile(file)
@@ -87,7 +87,7 @@ func execCmd(session *ssh.Session, cmd string) error {
 // init is the agent initialization implementation for sshd.
 func (s *sshd) init(pod *Pod, config interface{}) error {
 	if pod == nil {
-		return ErrNeedPod
+		return errNeedPod
 	}
 
 	if config == nil {
@@ -105,12 +105,32 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// start is the agent starting implementation for sshd.
-func (s *sshd) start(pod *Pod) error {
+// exec is the agent command execution implementation for sshd.
+func (s *sshd) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	if pod == nil {
-		return ErrNeedPod
+		return errNeedPod
 	}
 
+	session, err := s.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("Failed to create session")
+	}
+	defer session.Close()
+
+	if s.spawner != nil {
+		cmd.Args, err = s.spawner.formatArgs(cmd.Args)
+		if err != nil {
+			return err
+		}
+	}
+
+	strCmd := strings.Join(cmd.Args, " ")
+
+	return execCmd(session, strCmd)
+}
+
+// startPod is the agent Pod starting implementation for sshd.
+func (s *sshd) startPod(pod Pod) error {
 	if s.client != nil {
 		session, err := s.client.NewSession()
 		if err == nil {
@@ -146,40 +166,6 @@ func (s *sshd) start(pod *Pod) error {
 		return fmt.Errorf("Failed to dial: %s", err)
 	}
 
-	return nil
-}
-
-// stop is the agent stopping implementation for sshd.
-func (s *sshd) stop(pod Pod) error {
-	return nil
-}
-
-// exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
-	if pod == nil {
-		return nil, ErrNeedPod
-	}
-
-	session, err := s.client.NewSession()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to create session")
-	}
-	defer session.Close()
-
-	if s.spawner != nil {
-		cmd.Args, err = s.spawner.formatArgs(cmd.Args)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	strCmd := strings.Join(cmd.Args, " ")
-
-	return nil, execCmd(session, strCmd)
-}
-
-// startPod is the agent Pod starting implementation for sshd.
-func (s *sshd) startPod(pod Pod) error {
 	return nil
 }
 


### PR DESCRIPTION
Instead of using the console related to the container, a new process run on an existing container can have its own console.