### PR TITLE
cli: Do not load config file when displaying help.

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,13 @@ func main() {
 	}
 
 	app.Before = func(context *cli.Context) error {
+		if context.NArg() == 0 ||
+			(context.NArg() == 1 && context.Args()[0] == "help") {
+			// No setup required if the user just
+			// wants to see the usage statement.
+			return nil
+		}
+
 		if context.GlobalBool("debug") {
 			ccLog.Level = logrus.DebugLevel
 		}
@@ -106,6 +113,7 @@ func main() {
 			}
 			ccLog.Out = f
 		}
+
 		switch context.GlobalString("log-format") {
 		case "text":
 			// retain logrus's default.


### PR DESCRIPTION
Avoid attempting to load the configuration file when the help text
is displayed (when no arguments are specified or when the command is
specified as "help").

Previously, an error would be generated if the system either didn't
have a config file or it was not readable.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>