### PR TITLE
help: Remove references to "runc" in usage.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -49,7 +49,7 @@ EXAMPLE:
    If the container is configured to run the linux ps command the following
    will output a list of processes running in the container:
 
-       # runc exec <container-id> ps`,
+       # ` + name + ` <container-id> ps`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "console",

--- a/kill.go
+++ b/kill.go
@@ -35,7 +35,7 @@ EXAMPLE:
    If the container id is "ubuntu01" the following will send a "KILL" signal
    to the init process of the "ubuntu01" container:
 	 
-       # runc kill ubuntu01 KILL`,
+       # ` + name + ` kill ubuntu01 KILL`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",


### PR DESCRIPTION
The "exec" and "kill" sub-commands both erroneously referenced "runc".

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>