### PR TITLE
runtime: Replace "clearcontainers" with "clear-containers" naming

### DIFF
--- a/.ci/install_virtcontainers.sh
+++ b/.ci/install_virtcontainers.sh
@@ -25,7 +25,7 @@ pause_bin_name="pause"
 echo -e "Build ${pause_bin_name} binary"
 make ${pause_bin_name}
 
-pause_bin_path="/var/lib/clearcontainers/runtime/bundles/pause_bundle/bin"
+pause_bin_path="/var/lib/clear-containers/runtime/bundles/pause_bundle/bin"
 echo -e "Create ${pause_bin_path}"
 sudo mkdir -p ${pause_bin_path}
 

--- a/.ci/upstart-services/cc-proxy.conf
+++ b/.ci/upstart-services/cc-proxy.conf
@@ -6,4 +6,4 @@ start on runlevel [2345]
 # stop on shutdown/halt, single-user mode and reboot
 stop on runlevel [016]
 
-exec /usr/libexec/clearcontainers/cc-proxy -v 3
+exec /usr/libexec/clear-containers/cc-proxy -v 3

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ const (
 	defaultImagePath            = "/usr/share/clear-containers/clear-containers.img"
 	defaultHypervisorPath       = "/usr/bin/qemu-lite-system-x86_64"
 	defaultProxyURL             = "unix:///run/cc-oci-runtime/proxy.sock"
-	defaultPauseRootPath        = "/var/lib/clearcontainers/runtime/bundles/pause_bundle"
+	defaultPauseRootPath        = "/var/lib/clear-containers/runtime/bundles/pause_bundle"
 	pauseBinRelativePath        = "bin/pause"
 )
 

--- a/config/configuration.toml
+++ b/config/configuration.toml
@@ -4,14 +4,14 @@ kernel = "/usr/share/clear-containers/vmlinux.container"
 image = "/usr/share/clear-containers/clear-containers.img"
 
 [proxy.cc]
-url = "unix:///var/run/clearcontainers/proxy.sock"
+url = "unix:///var/run/clear-containers/proxy.sock"
 
 [shim.cc]
 path = "/usr/libexec/cc-shim"
 
 [agent.hyperstart]
-pause_root_path = "/var/lib/clearcontainers/runtime/bundles/pause_bundle"
+pause_root_path = "/var/lib/clear-containers/runtime/bundles/pause_bundle"
 
 ## Uncomment to enable the global logging to the default path.
 #[runtime]
-#global_log_path = "/var/lib/clearcontainers/runtime/runtime.log"
+#global_log_path = "/var/lib/clear-containers/runtime/runtime.log"

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "root",
-			Value: "/run/clearcontainers",
+			Value: "/run/clear-containers",
 			Usage: "root directory for storage of container state (this should be located in tmpfs)",
 		},
 	}


### PR DESCRIPTION
It has been decided that clear-containers will be cleaner and because we want to be consistent accross all projects, let's replace the name "clearcontainers" with "clear-containers".