### PR TITLE
ci: Fix cc-proxy upstart service

### DIFF
--- a/.ci/upstart-services/cc-proxy.conf
+++ b/.ci/upstart-services/cc-proxy.conf
@@ -6,4 +6,4 @@ start on runlevel [2345]
 # stop on shutdown/halt, single-user mode and reboot
 stop on runlevel [016]
 
-exec /usr/libexec/clear-containers/cc-proxy -v 3
+exec /usr/libexec/clear-containers/cc-proxy --log debug


### PR DESCRIPTION
According to latest proxy changes, we cannot use glog flags anymore. Instead we have to call "./cc-proxy --log debug" if we want all debug traces to be provided by the proxy.