### PR TITLE
cli: Allow partial container IDs.

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -62,9 +62,12 @@ EXAMPLE:
 
 func delete(containerID string, force bool) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	if err := validContainer(containerID); err != nil {
+	fullID, err := expandContainerID(containerID)
+	if err != nil {
 		return err
 	}
+
+	containerID = fullID
 
 	if force == false {
 		podStatus, err := vc.StatusPod(containerID)

--- a/exec.go
+++ b/exec.go
@@ -160,9 +160,12 @@ func generateExecParams(context *cli.Context) (execParams, error) {
 }
 
 func execute(params execParams) error {
-	if err := validContainer(params.cID); err != nil {
+	fullID, err := expandContainerID(params.cID)
+	if err != nil {
 		return err
 	}
+
+	params.cID = fullID
 
 	podStatus, err := vc.StatusPod(params.cID)
 	if err != nil {

--- a/kill.go
+++ b/kill.go
@@ -99,9 +99,12 @@ var signals = map[string]syscall.Signal{
 
 func kill(containerID, signal string, all bool) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	if err := validContainer(containerID); err != nil {
+	fullID, err := expandContainerID(containerID)
+	if err != nil {
 		return err
 	}
+
+	containerID = fullID
 
 	podStatus, err := vc.StatusPod(containerID)
 	if err != nil {

--- a/oci_test.go
+++ b/oci_test.go
@@ -26,9 +26,14 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func TestContainerExistsContainerIDEmptyFailure(t *testing.T) {
-	if _, err := containerExists(""); err == nil {
+func TestGetContainerIDByPrefixContainerIDEmptyFailure(t *testing.T) {
+	fullID, err := getContainerIDByPrefix("")
+	if err == nil {
 		t.Fatalf("This test should fail because containerID is empty")
+	}
+
+	if fullID != "" {
+		t.Fatalf("Expected blank fullID, but got %v", fullID)
 	}
 }
 
@@ -38,9 +43,15 @@ func TestValidCreateParamsContainerIDEmptyFailure(t *testing.T) {
 	}
 }
 
-func TestValidContainerContainerIDEmptyFailure(t *testing.T) {
-	if err := validContainer(""); err == nil {
+func TestExpandContainerID(t *testing.T) {
+	fullID, err := expandContainerID("")
+
+	if err == nil {
 		t.Fatalf("This test should fail because containerID is empty")
+	}
+
+	if fullID != "" {
+		t.Fatalf("Expected blank fullID, but got %v", fullID)
 	}
 }
 

--- a/start.go
+++ b/start.go
@@ -49,9 +49,12 @@ var startCommand = cli.Command{
 
 func start(containerID string) (*vc.Pod, error) {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	if err := validContainer(containerID); err != nil {
+	fullID, err := expandContainerID(containerID)
+	if err != nil {
 		return nil, err
 	}
+
+	containerID = fullID
 
 	pod, err := vc.StartPod(containerID)
 	if err != nil {

--- a/state.go
+++ b/state.go
@@ -45,9 +45,12 @@ instance of a container.`,
 
 func state(containerID string) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	if err := validContainer(containerID); err != nil {
+	fullID, err := expandContainerID(containerID)
+	if err != nil {
 		return err
 	}
+
+	containerID = fullID
 
 	podStatus, err := vc.StatusPod(containerID)
 	if err != nil {


### PR DESCRIPTION
Support the specification of partial container IDs. Now, the runtime
will expand a partial container ID as long as The container ID specified:

- is a valid container ID prefix.
- expands to a unique matching container ID.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>