### PR TITLE
config: Change the configuration for shim path.

### DIFF
--- a/config/configuration.toml
+++ b/config/configuration.toml
@@ -7,7 +7,7 @@ image = "/usr/share/clear-containers/clear-containers.img"
 url = "unix:///var/run/clear-containers/proxy.sock"
 
 [shim.cc]
-path = "/usr/libexec/cc-shim"
+path = "/usr/libexec/clear-containers/cc-shim"
 
 [agent.hyperstart]
 pause_root_path = "/var/lib/clear-containers/runtime/bundles/pause_bundle"


### PR DESCRIPTION
The shim installation path is changed to
/usr/libexec/clear-containers. Change the config to reflect this.

Fixes #112

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>