### PR TITLE
exec: Unmarshal to a specs.Process pointer

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -137,7 +137,7 @@ func generateExecParams(context *cli.Context) (execParams, error) {
 			return execParams{}, err
 		}
 
-		if err := json.Unmarshal(fileContent, ociProcess); err != nil {
+		if err := json.Unmarshal(fileContent, &ociProcess); err != nil {
 			return execParams{}, err
 		}
 


### PR DESCRIPTION
The unmarshalling was failing because we were not passing a pointer to a specs.Process structure.
With this patch, the exec command works as expected.