### PR TITLE
ci: Fix coverage report with travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 - sudo env "PATH=$PATH" make check
 
 after_success:
-- go get github.com/mattn/goveralls
+- sudo env "PATH=$PATH" go get github.com/mattn/goveralls
 - "$GOPATH/bin/goveralls -service=travis-ci -coverprofile=profile.cov"
 
 notifications:


### PR DESCRIPTION
Because some permissions were missing, goveralls binary was not installed and we lost the coverage report.