### PR TITLE
runtime: Remove Docker,Inc copyrights

### DIFF
--- a/create.go
+++ b/create.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/delete.go
+++ b/delete.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/exec.go
+++ b/exec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/kill.go
+++ b/kill.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/start.go
+++ b/start.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/state.go
+++ b/state.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014,2015,2016 Docker, Inc.
+//
 // Copyright (c) 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
There is no Docker copyrighted code in our runtime, it was just a
copy/paste leftover.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>