### PR TITLE
vendor: Update virtcontainers and runtime-spec vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "6b6f8c92eb25679cb8eecb13295a814efaf2a83e6c7a53f7e75abe697d7ddeba"
+memo = "74a8fb8b08f1a7d34a0abacc99cd4bc4a17e3b39c415b06a932492b5cab979ec"
 
 [[projects]]
   branch = "master"
@@ -33,7 +33,7 @@ memo = "6b6f8c92eb25679cb8eecb13295a814efaf2a83e6c7a53f7e75abe697d7ddeba"
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "82d8279d2fd045c71def1f4a89182ff9c8d844a8"
+  revision = "bcd26936f5051d80384e71682620c8247a18d5bd"
 
 [[projects]]
   branch = "master"
@@ -44,7 +44,8 @@ memo = "6b6f8c92eb25679cb8eecb13295a814efaf2a83e6c7a53f7e75abe697d7ddeba"
 [[projects]]
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
-  revision = "a5c4e91dae9533c46a98f122b5085c0b3fe27ee4"
+  revision = "035da1dca3dfbb00d752eb58b0b158d6129f3776"
+  version = "v1.0.0-rc5"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@
 
 [[dependencies]]
   name = "github.com/opencontainers/runtime-spec"
-  revision = "a5c4e91dae9533c46a98f122b5085c0b3fe27ee4"
+  version = "v1.0.0-rc5"
 
 [[dependencies]]
   branch = "master"

--- a/create.go
+++ b/create.go
@@ -23,7 +23,6 @@ import (
 
 	vc "github.com/containers/virtcontainers"
 	"github.com/containers/virtcontainers/pkg/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
 
@@ -123,10 +122,10 @@ func create(containerID, bundlePath, console, pidFilePath string,
 	return nil
 }
 
-func getConfigs(bundlePath, containerID, console string, runtimeConfig oci.RuntimeConfig) (vc.PodConfig, specs.Spec, error) {
+func getConfigs(bundlePath, containerID, console string, runtimeConfig oci.RuntimeConfig) (vc.PodConfig, oci.CompatOCISpec, error) {
 	podConfig, ociSpec, err := oci.PodConfig(runtimeConfig, bundlePath, containerID, console)
 	if err != nil {
-		return vc.PodConfig{}, specs.Spec{}, err
+		return vc.PodConfig{}, oci.CompatOCISpec{}, err
 	}
 
 	return *podConfig, *ociSpec, nil

--- a/oci.go
+++ b/oci.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	vc "github.com/containers/virtcontainers"
+	"github.com/containers/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -165,7 +166,7 @@ func stopContainer(podStatus vc.PodStatus) error {
 // processCgroupsPath process the cgroups path as expected from the
 // OCI runtime specification. It returns a list of complete paths
 // that should be created and used for every specified resource.
-func processCgroupsPath(ociSpec specs.Spec) ([]string, error) {
+func processCgroupsPath(ociSpec oci.CompatOCISpec) ([]string, error) {
 	var cgroupsPathList []string
 
 	if ociSpec.Linux.CgroupsPath == "" {
@@ -223,7 +224,7 @@ func processCgroupsPath(ociSpec specs.Spec) ([]string, error) {
 	return cgroupsPathList, nil
 }
 
-func processCgroupsPathForResource(ociSpec specs.Spec, resource string) (string, error) {
+func processCgroupsPathForResource(ociSpec oci.CompatOCISpec, resource string) (string, error) {
 	if resource == "" {
 		return "", errNeedLinuxResource
 	}

--- a/oci_test.go
+++ b/oci_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	vc "github.com/containers/virtcontainers"
+	"github.com/containers/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -93,7 +94,7 @@ func TestStopContainerTooManyContainerStatusesFailure(t *testing.T) {
 	}
 }
 
-func testProcessCgroupsPath(t *testing.T, ociSpec specs.Spec, expected []string) {
+func testProcessCgroupsPath(t *testing.T, ociSpec oci.CompatOCISpec, expected []string) {
 	result, err := processCgroupsPath(ociSpec)
 	if err != nil {
 		t.Fatal(err)
@@ -105,10 +106,10 @@ func testProcessCgroupsPath(t *testing.T, ociSpec specs.Spec, expected []string)
 }
 
 func TestProcessCgroupsPathEmptyPathSuccessful(t *testing.T) {
-	ociSpec := specs.Spec{
-		Linux: &specs.Linux{
-			CgroupsPath: "",
-		},
+	ociSpec := oci.CompatOCISpec{}
+
+	ociSpec.Linux = &specs.Linux{
+		CgroupsPath: "",
 	}
 
 	testProcessCgroupsPath(t, ociSpec, []string{})
@@ -118,13 +119,13 @@ func TestProcessCgroupsPathRelativePathSuccessful(t *testing.T) {
 	relativeCgroupsPath := "relative/cgroups/path"
 	cgroupsMemDirPath = "/foo/runtime/base"
 
-	ociSpec := specs.Spec{
-		Linux: &specs.Linux{
-			Resources: &specs.LinuxResources{
-				Memory: &specs.LinuxMemory{},
-			},
-			CgroupsPath: relativeCgroupsPath,
+	ociSpec := oci.CompatOCISpec{}
+
+	ociSpec.Linux = &specs.Linux{
+		Resources: &specs.LinuxResources{
+			Memory: &specs.LinuxMemory{},
 		},
+		CgroupsPath: relativeCgroupsPath,
 	}
 
 	testProcessCgroupsPath(t, ociSpec, []string{filepath.Join(cgroupsMemDirPath, "memory", relativeCgroupsPath)})
@@ -133,13 +134,13 @@ func TestProcessCgroupsPathRelativePathSuccessful(t *testing.T) {
 func TestProcessCgroupsPathAbsoluteNoCgroupMountFailure(t *testing.T) {
 	absoluteCgroupsPath := "/absolute/cgroups/path"
 
-	ociSpec := specs.Spec{
-		Linux: &specs.Linux{
-			Resources: &specs.LinuxResources{
-				Memory: &specs.LinuxMemory{},
-			},
-			CgroupsPath: absoluteCgroupsPath,
+	ociSpec := oci.CompatOCISpec{}
+
+	ociSpec.Linux = &specs.Linux{
+		Resources: &specs.LinuxResources{
+			Memory: &specs.LinuxMemory{},
 		},
+		CgroupsPath: absoluteCgroupsPath,
 	}
 
 	_, err := processCgroupsPath(ociSpec)
@@ -151,17 +152,18 @@ func TestProcessCgroupsPathAbsoluteNoCgroupMountFailure(t *testing.T) {
 func TestProcessCgroupsPathAbsoluteNoCgroupMountDestinationFailure(t *testing.T) {
 	absoluteCgroupsPath := "/absolute/cgroups/path"
 
-	ociSpec := specs.Spec{
-		Linux: &specs.Linux{
-			Resources: &specs.LinuxResources{
-				Memory: &specs.LinuxMemory{},
-			},
-			CgroupsPath: absoluteCgroupsPath,
+	ociSpec := oci.CompatOCISpec{}
+
+	ociSpec.Linux = &specs.Linux{
+		Resources: &specs.LinuxResources{
+			Memory: &specs.LinuxMemory{},
 		},
-		Mounts: []specs.Mount{
-			{
-				Type: "cgroup",
-			},
+		CgroupsPath: absoluteCgroupsPath,
+	}
+
+	ociSpec.Mounts = []specs.Mount{
+		{
+			Type: "cgroup",
 		},
 	}
 
@@ -191,18 +193,19 @@ func TestProcessCgroupsPathAbsoluteSuccessful(t *testing.T) {
 	}
 	defer syscall.Unmount(resourceMountPath, 0)
 
-	ociSpec := specs.Spec{
-		Linux: &specs.Linux{
-			Resources: &specs.LinuxResources{
-				Memory: &specs.LinuxMemory{},
-			},
-			CgroupsPath: absoluteCgroupsPath,
+	ociSpec := oci.CompatOCISpec{}
+
+	ociSpec.Linux = &specs.Linux{
+		Resources: &specs.LinuxResources{
+			Memory: &specs.LinuxMemory{},
 		},
-		Mounts: []specs.Mount{
-			{
-				Type:        "cgroup",
-				Destination: cgroupMountDest,
-			},
+		CgroupsPath: absoluteCgroupsPath,
+	}
+
+	ociSpec.Mounts = []specs.Mount{
+		{
+			Type:        "cgroup",
+			Destination: cgroupMountDest,
 		},
 	}
 

--- a/vendor/github.com/containers/virtcontainers/.gitignore
+++ b/vendor/github.com/containers/virtcontainers/.gitignore
@@ -2,3 +2,6 @@
 *.o
 /hack/virtc/virtc
 /pause/pause
+/hook/mock/hook
+/shim/mock/shim
+profile.cov

--- a/vendor/github.com/containers/virtcontainers/.travis.yml
+++ b/vendor/github.com/containers/virtcontainers/.travis.yml
@@ -12,37 +12,18 @@ env:
 services:
 - docker
 
-before_install:
-- go get github.com/mattn/goveralls
-- go get golang.org/x/tools/cmd/cover
-- go get github.com/pierrre/gotestcover
-- go get github.com/fzipp/gocyclo
-- go get github.com/gordonklaus/ineffassign
-- go get github.com/golang/lint/golint
-- go get github.com/client9/misspell/cmd/misspell
-- go get github.com/01org/ciao/test-cases
-- go get github.com/opencontainers/runc/libcontainer/configs
-
 install:
-- sudo env "PATH=$PATH" bash $GOPATH/src/github.com/containers/virtcontainers/ci/ci-setup.sh
-- go_packages=$(go list ./... | grep -v vendor)
-- go_files=`go list -f '{{.Dir}}/*.go' $go_packages`
-- go get -t -v $go_packages
+- go env
+- sudo env "PATH=$PATH" bash $GOPATH/src/github.com/containers/virtcontainers/utils/virtcontainers-setup.sh
+- make
+- sudo make install
 
 script:
-- go env
-- misspell -error $go_packages
-- go vet $go_packages
-- if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then golint $go_packages; fi
-- gocyclo -over 15 $go_files
-- go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
-- gofmt -s -l $go_files | wc -l | xargs -I % bash -c "test % -eq 0"
-- make
-- export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin:/tmp/cni/bin $GOPATH/bin/test-cases
-  -v -timeout 9 -short -coverprofile /tmp/cover.out $go_packages
+- make check
 
 after_success:
-- "$GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out"
+- go get github.com/mattn/goveralls
+- "$GOPATH/bin/goveralls -service=travis-ci -coverprofile=profile.cov"
 
 notifications:
   slack:

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -1,16 +1,16 @@
-memo = "c198a36088d02f37969285b50b8e1c2f5e8b35ec380dbf1f0eed16f39d6202c0"
+memo = "917f44d6975d69f6054c2dffad960b595e8c0071442c56c5a1bc892f34909b92"
 
 [[projects]]
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "a16660bbedd1aa3479b38a7b05b5812f7ece8114"
+  revision = "e4f8a4073f364a86b532365ccb8f548ce31c58e2"
 
 [[projects]]
   branch = "master"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
-  revision = "10f801ebc38b33738c9d17d50860f484a0988ff5"
+  revision = "5e5dc898656f695e2a086b8e12559febbfc01562"
 
 [[projects]]
   name = "github.com/clearcontainers/proxy"
@@ -21,7 +21,7 @@ memo = "c198a36088d02f37969285b50b8e1c2f5e8b35ec380dbf1f0eed16f39d6202c0"
   branch = "master"
   name = "github.com/containernetworking/cni"
   packages = ["libcni","pkg/invoke","pkg/ns","pkg/types","pkg/types/020","pkg/types/current","pkg/version"]
-  revision = "231f6c4c5346c8cc56190bd46d4fa8a103b21d4b"
+  revision = "8ea1605c26c50928e5fce74c2432d24c95ebd82c"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -43,7 +43,8 @@ memo = "c198a36088d02f37969285b50b8e1c2f5e8b35ec380dbf1f0eed16f39d6202c0"
 [[projects]]
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
-  revision = "a5c4e91dae9533c46a98f122b5085c0b3fe27ee4"
+  revision = "035da1dca3dfbb00d752eb58b0b158d6129f3776"
+  version = "v1.0.0-rc5"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -61,13 +62,13 @@ memo = "c198a36088d02f37969285b50b8e1c2f5e8b35ec380dbf1f0eed16f39d6202c0"
   branch = "master"
   name = "github.com/urfave/cli"
   packages = ["."]
-  revision = "ab403a54a148f2d857920810291539e1f817ee7b"
+  revision = "d70f47eeca3afd795160003bc6e28b001d60c67c"
 
 [[projects]]
   branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "1e045880fbc2f6703d3c771db56cfb0351208637"
+  revision = "0872fbf3015e21e760f71debd11379a9daf7abcc"
 
 [[projects]]
   branch = "master"
@@ -79,10 +80,10 @@ memo = "c198a36088d02f37969285b50b8e1c2f5e8b35ec380dbf1f0eed16f39d6202c0"
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh"]
-  revision = "8e03fc1ab6a36bdb9e7dee75a213c30f0249d0c1"
+  revision = "0fe963104e9d1877082f8fb38f816fcd97eb1d10"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "9ccfe848b9db8435a24c424abbc07a921adf1df5"
+  revision = "98b5b1e7e80eb60271c8dc4eba6521ec2c3e811e"

--- a/vendor/github.com/containers/virtcontainers/Gopkg.toml
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.toml
@@ -25,7 +25,7 @@
 
 [[dependencies]]
   name = "github.com/opencontainers/runtime-spec"
-  revision = "a5c4e91dae9533c46a98f122b5085c0b3fe27ee4"
+  version = "v1.0.0-rc5"
 
 [[dependencies]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/Makefile
+++ b/vendor/github.com/containers/virtcontainers/Makefile
@@ -1,25 +1,120 @@
-all: binaries
-	go build $(go list ./... | grep -v /vendor/)
-	cd hack/virtc && go build
+PREFIX := /usr
+BIN_DIR := $(PREFIX)/bin
+VC_BIN_DIR := $(BIN_DIR)/virtcontainers/bin
+TEST_BIN_DIR := $(VC_BIN_DIR)/test
+VIRTC_DIR := hack/virtc
+VIRTC_BIN := virtc
+PAUSE_DIR := pause
+PAUSE_BIN := pause
+HOOK_DIR := hook/mock
+HOOK_BIN := hook
+SHIM_DIR := shim/mock
+SHIM_BIN := shim
+
+#
+# Pretty printing
+#
+
+V	      = @
+Q	      = $(V:1=)
+QUIET_GOBUILD = $(Q:@=@echo    '     GOBUILD  '$@;)
+
+#
+# Build
+#
+
+all: build binaries
+
+build:
+	$(QUIET_GOBUILD)go build $(go list ./... | grep -v /vendor/)
+
+virtc:
+	$(QUIET_GOBUILD)go build -o $(VIRTC_DIR)/$@ $(VIRTC_DIR)/*.go
 
 pause:
 	make -C $@
 
-binaries: pause
+hook:
+	$(QUIET_GOBUILD)go build -o $(HOOK_DIR)/$@ $(HOOK_DIR)/*.go
 
-clean:
-	make -C pause clean
-	rm -f hack/virtc/virtc
+shim:
+	$(QUIET_GOBUILD)go build -o $(SHIM_DIR)/$@ $(SHIM_DIR)/*.go
+
+binaries: virtc pause hook shim
+
+#
+# Tests
+#
+
+check: check-go-static check-go-test
+
+check-go-static:
+	.ci/go-lint.sh
+
+check-go-test:
+	.ci/go-test.sh \
+		$(TEST_BIN_DIR)/$(SHIM_BIN) \
+		$(TEST_BIN_DIR)/$(HOOK_BIN)
+
+#
+# Install
+#
+
+define INSTALL_EXEC
+	install -D $1 $(VC_BIN_DIR)/ || exit 1;
+endef
+
+define INSTALL_TEST_EXEC
+	install -D $1 $(TEST_BIN_DIR)/ || exit 1;
+endef
 
 install:
-	install -D -m 755 pause/pause /usr/bin/pause
+	@mkdir -p $(VC_BIN_DIR)
+	$(call INSTALL_EXEC,$(VIRTC_DIR)/$(VIRTC_BIN))
+	$(call INSTALL_EXEC,$(PAUSE_DIR)/$(PAUSE_BIN))
+	@mkdir -p $(TEST_BIN_DIR)
+	$(call INSTALL_TEST_EXEC,$(HOOK_DIR)/$(HOOK_BIN))
+	$(call INSTALL_TEST_EXEC,$(SHIM_DIR)/$(SHIM_BIN))
+
+#
+# Uninstall
+#
+
+define UNINSTALL_EXEC
+	rm -f $(VC_BIN_DIR)/$1 || exit 1;
+endef
+
+define UNINSTALL_TEST_EXEC
+	rm -f $(TEST_BIN_DIR)/$1 || exit 1;
+endef
 
 uninstall:
-	rm -f /usr/bin/pause
+	$(call UNINSTALL_EXEC,$(VIRTC_BIN))
+	$(call UNINSTALL_EXEC,$(PAUSE_BIN))
+	$(call UNINSTALL_TEST_EXEC,$(HOOK_BIN))
+	$(call UNINSTALL_TEST_EXEC,$(SHIM_BIN))
+
+#
+# Clean
+#
+
+clean:
+	rm -f $(VIRTC_DIR)/$(VIRTC_BIN)
+	make -C $(PAUSE_BIN) clean
+	rm -f $(HOOK_DIR)/$(HOOK_BIN)
+	rm -f $(SHIM_DIR)/$(SHIM_BIN)
 
 .PHONY: \
-	binaries \
-	clean \
-	install \
+	all \
+	build \
+	virtc \
 	pause \
-	uninstall
+	hook \
+	shim \
+	binaries \
+	check \
+	check-go-static \
+	check-go-test \
+	install \
+	uninstall \
+	clean

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -201,7 +201,7 @@ func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 	hooks := Hooks{
 		PreStartHooks: []Hook{
 			{
-				Path: testBinHookPath,
+				Path: getMockHookBinPath(),
 				Args: []string{testKeyHook, testContainerIDHook, testControllerIDHook},
 			},
 		},

--- a/vendor/github.com/containers/virtcontainers/cc_shim.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 type ccShim struct{}
@@ -75,6 +76,15 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		cmd.Stdin = f
 		cmd.Stdout = f
 		cmd.Stderr = f
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			// Create Session
+			Setsid: true,
+
+			// Set Controlling terminal to Ctty
+			Setctty: true,
+			Ctty:    int(f.Fd()),
+		}
+
 	}
 	defer func() {
 		if f != nil {

--- a/vendor/github.com/containers/virtcontainers/cc_shim_test.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim_test.go
@@ -17,15 +17,27 @@
 package virtcontainers
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
+	"syscall"
 	"testing"
+	"unsafe"
+
+	. "github.com/containers/virtcontainers/pkg/mock"
 )
 
-var testShimPath = "/tmp/bin/cc-shim-mock"
+var testShimPath = "/usr/bin/virtcontainers/bin/test/shim"
 var testProxyURL = "foo:///foo/clear-containers/proxy.sock"
 var testWrongConsolePath = "/foo/wrong-console"
 var testConsolePath = "tty-console"
+
+func getMockCCShimBinPath() string {
+	if DefaultMockCCShimBinPath == "" {
+		return testShimPath
+	}
+
+	return DefaultMockCCShimBinPath
+}
 
 func testCCShimStart(t *testing.T, pod Pod, params ShimParams, expectFail bool) {
 	s := &ccShim{}
@@ -77,7 +89,7 @@ func TestCCShimStartParamsTokenEmptyFailure(t *testing.T) {
 		config: &PodConfig{
 			ShimType: CCShimType,
 			ShimConfig: CCShimConfig{
-				Path: testShimPath,
+				Path: getMockCCShimBinPath(),
 			},
 		},
 	}
@@ -90,7 +102,7 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 		config: &PodConfig{
 			ShimType: CCShimType,
 			ShimConfig: CCShimConfig{
-				Path: testShimPath,
+				Path: getMockCCShimBinPath(),
 			},
 		},
 	}
@@ -107,7 +119,7 @@ func TestCCShimStartSuccessful(t *testing.T) {
 		config: &PodConfig{
 			ShimType: CCShimType,
 			ShimConfig: CCShimConfig{
-				Path: testShimPath,
+				Path: getMockCCShimBinPath(),
 			},
 		},
 	}
@@ -125,7 +137,7 @@ func TestCCShimStartWithConsoleNonExistingFailure(t *testing.T) {
 		config: &PodConfig{
 			ShimType: CCShimType,
 			ShimConfig: CCShimConfig{
-				Path: testShimPath,
+				Path: getMockCCShimBinPath(),
 			},
 		},
 	}
@@ -139,21 +151,69 @@ func TestCCShimStartWithConsoleNonExistingFailure(t *testing.T) {
 	testCCShimStart(t, pod, params, true)
 }
 
+func ioctl(fd uintptr, flag, data uintptr) error {
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, flag, data); err != 0 {
+		return err
+	}
+
+	return nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+func unlockpt(f *os.File) error {
+	var u int32
+
+	return ioctl(f.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+}
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	var n int32
+
+	if err := ioctl(f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}
+
+func newConsole() (*os.File, string, error) {
+	master, err := os.OpenFile("/dev/ptmx", syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, "", err
+	}
+
+	console, err := ptsname(master)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err := unlockpt(master); err != nil {
+		return nil, "", err
+	}
+
+	if err := os.Chmod(console, 0600); err != nil {
+		return nil, "", err
+	}
+
+	return master, console, nil
+}
+
 func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 	cleanUp()
 
-	consolePath := filepath.Join(testDir, testConsolePath)
-	f, err := os.Create(consolePath)
+	master, console, err := newConsole()
+	t.Logf("Console created for tests:%s\n", console)
+
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
 
 	pod := Pod{
 		config: &PodConfig{
 			ShimType: CCShimType,
 			ShimConfig: CCShimConfig{
-				Path: testShimPath,
+				Path: getMockCCShimBinPath(),
 			},
 		},
 	}
@@ -161,8 +221,9 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 	params := ShimParams{
 		Token:   "testToken",
 		URL:     testProxyURL,
-		Console: consolePath,
+		Console: console,
 	}
 
 	testCCShimStart(t, pod, params, false)
+	master.Close()
 }

--- a/vendor/github.com/containers/virtcontainers/hook_test.go
+++ b/vendor/github.com/containers/virtcontainers/hook_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/containers/virtcontainers/pkg/mock"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -29,7 +30,15 @@ var testKeyHook = "test-key"
 var testContainerIDHook = "test-container-id"
 var testControllerIDHook = "test-controller-id"
 var testProcessIDHook = 12345
-var testBinHookPath = "/tmp/bin/hook"
+var testBinHookPath = "/usr/bin/virtcontainers/bin/test/hook"
+
+func getMockHookBinPath() string {
+	if DefaultMockHookBinPath == "" {
+		return testBinHookPath
+	}
+
+	return DefaultMockHookBinPath
+}
 
 func TestBuildHookState(t *testing.T) {
 	expected := specs.State{
@@ -45,7 +54,7 @@ func TestBuildHookState(t *testing.T) {
 
 func createHook(timeout int) *Hook {
 	return &Hook{
-		Path:    testBinHookPath,
+		Path:    getMockHookBinPath(),
 		Args:    []string{testKeyHook, testContainerIDHook, testControllerIDHook},
 		Env:     os.Environ(),
 		Timeout: timeout,
@@ -54,7 +63,7 @@ func createHook(timeout int) *Hook {
 
 func createWrongHook() *Hook {
 	return &Hook{
-		Path: testBinHookPath,
+		Path: getMockHookBinPath(),
 		Args: []string{"wrong-args"},
 		Env:  os.Environ(),
 	}

--- a/vendor/github.com/opencontainers/runtime-spec/README.md
+++ b/vendor/github.com/opencontainers/runtime-spec/README.md
@@ -1,6 +1,6 @@
 # Open Container Initiative Runtime Specification
 
-The [Open Container Initiative](http://www.opencontainers.org/) develops specifications for standards on Operating System process and application containers.
+The [Open Container Initiative][oci] develops specifications for standards on Operating System process and application containers.
 
 The specification can be found [here](spec.md).
 
@@ -8,7 +8,7 @@ The specification can be found [here](spec.md).
 
 Additional documentation about how this group operates:
 
-- [Code of Conduct](https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md)
+- [Code of Conduct][code-of-conduct]
 - [Style and Conventions](style.md)
 - [Roadmap](ROADMAP.md)
 - [Implementations](implementations.md)
@@ -61,13 +61,13 @@ When in doubt, start on the [mailing-list](#mailing-list).
 ### Weekly Call
 
 The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
-Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: 415-968-0849 (no PIN needed.)
+Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: 415-968-0849 (no PIN needed.)
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/runtime-spec/wiki) for those who are unable to join the call.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki][runtime-wiki].
 
 ### Mailing List
 
-You can subscribe and join the mailing list on [Google Groups](https://groups.google.com/a/opencontainers.org/forum/#!forum/dev).
+You can subscribe and join the mailing list on [Google Groups][dev-list].
 
 ### IRC
 
@@ -78,7 +78,7 @@ OCI discussion happens on #opencontainers on Freenode ([logs][irc-logs]).
 #### Sign your work
 
 The sign-off is a simple line at the end of the explanation for the patch, which certifies that you wrote it or otherwise have the right to pass it on as an open-source patch.
-The rules are pretty simple: if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
+The rules are pretty simple: if you can certify the below (from http://developercertificate.org):
 
 ```
 Developer Certificate of Origin
@@ -130,7 +130,7 @@ You can add the sign off when creating the git commit via `git commit -s`.
 #### Commit Style
 
 Simple house-keeping for clean git history.
-Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) or the Discussion section of [`git-commit(1)`](http://git-scm.com/docs/git-commit).
+Read more on [How to Write a Git Commit Message][how-to-git-commit] or the Discussion section of [git-commit(1)][git-commit.1].
 
 1. Separate the subject from body with a blank line
 2. Limit the subject line to 50 characters
@@ -142,6 +142,14 @@ Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git
   * If there was important/useful/essential conversation or information, copy or include a reference
 8. When possible, one keyword to scope the change in the subject (i.e. "README: ...", "runtime: ...")
 
-[UberConference]: https://www.uberconference.com/opencontainers
-[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+
 [charter]: https://www.opencontainers.org/about/governance
+[code-of-conduct]: https://github.com/opencontainers/tob/blob/master/code-of-conduct.md
+[dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
+[how-to-git-commit]: http://chris.beams.io/posts/git-commit
+[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[oci]: https://www.opencontainers.org
+[runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki
+[uberconference]: https://www.uberconference.com/opencontainers
+
+[git-commit.1]: http://git-scm.com/docs/git-commit

--- a/vendor/github.com/opencontainers/runtime-spec/ROADMAP.md
+++ b/vendor/github.com/opencontainers/runtime-spec/ROADMAP.md
@@ -6,7 +6,7 @@ The items in the 1.0 roadmap can be broken down into smaller milestones that are
 The topics below are broad and small working groups will be needed for each to define scope and requirements or if the feature is required at all for the OCI level.
 Topics listed in the roadmap do not mean that they will be implemented or added but are areas that need discussion to see if they fit in to the goals of the OCI.
 
-Listed topics may defer to the [project wiki](https://github.com/opencontainers/runtime-spec/wiki/RoadMap:) for collaboration.
+Listed topics may defer to the [project wiki][runtime-wiki] for collaboration.
 
 ## 1.0
 
@@ -32,9 +32,9 @@ Ensure that the base configuration format is viable for various platforms.
 
 Systems:
 
+* Linux
 * Solaris
 * Windows
-* Linux
 
 *Owner:* robdolinms as lead coordinator
 
@@ -45,3 +45,6 @@ Ensure that we have lifecycle hooks in the correct places with full coverage ove
 Will probably go away with Vish's work on splitting create and start, and if we have exec.
 
 *Owner:*
+
+
+[runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki/RoadMap

--- a/vendor/github.com/opencontainers/runtime-spec/bundle.md
+++ b/vendor/github.com/opencontainers/runtime-spec/bundle.md
@@ -3,7 +3,7 @@
 ## <a name="containerFormat" />Container Format
 
 This section defines a format for encoding a container as a *filesystem bundle* - a set of files organized in a certain way, and containing all the necessary data and metadata for any compliant runtime to perform all standard operations against it.
-See also [OS X application bundles](http://en.wikipedia.org/wiki/Bundle_%28OS_X%29) for a similar use of the term *bundle*.
+See also [MacOS application bundles][macos_bundle] for a similar use of the term *bundle*.
 
 The definition of a bundle is only concerned with how a container, and its configuration data, are stored on a local filesystem so that it can be consumed by a compliant runtime.
 
@@ -20,3 +20,5 @@ This directory MUST be referenced from within the `config.json` file.
 
 While these artifacts MUST all be present in a single directory on the local filesystem, that directory itself is not part of the bundle.
 In other words, a tar archive of a *bundle* will have these artifacts at the root of the archive, not nested within a top-level directory.
+
+[macos_bundle]: https://en.wikipedia.org/wiki/Bundle_%28macOS%29

--- a/vendor/github.com/opencontainers/runtime-spec/config-linux.md
+++ b/vendor/github.com/opencontainers/runtime-spec/config-linux.md
@@ -1,27 +1,27 @@
-# Linux-specific Container Configuration
+# <a name="linuxContainerConfiguration" />Linux Container Configuration
 
 This document describes the schema for the [Linux-specific section](config.md#platform-specific-configuration) of the [container configuration](config.md).
 The Linux container specification uses various kernel features like namespaces, cgroups, capabilities, LSM, and filesystem jails to fulfill the spec.
 
-## Default Filesystems
+## <a name="configLinuxDefaultFilesystems" />Default Filesystems
 
 The Linux ABI includes both syscalls and several special file paths.
 Applications expecting a Linux environment will very likely expect these file paths to be setup correctly.
 
 The following filesystems SHOULD be made available in each container's filesystem:
 
-|   Path   |  Type  |
+| Path     | Type   |
 | -------- | ------ |
-| /proc    | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)   |
-| /sys     | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)   |
-| /dev/pts | [devpts](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt) |
-| /dev/shm | [tmpfs](https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt)   |
+| /proc    | [procfs][procfs]   |
+| /sys     | [sysfs][sysfs]     |
+| /dev/pts | [devpts][devpts]   |
+| /dev/shm | [tmpfs][tmpfs]     |
 
-## Namespaces
+## <a name="configLinuxNamespaces" />Namespaces
 
 A namespace wraps a global system resource in an abstraction that makes it appear to the processes within the namespace that they have their own isolated instance of the global resource.
 Changes to the global resource are visible to other processes that are members of the namespace, but are invisible to other processes.
-For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html).
+For more information, see the [namespaces(7)][namespaces.7_2] man page.
 
 Namespaces are specified as an array of entries inside the `namespaces` root field.
 The following parameters can be specified to setup namespaces:
@@ -71,16 +71,16 @@ If a `namespaces` field contains duplicated namespaces with same `type`, the run
     ]
 ```
 
-## User namespace mappings
+## <a name="configLinuxUserNamespaceMappings" />User namespace mappings
 
 **`uidMappings`** (array of objects, OPTIONAL) describes the user namespace uid mappings from the host to the container.
 **`gidMappings`** (array of objects, OPTIONAL) describes the user namespace gid mappings from the host to the container.
 
 Each entry has the following structure:
 
-* **`hostID`** (uint32, REQUIRED)* - is the starting uid/gid on the host to be mapped to *containerID*.
-* **`containerID`** (uint32, REQUIRED)* - is the starting uid/gid in the container.
-* **`size`** (uint32, REQUIRED)* - is the number of ids to be mapped.
+* **`hostID`** *(uint32, REQUIRED)* - is the starting uid/gid on the host to be mapped to *containerID*.
+* **`containerID`** *(uint32, REQUIRED)* - is the starting uid/gid in the container.
+* **`size`** *(uint32, REQUIRED)* - is the number of ids to be mapped.
 
 The runtime SHOULD NOT modify the ownership of referenced filesystems to realize the mapping.
 Note that the number of mapping entries MAY be limited by the [kernel][user-namespaces].
@@ -104,7 +104,7 @@ Note that the number of mapping entries MAY be limited by the [kernel][user-name
     ]
 ```
 
-## Devices
+## <a name="configLinuxDevices" />Devices
 
 **`devices`** (array of objects, OPTIONAL) lists devices that MUST be available in the container.
 The runtime may supply them however it likes (with [mknod][mknod.2], by bind mounting from the runtime mount namespace, etc.).
@@ -115,7 +115,7 @@ Each entry has the following structure:
   More info in [mknod(1)][mknod.1].
 * **`path`** *(string, REQUIRED)* - full path to device inside container.
   If a [file][file.1] already exists at `path` that does not match the requested device, the runtime MUST generate an error.
-* **`major, minor`** *(int64, REQUIRED unless **`type`** is `p`)* - [major, minor numbers][devices] for the device.
+* **`major, minor`** *(int64, REQUIRED unless `type` is `p`)* - [major, minor numbers][devices] for the device.
 * **`fileMode`** *(uint32, OPTIONAL)* - file mode for the device.
   You can also control access to devices [with cgroups](#device-whitelist).
 * **`uid`** *(uint32, OPTIONAL)* - id of device owner.
@@ -148,7 +148,7 @@ The same `type`, `major` and `minor` SHOULD NOT be used for multiple devices.
     ]
 ```
 
-###### Default Devices
+###### <a name="configLinuxDefaultDevices" />Default Devices
 
 In addition to any devices configured with this setting, the runtime MUST also supply:
 
@@ -162,7 +162,7 @@ In addition to any devices configured with this setting, the runtime MUST also s
 * [`/dev/ptmx`][pts.4].
   A [bind-mount or symlink of the container's `/dev/pts/ptmx`][devpts].
 
-## Control groups
+## <a name="configLinuxControlGroups" />Control groups
 
 Also known as cgroups, they are used to restrict resource usage for a container and handle device access.
 cgroups provide controls (through controllers) to restrict cpu, memory, IO, pids and network for the container.
@@ -207,7 +207,7 @@ However, a runtime MAY attach the container process to additional cgroup control
    }
 ```
 
-#### Device whitelist
+#### <a name="configLinuxDeviceWhitelist" />Device whitelist
 
 **`devices`** (array of objects, OPTIONAL) configures the [device whitelist][cgroup-v1-devices].
 The runtime MUST apply entries in the listed order.
@@ -247,7 +247,7 @@ Each entry has the following structure:
     ]
 ```
 
-#### Disable out-of-memory killer
+#### <a name="configLinuxDisableOutOfMemoryKiller" />Disable out-of-memory killer
 
 `disableOOMKiller` contains a boolean (`true` or `false`) that enables or disables the Out of Memory killer for a cgroup.
 If enabled (`false`), tasks that attempt to consume more memory than they are allowed are immediately killed by the OOM killer.
@@ -263,10 +263,10 @@ For more information, see [the memory cgroup man page][cgroup-v1-memory].
     "disableOOMKiller": false
 ```
 
-#### Set oom_score_adj
+#### <a name="configLinuxSetOomScoreAdj" />Set oom_score_adj
 
 `oomScoreAdj` sets heuristic regarding how the process is evaluated by the kernel during memory pressure.
-For more information, see [the proc filesystem documentation section 3.1](https://www.kernel.org/doc/Documentation/filesystems/proc.txt).
+For more information, see [the proc filesystem documentation section 3.1][procfs].
 This is a kernel/system level setting, where as `disableOOMKiller` is scoped for a memory cgroup.
 For more information on how these two settings work together, see [the memory cgroup documentation section 10. OOM Contol][cgroup-v1-memory].
 
@@ -278,22 +278,22 @@ For more information on how these two settings work together, see [the memory cg
     "oomScoreAdj": 100
 ```
 
-#### Memory
+#### <a name="configLinuxMemory" />Memory
 
 **`memory`** (object, OPTIONAL) represents the cgroup subsystem `memory` and it's used to set limits on the container's memory usage.
 For more information, see [the memory cgroup man page][cgroup-v1-memory].
 
 The following parameters can be specified to setup the controller:
 
-* **`limit`** *(int64, OPTIONAL)* - sets limit of memory usage in bytes
+* **`limit`** *(uint64, OPTIONAL)* - sets limit of memory usage in bytes
 
-* **`reservation`** *(int64, OPTIONAL)* - sets soft limit of memory usage in bytes
+* **`reservation`** *(uint64, OPTIONAL)* - sets soft limit of memory usage in bytes
 
-* **`swap`** *(int64, OPTIONAL)* - sets limit of memory+Swap usage
+* **`swap`** *(uint64, OPTIONAL)* - sets limit of memory+Swap usage
 
-* **`kernel`** *(int64, OPTIONAL)* - sets hard limit for kernel memory
+* **`kernel`** *(uint64, OPTIONAL)* - sets hard limit for kernel memory
 
-* **`kernelTCP`** *(int64, OPTIONAL)* - sets hard limit in bytes for kernel TCP buffer memory
+* **`kernelTCP`** *(uint64, OPTIONAL)* - sets hard limit in bytes for kernel TCP buffer memory
 
 * **`swappiness`** *(uint64, OPTIONAL)* - sets swappiness parameter of vmscan (See sysctl's vm.swappiness)
 
@@ -310,7 +310,7 @@ The following parameters can be specified to setup the controller:
     }
 ```
 
-#### CPU
+#### <a name="configLinuxCPU" />CPU
 
 **`cpu`** (object, OPTIONAL) represents the cgroup subsystems `cpu` and `cpusets`.
 For more information, see [the cpusets cgroup man page][cgroup-v1-cpusets].
@@ -345,7 +345,7 @@ The following parameters can be specified to setup the controller:
     }
 ```
 
-#### Block IO Controller
+#### <a name="configLinuxBlockIO" />Block IO
 
 **`blockIO`** (object, OPTIONAL) represents the cgroup subsystem `blkio` which implements the block IO controller.
 For more information, see [the kernel cgroups documentation about blkio][cgroup-v1-blkio].
@@ -404,7 +404,7 @@ The following parameters can be specified to setup the controller:
     }
 ```
 
-#### Huge page limits
+#### <a name="configLinuxHugePageLimits" />Huge page limits
 
 **`hugepageLimits`** (array of objects, OPTIONAL) represents the `hugetlb` controller which allows to limit the
 HugeTLB usage per control group and enforces the controller limit during page fault.
@@ -414,7 +414,7 @@ Each entry has the following structure:
 
 * **`pageSize`** *(string, REQUIRED)* - hugepage size
 
-* **`limit`** *(int64, REQUIRED)* - limit in bytes of *hugepagesize* HugeTLB usage
+* **`limit`** *(uint64, REQUIRED)* - limit in bytes of *hugepagesize* HugeTLB usage
 
 ###### Example
 
@@ -427,7 +427,7 @@ Each entry has the following structure:
    ]
 ```
 
-#### Network
+#### <a name="configLinuxNetwork" />Network
 
 **`network`** (object, OPTIONAL) represents the cgroup subsystems `net_cls` and `net_prio`.
 For more information, see [the net\_cls cgroup man page][cgroup-v1-net-cls] and [the net\_prio cgroup man page][cgroup-v1-net-prio].
@@ -459,7 +459,7 @@ The following parameters can be specified to setup the controller:
    }
 ```
 
-#### PIDs
+#### <a name="configLinuxPIDS" />PIDs
 
 **`pids`** (object, OPTIONAL) represents the cgroup subsystem `pids`.
 For more information, see [the pids cgroup man page][cgroup-v1-pids].
@@ -476,10 +476,10 @@ The following parameters can be specified to setup the controller:
    }
 ```
 
-## Sysctl
+## <a name="configLinuxSysctl" />Sysctl
 
 **`sysctl`** (object, OPTIONAL) allows kernel parameters to be modified at runtime for the container.
-For more information, see [the man page](http://man7.org/linux/man-pages/man8/sysctl.8.html)
+For more information, see the [sysctl(8)][sysctl.8] man page.
 
 ###### Example
 
@@ -490,13 +490,13 @@ For more information, see [the man page](http://man7.org/linux/man-pages/man8/sy
    }
 ```
 
-## seccomp
+## <a name="configLinuxSeccomp" />Seccomp
 
 Seccomp provides application sandboxing mechanism in the Linux kernel.
 Seccomp configuration allows one to configure actions to take for matched syscalls and furthermore also allows matching on values passed as arguments to syscalls.
-For more information about Seccomp, see [Seccomp kernel documentation](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt)
-The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp](https://github.com/seccomp/libseccomp) and are translated to corresponding values.
-A valid list of constants as of libseccomp v2.3.0 is shown below.
+For more information about Seccomp, see [Seccomp][seccomp] kernel documentation.
+The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp][] and are translated to corresponding values.
+A valid list of constants as of libseccomp v2.3.2 is shown below.
 
 Architecture Constants
 * `SCMP_ARCH_X86`
@@ -515,6 +515,8 @@ Architecture Constants
 * `SCMP_ARCH_PPC64LE`
 * `SCMP_ARCH_S390`
 * `SCMP_ARCH_S390X`
+* `SCMP_ARCH_PARISC`
+* `SCMP_ARCH_PARISC64`
 
 Action Constants:
 * `SCMP_ACT_KILL`
@@ -538,22 +540,27 @@ Operator Constants:
    "seccomp": {
        "defaultAction": "SCMP_ACT_ALLOW",
        "architectures": [
-           "SCMP_ARCH_X86"
+           "SCMP_ARCH_X86",
+           "SCMP_ARCH_X32"
        ],
        "syscalls": [
            {
-               "name": "getcwd",
-               "action": "SCMP_ACT_ERRNO"
+               "names": [
+                   "getcwd",
+                   "chmod"
+               ],
+               "action": "SCMP_ACT_ERRNO",
+               "comment": "stop exploit x"
            }
        ]
    }
 ```
 
-## Rootfs Mount Propagation
+## <a name="configLinuxRootfsMountPropagation" />Rootfs Mount Propagation
 
 **`rootfsPropagation`** (string, OPTIONAL) sets the rootfs's mount propagation.
 Its value is either slave, private, or shared.
-[The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.
+The [Shared Subtrees][sharedsubtree] article in the kernel documentation has more information about mount propagation.
 
 ###### Example
 
@@ -561,7 +568,7 @@ Its value is either slave, private, or shared.
     "rootfsPropagation": "slave",
 ```
 
-## Masked Paths
+## <a name="configLinuxMaskedPaths" />Masked Paths
 
 **`maskedPaths`** (array of strings, OPTIONAL) will mask over the provided paths inside the container so that they cannot be read.
 The values MUST be absolute paths in the [container namespace][container-namespace2].
@@ -574,7 +581,7 @@ The values MUST be absolute paths in the [container namespace][container-namespa
     ]
 ```
 
-## Readonly Paths
+## <a name="configLinuxReadonlyPaths" />Readonly Paths
 
 **`readonlyPaths`** (array of strings, OPTIONAL) will set the provided paths as readonly inside the container.
 The values MUST be absolute paths in the [container namespace][container-namespace2].
@@ -587,7 +594,7 @@ The values MUST be absolute paths in the [container namespace][container-namespa
     ]
 ```
 
-## Mount Label
+## <a name"configLinuxMountLabel" />Mount Label
 
 **`mountLabel`** (string, OPTIONAL) will set the Selinux context for the mounts in the container.
 
@@ -597,7 +604,9 @@ The values MUST be absolute paths in the [container namespace][container-namespa
     "mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
 ```
 
+
 [container-namespace2]: glossary.md#container_namespace
+
 [cgroup-v1]: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
 [cgroup-v1-blkio]: https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt
 [cgroup-v1-cpusets]: https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt
@@ -610,15 +619,23 @@ The values MUST be absolute paths in the [container namespace][container-namespa
 [cgroup-v2]: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 [devices]: https://www.kernel.org/doc/Documentation/devices.txt
 [devpts]: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
-[file.1]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_164
+[file]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_164
+[libseccomp]: https://github.com/seccomp/libseccomp
+[procfs]: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+[seccomp]: https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt
+[sharedsubtree]: https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
+[sysfs]: https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt
+[tmpfs]: https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt
 
-[mknod.1]: http://man7.org/linux/man-pages/man1/mknod.1.html
-[mknod.2]: http://man7.org/linux/man-pages/man2/mknod.2.html
 [console.4]: http://man7.org/linux/man-pages/man4/console.4.html
 [full.4]: http://man7.org/linux/man-pages/man4/full.4.html
+[mknod.1]: http://man7.org/linux/man-pages/man1/mknod.1.html
+[mknod.2]: http://man7.org/linux/man-pages/man2/mknod.2.html
+[namespaces.7_2]: http://man7.org/linux/man-pages/man7/namespaces.7.html
 [null.4]: http://man7.org/linux/man-pages/man4/null.4.html
 [pts.4]: http://man7.org/linux/man-pages/man4/pts.4.html
 [random.4]: http://man7.org/linux/man-pages/man4/random.4.html
+[sysctl.8]: http://man7.org/linux/man-pages/man8/sysctl.8.html
 [tty.4]: http://man7.org/linux/man-pages/man4/tty.4.html
 [zero.4]: http://man7.org/linux/man-pages/man4/zero.4.html
 [user-namespaces]: http://man7.org/linux/man-pages/man7/user_namespaces.7.html

--- a/vendor/github.com/opencontainers/runtime-spec/config-solaris.md
+++ b/vendor/github.com/opencontainers/runtime-spec/config-solaris.md
@@ -1,6 +1,6 @@
 # <a name="solarisApplicationContainerConfiguration" />Solaris Application Container Configuration
 
-Solaris application containers can be configured using the following properties, all of the below properties have mappings to properties specified under zonecfg(8) man page, except milestone.
+Solaris application containers can be configured using the following properties, all of the below properties have mappings to properties specified under [zonecfg(1M)][zonecfg.1m_2] man page, except milestone.
 
 ## <a name="configSolarisMilestone" />milestone
 The SMF(Service Management Facility) FMRI which should go to "online" state before we start the desired process within the container.
@@ -14,7 +14,7 @@ The SMF(Service Management Facility) FMRI which should go to "online" state befo
 
 ## <a name="configSolarisLimitpriv" />limitpriv
 The maximum set of privileges any process in this container can obtain.
-The property should consist of a comma-separated privilege set specification as described in priv_str_to_set(3C) man page for the respective release of Solaris.
+The property should consist of a comma-separated privilege set specification as described in [priv_str_to_set(3C)][priv-str-to-set.3c] man page for the respective release of Solaris.
 
 **`limitpriv`** *(string, OPTIONAL)*
 
@@ -26,7 +26,7 @@ The property should consist of a comma-separated privilege set specification as 
 ## <a name="configSolarisMaxShmMemory" />maxShmMemory
 The maximum amount of shared memory allowed for this application container.
 A scale (K, M, G, T) can be applied to the value for each of these numbers (for example, 1M is one megabyte).
-Mapped to max-shm-memory in zonecfg(8) man page.
+Mapped to `max-shm-memory` in [zonecfg(1M)][zonecfg.1m] man page.
 
 **`maxShmMemory`** *(string, OPTIONAL)*
 
@@ -40,7 +40,7 @@ Sets a limit on the amount of CPU time that can be used by a container.
 The unit used translates to the percentage of a single CPU that can be used by all user threads in a container, expressed as a fraction (for example, .75) or a mixed number (whole number and fraction, for example, 1.25).
 An ncpu value of 1 means 100% of a CPU, a value of 1.25 means 125%, .75 mean 75%, and so forth.
 When projects within a capped container have their own caps, the minimum value takes precedence.
-cappedCPU is mapped to capped-cpu in zonecfg(8) man page.
+cappedCPU is mapped to `capped-cpu` in [zonecfg(1M)][zonecfg.1m] man page.
 
 * **`ncpus`** *(string, OPTIONAL)*
 
@@ -54,7 +54,7 @@ cappedCPU is mapped to capped-cpu in zonecfg(8) man page.
 ## <a name="configSolarisCappedMemory" />cappedMemory
 The physical and swap caps on the memory that can be used by this application container.
 A scale (K, M, G, T) can be applied to the value for each of these numbers (for example, 1M is one megabyte).
-cappedMemory is mapped to capped-memory in zonecfg(8) man page.
+cappedMemory is mapped to `capped-memory` in [zonecfg(1M)][zonecfg.1m] man page.
 
 * **`physical`** *(string, OPTIONAL)*
 * **`swap`** *(string, OPTIONAL)*
@@ -73,31 +73,31 @@ cappedMemory is mapped to capped-memory in zonecfg(8) man page.
 anet is specified as an array that is used to setup networking for Solaris application containers.
 The anet resource represents the automatic creation of a network resource for an application container.
 The zones administration daemon, zoneadmd, is the primary process for managing the container's virtual platform.
-One of the daemons is responsibilities is creation and teardown of the networks for the container.
-For more information on the daemon check the zoneadmd(1M) man page.
+One of the daemon's responsibilities is creation and teardown of the networks for the container.
+For more information on the daemon see the [zoneadmd(1M)][zoneadmd.1m] man page.
 When such a container is started, a temporary VNIC(Virtual NIC) is automatically created for the container.
 The VNIC is deleted when the container is torn down.
 The following properties can be used to setup automatic networks.
-For additional information on properties check zonecfg(8) man page for the respective release of Solaris.
+For additional information on properties, check the [zonecfg(1M)][zonecfg.1m] man page for the respective release of Solaris.
 
 * **`linkname`** *(string, OPTIONAL)* Specify a name for the automatically created VNIC datalink.
 * **`lowerLink`** *(string, OPTIONAL)* Specify the link over which the VNIC will be created.
-Mapped to lower-link in the zonecfg(8) man page.
+Mapped to `lower-link` in the [zonecfg(1M)][zonecfg.1m] man page.
 * **`allowedAddress`** *(string, OPTIONAL)* The set of IP addresses that the container can use might be constrained by specifying the allowedAddress property.
 If allowedAddress has not been specified, then they can use any IP address on the associated physical interface for the network resource.
 Otherwise, when allowedAddress is specified, the container cannot use IP addresses that are not in the allowedAddress list for the physical address.
-Mapped to allowed-address in the zonecfg(8) man page.
+Mapped to `allowed-address` in the [zonecfg(1M)][zonecfg.1m] man page.
 * **`configureAllowedAddress`** *(string, OPTIONAL)* If configureAllowedAddress is set to true, the addresses specified by allowedAddress are automatically configured on the interface each time the container starts.
 When it is set to false, the allowedAddress will not be configured on container start.
-Mapped to configure-allowed-address in the zonecfg(8) man page.
+Mapped to `configure-allowed-address` in the [zonecfg(1M)][zonecfg.1m] man page.
 * **`defrouter`** *(string, OPTIONAL)* The value for the OPTIONAL default router.
-* **`macAddress`** *(string, OPTIONAL)* Set the VNIC's MAC addresses based on the specified value or keyword.
+* **`macAddress`** *(string, OPTIONAL)* Set the VNIC`s MAC addresses based on the specified value or keyword.
 If not a keyword, it is interpreted as a unicast MAC address.
-For a list of the supported keywords please refer to the zonecfg(8) man page of the respective Solaris release.
-Mapped to mac-address in the zonecfg(8) man page.
+For a list of the supported keywords please refer to the [zonecfg(1M)][zonecfg.1m] man page of the respective Solaris release.
+Mapped to `mac-address` in the [zonecfg(1M)][zonecfg.1m] man page.
 * **`linkProtection`** *(string, OPTIONAL)* Enables one or more types of link protection using comma-separated values.
 See the protection property in dladm(8) for supported values in respective release of Solaris.
-Mapped to link-protection in the zonecfg(8) man page.
+Mapped to `link-protection` in the [zonecfg(1M)][zonecfg.1m] man page.
 
 #### Example
 ```json
@@ -113,3 +113,8 @@ Mapped to link-protection in the zonecfg(8) man page.
     }
 ]
 ```
+
+
+[priv-str-to-set.3c]: http://docs.oracle.com/cd/E53394_01/html/E54766/priv-str-to-set-3c.html
+[zoneadmd.1m]: http://docs.oracle.com/cd/E53394_01/html/E54764/zoneadmd-1m.html
+[zonecfg.1m_2]: http://docs.oracle.com/cd/E53394_01/html/E54764/zonecfg-1m.html

--- a/vendor/github.com/opencontainers/runtime-spec/config.md
+++ b/vendor/github.com/opencontainers/runtime-spec/config.md
@@ -1,4 +1,4 @@
-# Container Configuration file
+# <a name="containerConfigurationFile" />Container Configuration file
 
 The container's top-level directory MUST contain a configuration file called `config.json`.
 The canonical schema is defined in this document, but there is a JSON Schema in [`schema/config-schema.json`](schema/config-schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
@@ -13,9 +13,9 @@ Platform-specific fields are identified as such.
 For all platform-specific configuration values, the scope defined below in the [Platform-specific configuration](#platform-specific-configuration) section applies.
 
 
-## Specification version
+## <a name="configSpecificationVersion" />Specification version
 
-* **`ociVersion`** (string, REQUIRED) MUST be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the Open Container Runtime Specification with which the bundle complies.
+* **`ociVersion`** (string, REQUIRED) MUST be in [SemVer v2.0.0][semver-v2.0.0] format and specifies the version of the Open Container Runtime Specification with which the bundle complies.
 The Open Container Runtime Specification follows semantic versioning and retains forward and backward compatibility within major versions.
 For example, if a configuration is compliant with version 1.1 of this specification, it is compatible with all runtimes that support any 1.1 or later release of this specification, but is not compatible with a runtime that supports 1.0 and not 1.1.
 
@@ -25,7 +25,7 @@ For example, if a configuration is compliant with version 1.1 of this specificat
     "ociVersion": "0.1.0"
 ```
 
-## Root Configuration
+## <a name="configRoot" />Root
 
 **`root`** (object, REQUIRED) specifies the container's root filesystem.
 
@@ -44,29 +44,29 @@ For example, if a configuration is compliant with version 1.1 of this specificat
 }
 ```
 
-## Mounts
+## <a name="configMounts" />Mounts
 
 **`mounts`** (array, OPTIONAL) specifies additional mounts beyond [`root`](#root-configuration).
 The runtime MUST mount entries in the listed order.
-For Linux, the parameters are as documented in [the mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
-For Solaris, the mount entry corresponds to the 'fs' resource in zonecfg(8).
-For Windows, see links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx).
+For Linux, the parameters are as documented in [mount(2)][mount.2] system call man page.
+For Solaris, the mount entry corresponds to the 'fs' resource in the [zonecfg(1M)][zonecfg.1m] man page.
+For Windows, see [mountvol][mountvol] and [SetVolumeMountPoint][set-volume-mountpoint] for details.
 
 
 * **`destination`** (string, REQUIRED) Destination of mount point: path inside container.
   This value MUST be an absolute path.
   * Windows: one mount destination MUST NOT be nested within another mount (e.g., c:\\foo and c:\\foo\\bar).
-  * Solaris: corresponds to "dir" of the fs resource in zonecfg(8).
-* **`type`** (string, REQUIRED) The filesystem type of the filesystem to be mounted.
+  * Solaris: corresponds to "dir" of the fs resource in [zonecfg(1M)][zonecfg.1m].
+* **`type`** (string, OPTIONAL) The filesystem type of the filesystem to be mounted.
   * Linux: valid *filesystemtype* supported by the kernel as listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660").
   * Windows: the type of file system on the volume, e.g. "ntfs".
-  * Solaris: corresponds to "type" of the fs resource in zonecfg(8).
-* **`source`** (string, REQUIRED) A device name, but can also be a directory name or a dummy.
+  * Solaris: corresponds to "type" of the fs resource in [zonecfg(1M)][zonecfg.1m].
+* **`source`** (string, OPTIONAL) A device name, but can also be a directory name or a dummy.
   * Windows: the volume name that is the target of the mount point, \\?\Volume\{GUID}\ (on Windows source is called target).
-  * Solaris: corresponds to "special" of the fs resource in zonecfg(8).
+  * Solaris: corresponds to "special" of the fs resource in [zonecfg(1M)][zonecfg.1m].
 * **`options`** (list of strings, OPTIONAL) Mount options of the filesystem to be used.
-  * Linux: [supported][mount.8-filesystem-independent] [options][mount.8-filesystem-specific] are listed in [mount(8)][mount.8].
-  * Solaris: corresponds to "options" of the fs resource in zonecfg(8).
+  * Linux: supported options are listed in the [mount(8)][mount.8] man page. Note both [filesystem-independent][mount.8-filesystem-independent] and [filesystem-specific][mount.8-filesystem-specific] options are listed.
+  * Solaris: corresponds to "options" of the fs resource in [zonecfg(1M)][zonecfg.1m].
 
 ### Example (Linux)
 
@@ -118,7 +118,7 @@ For Windows, see links for details about [mountvol](http://ss64.com/nt/mountvol.
 ]
 ```
 
-## Process
+## <a name="configProcess" />Process
 
 **`process`** (object, REQUIRED) specifies the container process.
 
@@ -132,37 +132,43 @@ For Windows, see links for details about [mountvol](http://ss64.com/nt/mountvol.
 * **`env`** (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2001's `environ`][ieee-1003.1-2001-xbd-c8.1].
 * **`args`** (array of strings, REQUIRED) with similar semantics to [IEEE Std 1003.1-2001 `execvp`'s *argv*][ieee-1003.1-2001-xsh-exec].
   This specification extends the IEEE standard in that at least one entry is REQUIRED, and that entry is used with the same semantics as `execvp`'s *file*.
-* **`capabilities`** (array of strings, OPTIONAL) is an array that specifies the set of capabilities of the process(es) inside the container. Valid values are platform-specific. For example, valid values for Linux are defined in the [CAPABILITIES(7)](http://man7.org/linux/man-pages/man7/capabilities.7.html) man page.
+* **`capabilities`** (object, OPTIONAL) is an object containing arrays that specifies the sets of capabilities for the process(es) inside the container. Valid values are platform-specific. For example, valid values for Linux are defined in the [capabilities(7)][capabilities.7] man page.
+  capabilities contains the following properties:
+    * **`effective`** (array of strings, OPTIONAL) - the `effective` field is an array of effective capabilities that are kept for the process.
+    * **`bounding`** (array of strings, OPTIONAL) - the `bounding` field is an array of bounding capabilities that are kept for the process.
+    * **`inheritable`** (array of strings, OPTIONAL) - the `inheritable` field is an array of inheritable capabilities that are kept for the process.
+    * **`permitted`** (array of strings, OPTIONAL) - the `permitted` field is an array of permitted capabilities that are kept for the process.
+    * **`ambient`** (array of strings, OPTIONAL) - the `ambient` field is an array of ambient capabilities that are kept for the process.
 * **`rlimits`** (array of objects, OPTIONAL) allows setting resource limits for a process inside the container.
   Each entry has the following structure:
 
-    * **`type`** (string, REQUIRED) - the platform resource being limited, for example on Linux as defined in the [SETRLIMIT(2)](http://man7.org/linux/man-pages/man2/setrlimit.2.html) man page.
+    * **`type`** (string, REQUIRED) - the platform resource being limited, for example on Linux as defined in the [setrlimit(2)][setrlimit.2] man page.
     * **`soft`** (uint64, REQUIRED) - the value of the limit enforced for the corresponding resource.
     * **`hard`** (uint64, REQUIRED) - the ceiling for the soft limit that could be set by an unprivileged process. Only a privileged process (e.g. under Linux: one with the CAP_SYS_RESOURCE capability) can raise a hard limit.
 
     If `rlimits` contains duplicated entries with same `type`, the runtime MUST error out.
 
 * **`noNewPrivileges`** (bool, OPTIONAL) setting `noNewPrivileges` to true prevents the processes in the container from gaining additional privileges.
-  As an example, the ['no_new_privs' kernel doc](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) has more information on how this is achieved using a prctl system call on Linux.
+  As an example, the ['no_new_privs'][no-new-privs] article in the kernel documentation has information on how this is achieved using a prctl system call on Linux.
 
 For Linux-based systems the process structure supports the following process specific fields.
 
 * **`apparmorProfile`** (string, OPTIONAL) specifies the name of the AppArmor profile to be applied to processes in the container.
-  For more information about AppArmor, see [AppArmor documentation](https://wiki.ubuntu.com/AppArmor)
+  For more information about AppArmor, see [AppArmor documentation][apparmor].
 * **`selinuxLabel`** (string, OPTIONAL) specifies the SELinux label to be applied to the processes in the container.
-  For more information about SELinux, see  [SELinux documentation](http://selinuxproject.org/page/Main_Page)
+  For more information about SELinux, see  [SELinux documentation][selinux].
 
-### User
+### <a name="configUser" />User
 
 The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
 
-#### Linux and Solaris User
+#### <a name="configLinuxAndSolarisUser" />Linux and Solaris User
 
 For Linux and Solaris based systems the user structure has the following fields:
 
-* **`uid`** (int, REQUIRED) specifies the user ID in the [container namespace][container-namespace].
-* **`gid`** (int, REQUIRED) specifies the group ID in the [container namespace][container-namespace].
-* **`additionalGids`** (array of ints, OPTIONAL) specifies additional group IDs (in the [container namespace][container-namespace]) to be added to the process.
+* **`uid`** (int, REQUIRED) specifies the user ID in the [container namespace](glossary.md#container-namespace).
+* **`gid`** (int, REQUIRED) specifies the group ID in the [container namespace](glossary.md#container-namespace).
+* **`additionalGids`** (array of ints, OPTIONAL) specifies additional group IDs (in the [container namespace](glossary.md#container-namespace) to be added to the process.
 
 _Note: symbolic name for uid and gid, such as uname and gname respectively, are left to upper levels to derive (i.e. `/etc/passwd` parsing, NSS, etc)_
 
@@ -191,11 +197,30 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
     "apparmorProfile": "acme_secure_profile",
     "selinuxLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675",
     "noNewPrivileges": true,
-    "capabilities": [
-        "CAP_AUDIT_WRITE",
-        "CAP_KILL",
-        "CAP_NET_BIND_SERVICE"
-    ],
+    "capabilities": {
+        "bounding": [
+            "CAP_AUDIT_WRITE",
+            "CAP_KILL",
+            "CAP_NET_BIND_SERVICE"
+        ],
+       "permitted": [
+            "CAP_AUDIT_WRITE",
+            "CAP_KILL",
+            "CAP_NET_BIND_SERVICE"
+        ],
+       "inheritable": [
+            "CAP_AUDIT_WRITE",
+            "CAP_KILL",
+            "CAP_NET_BIND_SERVICE"
+        ],
+        "effective": [
+            "CAP_AUDIT_WRITE",
+            "CAP_KILL",
+        ],
+        "ambient": [
+            "CAP_NET_BIND_SERVICE"
+        ]
+    },
     "rlimits": [
         {
             "type": "RLIMIT_NOFILE",
@@ -230,7 +255,7 @@ _Note: symbolic name for uid and gid, such as uname and gname respectively, are 
 }
 ```
 
-#### Windows User
+#### <a name="configWindowsUser" />Windows User
 
 For Windows based systems the user structure has the following fields:
 
@@ -255,11 +280,11 @@ For Windows based systems the user structure has the following fields:
 ```
 
 
-## Hostname
+## <a name="configHostname" />Hostname
 
 * **`hostname`** (string, OPTIONAL) specifies the container's hostname as seen by processes running inside the container.
-  On Linux, for example, this will change the hostname in the [container][container-namespace] [UTS namespace][uts-namespace].
-  Depending on your [namespace configuration](config-linux.md#namespaces), the container UTS namespace may be the [runtime UTS namespace][runtime-namespace].
+  On Linux, for example, this will change the hostname in the [container](glossary.md#container-namespace) [UTS namespace][uts-namespace.7].
+  Depending on your [namespace configuration](config-linux.md#namespaces), the container UTS namespace may be the [runtime UTS namespace](glossary.md#runtime-namespace).
 
 ### Example
 
@@ -267,9 +292,9 @@ For Windows based systems the user structure has the following fields:
 "hostname": "mrsdalloway"
 ```
 
-## Platform
+## <a name="configPlatform" />Platform
 
-**`platform`** specifies the configuration's target platform.
+**`platform`** (object, REQUIRED) specifies the configuration's target platform.
 
 * **`os`** (string, REQUIRED) specifies the operating system family of the container configuration's specified [`root`](#root-configuration) file system bundle.
   The runtime MUST generate an error if it does not support the specified **`os`**.
@@ -289,7 +314,7 @@ For Windows based systems the user structure has the following fields:
 }
 ```
 
-## Platform-specific configuration
+## <a name="configPlatformSpecificConfiguration" />Platform-specific configuration
 
 [**`platform.os`**](#platform) is used to specify platform-specific configuration.
 Runtime implementations MAY support any valid values for platform-specific fields as part of this configuration.
@@ -320,7 +345,7 @@ Implementations MUST error out when invalid values are encountered and MUST gene
 }
 ```
 
-## Hooks
+## <a name="configHooks" />Hooks
 
 Hooks allow for the configuration of custom actions related to the [lifecycle](runtime.md#lifecycle) of the container.
 
@@ -341,25 +366,20 @@ Hooks allow users to specify programs to run before or after various lifecycle e
 Hooks MUST be called in the listed order.
 The [state](runtime.md#state) of the container MUST be passed to hooks over stdin so that they may do work appropriate to the current state of the container.
 
-### Prestart
+### <a name="configHooksPrestart" />Prestart
 
-The pre-start hooks MUST be called after the container has been created, but before the user supplied command is executed.
+The pre-start hooks MUST be called after the [`start`](runtime.md#start) operation is called but [before the user-specified program command is executed](runtime.md#lifecycle).
 On Linux, for example, they are called after the container namespaces are created, so they provide an opportunity to customize the container (e.g. the network namespace could be specified in this hook).
 
-If a hook returns a non-zero exit code, an error including the exit code and the stderr MUST be returned to the caller and the container MUST be destroyed.
+### <a name="configHooksPoststart" />Poststart
 
-### Poststart
-
-The post-start hooks MUST be called after the user process is started.
+The post-start hooks MUST be called [after the user-specified process is executed](runtime#lifecycle) but before the [`start`](runtime.md#start) operation returns.
 For example, this hook can notify the user that the container process is spawned.
 
-If a hook returns a non-zero exit code, then an error MUST be logged and the remaining hooks are executed.
+### <a name="configHooksPoststop" />Poststop
 
-### Poststop
-
-The post-stop hooks MUST be called after the container process is stopped.
+The post-stop hooks MUST be called [after the container is deleted](runtime#lifecycle) but before the [`delete`](runtime.md#delete) operation returns.
 Cleanup or debugging functions are examples of such a hook.
-If a hook returns a non-zero exit code, then an error MUST be logged and the remaining hooks are executed.
 
 ### Example
 
@@ -390,7 +410,7 @@ If a hook returns a non-zero exit code, then an error MUST be logged and the rem
     }
 ```
 
-## Annotations
+## <a name="configAnnotations" />Annotations
 
 **`annotations`** (object, OPTIONAL) contains arbitrary metadata for the container.
 This information MAY be structured or unstructured.
@@ -413,7 +433,7 @@ Values MAY be an empty string.
 }
 ```
 
-## Extensibility
+## <a name="configExtensibility" />Extensibility
 Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown property.
 Instead they MUST ignore unknown properties.
 
@@ -446,11 +466,30 @@ Here is a full example `config.json` for reference.
             "TERM=xterm"
         ],
         "cwd": "/",
-        "capabilities": [
-            "CAP_AUDIT_WRITE",
-            "CAP_KILL",
-            "CAP_NET_BIND_SERVICE"
-        ],
+        "capabilities": {
+            "bounding": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+                "CAP_NET_BIND_SERVICE"
+            ],
+            "permitted": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+                "CAP_NET_BIND_SERVICE"
+            ],
+            "inheritable": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+                "CAP_NET_BIND_SERVICE"
+            ],
+            "effective": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+            ],
+            "ambient": [
+                "CAP_NET_BIND_SERVICE"
+            ]
+        },
         "rlimits": [
             {
                 "type": "RLIMIT_CORE",
@@ -718,12 +757,17 @@ Here is a full example `config.json` for reference.
         "seccomp": {
             "defaultAction": "SCMP_ACT_ALLOW",
             "architectures": [
-                "SCMP_ARCH_X86"
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
             ],
             "syscalls": [
                 {
-                    "name": "getcwd",
-                    "action": "SCMP_ACT_ERRNO"
+                    "names": [
+                        "getcwd",
+                        "chmod"
+                    ],
+                    "action": "SCMP_ACT_ERRNO",
+                    "comment": "stop exploit x"
                 }
             ]
         },
@@ -773,13 +817,23 @@ Here is a full example `config.json` for reference.
 }
 ```
 
-[container-namespace]: glossary.md#container-namespace
+
+[apparmor]: https://wiki.ubuntu.com/AppArmor
+[selinux]:http://selinuxproject.org/page/Main_Page
+[no-new-privs]: https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
+[semver-v2.0.0]: http://semver.org/spec/v2.0.0.html
 [go-environment]: https://golang.org/doc/install/source#environment
 [ieee-1003.1-2001-xbd-c8.1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html#tag_08_01
 [ieee-1003.1-2001-xsh-exec]: http://pubs.opengroup.org/onlinepubs/009695399/functions/exec.html
-[runtime-namespace]: glossary.md#runtime-namespace
-[uts-namespace]: http://man7.org/linux/man-pages/man7/namespaces.7.html
+[mountvol]: http://ss64.com/nt/mountvol.html
+[set-volume-mountpoint]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx
+
+[capabilities.7]: http://man7.org/linux/man-pages/man7/capabilities.7.html
+[mount.2]: http://man7.org/linux/man-pages/man2/mount.2.html
+[mount.8]: http://man7.org/linux/man-pages/man8/mount.8.html
 [mount.8-filesystem-independent]: http://man7.org/linux/man-pages/man8/mount.8.html#FILESYSTEM-INDEPENDENT_MOUNT%20OPTIONS
 [mount.8-filesystem-specific]: http://man7.org/linux/man-pages/man8/mount.8.html#FILESYSTEM-SPECIFIC_MOUNT%20OPTIONS
-[mount.8]: http://man7.org/linux/man-pages/man8/mount.8.html
+[setrlimit.2]: http://man7.org/linux/man-pages/man2/setrlimit.2.html
 [stdin.3]: http://man7.org/linux/man-pages/man3/stdin.3.html
+[uts-namespace.7]: http://man7.org/linux/man-pages/man7/namespaces.7.html
+[zonecfg.1m]: http://docs.oracle.com/cd/E53394_01/html/E54764/zonecfg-1m.html

--- a/vendor/github.com/opencontainers/runtime-spec/glossary.md
+++ b/vendor/github.com/opencontainers/runtime-spec/glossary.md
@@ -33,6 +33,8 @@ It reads the [configuration files](#configuration) from a [bundle](#bundle), use
 On Linux, a leaf in the [namespace][namespaces.7] hierarchy from which the [runtime](#runtime) process is executed.
 New container namespaces will be created as children of the runtime namespaces.
 
+
 [JSON]: https://tools.ietf.org/html/rfc7159
 [UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf
+
 [namespaces.7]: http://man7.org/linux/man-pages/man7/namespaces.7.html

--- a/vendor/github.com/opencontainers/runtime-spec/implementations.md
+++ b/vendor/github.com/opencontainers/runtime-spec/implementations.md
@@ -1,19 +1,27 @@
-# Implementations
+# <a name="implementations" />Implementations
 
 The following sections link to associated projects, some of which are maintained by the OCI and some of which are maintained by external organizations.
 If you know of any associated projects that are not listed here, please file a pull request adding a link to that project.
 
-## Runtime (Container)
+## <a name"implementationsRuntimeContainer" />Runtime (Container)
 
-* [opencontainers/runc](https://github.com/opencontainers/runc) - Reference implementation of OCI runtime
+* [opencontainers/runc][runc] - Reference implementation of OCI runtime
 
-## Runtime (Virtual Machine)
+## <a name="implementationsRuntimeVirtualMachine" />Runtime (Virtual Machine)
 
-* [hyperhq/runv](https://github.com/hyperhq/runv) - Hypervisor-based runtime for OCI
-* [01org/cc-oci-runtime](https://github.com/01org/cc-oci-runtime) - Hypervisor-based OCI runtime for Intel® Architecture
+* [hyperhq/runv][runv] - Hypervisor-based runtime for OCI
+* [01org/cc-oci-runtime][cc-oci] - Hypervisor-based OCI runtime for Intel® Architecture
 
-## Testing & Tools
+## <a name="implementationsTestingTools" />Testing & Tools
 
-* [kunalkushwaha/octool](https://github.com/kunalkushwaha/octool) - A config linter and validator.
-* [huawei-openlab/oct](https://github.com/huawei-openlab/oct) - Open Container Testing framework for OCI configuration and runtime
-* [opencontainers/runtime-tools](https://github.com/opencontainers/runtime-tools) - A config generator and runtime/bundle testing framework.
+* [kunalkushwaha/octool][octool] - A config linter and validator.
+* [huawei-openlab/oct][oct] - Open Container Testing framework for OCI configuration and runtime
+* [opencontainers/runtime-tools][runtime-tools] - A config generator and runtime/bundle testing framework.
+
+
+[runc]: https://github.com/opencontainers/runc
+[runv]: https://github.com/hyperhq/runv
+[cc-oci]: https://github.com/01org/cc-oci-runtime
+[octool]: https://github.com/kunalkushwaha/octool
+[oct]: https://github.com/huawei-openlab/oct
+[runtime-tools]: https://github.com/opencontainers/runtime-tools

--- a/vendor/github.com/opencontainers/runtime-spec/project.md
+++ b/vendor/github.com/opencontainers/runtime-spec/project.md
@@ -1,10 +1,12 @@
-# Project docs
+# <a name="projectDocs" />Project docs
 
-## Release Process
+## <a name="projectReleaseProcess" />Release Process
 
 * Increment version in [`specs-go/version.go`](specs-go/version.go)
 * `git commit` version increment
 * `git tag` the prior commit (preferably signed tag)
 * `make docs` to produce PDF and HTML copies of the spec
-* Make a release on [github.com/opencontainers/runtime-spec](https://github.com/opencontainers/runtime-spec/releases) for the version. Attach the produced docs.
+* Make a [release][releases] for the version. Attach the produced docs.
 
+
+[releases]: https://github.com/opencontainers/runtime-spec/releases

--- a/vendor/github.com/opencontainers/runtime-spec/runtime-linux.md
+++ b/vendor/github.com/opencontainers/runtime-spec/runtime-linux.md
@@ -3,7 +3,7 @@
 ## <a name="runtimeLinuxFileDescriptors" />File descriptors
 
 By default, only the `stdin`, `stdout` and `stderr` file descriptors are kept open for the application by the runtime.
-The runtime MAY pass additional file descriptors to the application to support features such as [socket activation](http://0pointer.de/blog/projects/socket-activated-containers.html).
+The runtime MAY pass additional file descriptors to the application to support features such as [socket activation][socket-activated-containers].
 Some of the file descriptors MAY be redirected to `/dev/null` even though they are open.
 
 ## <a name="runtimeLinuxDevSymbolicLinks" /> Dev symbolic links
@@ -16,3 +16,6 @@ After the container has `/proc` mounted, the following standard symlinks MUST be
 | /proc/self/fd/0 | /dev/stdin  |
 | /proc/self/fd/1 | /dev/stdout |
 | /proc/self/fd/2 | /dev/stderr |
+
+
+[socket-activated-containers]: http://0pointer.de/blog/projects/socket-activated-containers.html

--- a/vendor/github.com/opencontainers/runtime-spec/runtime.md
+++ b/vendor/github.com/opencontainers/runtime-spec/runtime.md
@@ -1,11 +1,11 @@
-# Runtime and Lifecycle
+# <a name="runtimeAndLifecycle" />Runtime and Lifecycle
 
-## Scope of a Container
+## <a name="runtimeScopeContainer" />Scope of a Container
 
 Barring access control concerns, the entity using a runtime to create a container MUST be able to use the operations defined in this specification against that same container.
 Whether other entities using the same, or other, instance of the runtime can see that container is out of scope of this specification.
 
-## State
+## <a name="runtimeState" />State
 
 The state of a container includes the following properties:
 
@@ -47,51 +47,62 @@ When serialized in JSON, the format MUST adhere to the following pattern:
 
 See [Query State](#query-state) for information on retrieving the state of a container.
 
-## Lifecycle
+## <a name="runtimeLifecycle" />Lifecycle
 The lifecycle describes the timeline of events that happen from when a container is created to when it ceases to exist.
 
 1. OCI compliant runtime's [`create`](runtime.md#create) command is invoked with a reference to the location of the bundle and a unique identifier.
 2. The container's runtime environment MUST be created according to the configuration in [`config.json`](config.md).
-   If the runtime is unable to create the environment specified in the [`config.json`](config.md), it MUST generate an error.
+   If the runtime is unable to create the environment specified in the [`config.json`](config.md), it MUST [generate an error](#errors).
    While the resources requested in the [`config.json`](config.md) MUST be created, the user-specified program (from [`process`](config.md#process)) MUST NOT be run at this time.
    Any updates to [`config.json`](config.md) after this step MUST NOT affect the container.
 3. Once the container is created additional actions MAY be performed based on the features the runtime chooses to support.
    However, some actions might only be available based on the current state of the container (e.g. only available while it is started).
 4. Runtime's [`start`](runtime.md#start) command is invoked with the unique identifier of the container.
-   The runtime MUST run the user-specified program, as specified by [`process`](config.md#process).
-5. The container process exits.
+5. The [prestart hooks](config.md#prestart) MUST be invoked by the runtime.
+   If any prestart hook fails, the runtime MUST [generate an error](#errors), stop the container, and continue the lifecycle at step 10.
+6. The runtime MUST run the user-specified program, as specified by [`process`](config.md#process).
+7. The [poststart hooks](config.md#poststart) MUST be invoked by the runtime.
+   If any poststart hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
+8. The container process exits.
    This MAY happen due to erroring out, exiting, crashing or the runtime's [`kill`](runtime.md#kill) operation being invoked.
-6. Runtime's [`delete`](runtime.md#delete) command is invoked with the unique identifier of the container.
-   The container MUST be destroyed by undoing the steps performed during create phase (step 2).
+9. Runtime's [`delete`](runtime.md#delete) command is invoked with the unique identifier of the container.
+10. The container MUST be destroyed by undoing the steps performed during create phase (step 2).
+11. The [poststop hooks](config.md#poststop) MUST be invoked by the runtime.
+    If any poststop hook fails, the runtime MUST [log a warning](#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.
 
-## Errors
+## <a name="runtimeErrors" />Errors
 
 In cases where the specified operation generates an error, this specification does not mandate how, or even if, that error is returned or exposed to the user of an implementation.
 Unless otherwise stated, generating an error MUST leave the state of the environment as if the operation were never attempted - modulo any possible trivial ancillary changes such as logging.
 
-## Operations
+## <a name="runtimeWarnings" />Warnings
+
+In cases where the specified operation logs a warning, this specification does not mandate how, or even if, that warning is returned or exposed to the user of an implementation.
+Unless otherwise stated, logging a warning does not change the flow of the operation; it MUST continue as if the warning had not been logged.
+
+## <a name="runtimeOperations" />Operations
 
 OCI compliant runtimes MUST support the following operations, unless the operation is not supported by the base operating system.
 
 Note: these operations are not specifying any command-line APIs, and the parameters are inputs for general operations.
 
-### Query State
+### <a name="runtimeQueryState" />Query State
 
 `state <container-id>`
 
-This operation MUST generate an error if it is not provided the ID of a container.
-Attempting to query a container that does not exist MUST generate an error.
+This operation MUST [generate an error](#errors) if it is not provided the ID of a container.
+Attempting to query a container that does not exist MUST [generate an error](#errors).
 This operation MUST return the state of a container as specified in the [State](#state) section.
 
-### Create
+### <a name="runtimeCreate" />Create
 
 `create <container-id> <path-to-bundle>`
 
-This operation MUST generate an error if it is not provided a path to the bundle and the container ID to associate with the container.
-If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST generate an error and a new container MUST NOT be created.
+This operation MUST [generate an error](#errors) if it is not provided a path to the bundle and the container ID to associate with the container.
+If the ID provided is not unique across all containers within the scope of the runtime, or is not valid in any other way, the implementation MUST [generate an error](#errors) and a new container MUST NOT be created.
 Using the data in [`config.json`](config.md), this operation MUST create a new container.
 This means that all of the resources associated with the container MUST be created, however, the user-specified program MUST NOT be run at this time.
-If the runtime cannot create the container as specified in [`config.json`](config.md), it MUST generate an error and a new container MUST NOT be created.
+If the runtime cannot create the container as specified in [`config.json`](config.md), it MUST [generate an error](#errors) and a new container MUST NOT be created.
 
 Upon successful completion of this operation the `status` property of this container MUST be `created`.
 
@@ -100,36 +111,36 @@ Runtime callers who are interested in pre-create validation can run [bundle-vali
 
 Any changes made to the [`config.json`](config.md) file after this operation will not have an effect on the container.
 
-### Start
+### <a name="runtimeStart" />Start
 `start <container-id>`
 
-This operation MUST generate an error if it is not provided the container ID.
-Attempting to start a container that does not exist MUST generate an error.
-Attempting to start an already started container MUST have no effect on the container and MUST generate an error.
+This operation MUST [generate an error](#errors) if it is not provided the container ID.
+Attempting to start a container that does not exist MUST [generate an error](#errors).
+Attempting to start an already started container MUST have no effect on the container and MUST [generate an error](#errors).
 This operation MUST run the user-specified program as specified by [`process`](config.md#process).
 
 Upon successful completion of this operation the `status` property of this container MUST be `running`.
 
-### Kill
+### <a name="runtimeKill" />Kill
 `kill <container-id> <signal>`
 
-This operation MUST generate an error if it is not provided the container ID.
-Attempting to send a signal to a container that is not running MUST have no effect on the container and MUST generate an error.
+This operation MUST [generate an error](#errors) if it is not provided the container ID.
+Attempting to send a signal to a container that is not running MUST have no effect on the container and MUST [generate an error](#errors).
 This operation MUST send the specified signal to the process in the container.
 
 When the process in the container is stopped, irrespective of it being as a result of a `kill` operation or any other reason, the `status` property of this container MUST be `stopped`.
 
-### Delete
+### <a name="runtimeDelete" />Delete
 `delete <container-id>`
 
-This operation MUST generate an error if it is not provided the container ID.
-Attempting to delete a container that does not exist MUST generate an error.
-Attempting to delete a container whose process is still running MUST generate an error.
+This operation MUST [generate an error](#errors) if it is not provided the container ID.
+Attempting to delete a container that does not exist MUST [generate an error](#errors).
+Attempting to delete a container whose process is still running MUST [generate an error](#errors).
 Deleting a container MUST delete the resources that were created during the `create` step.
 Note that resources associated with the container, but not created by this container, MUST NOT be deleted.
 Once a container is deleted its ID MAY be used by a subsequent container.
 
 
-## Hooks
+## <a name="runtimeHooks" />Hooks
 Many of the operations specified in this specification have "hooks" that allow for additional actions to be taken before or after each operation.
 See [runtime configuration for hooks](./config.md#hooks) for more information.

--- a/vendor/github.com/opencontainers/runtime-spec/spec.md
+++ b/vendor/github.com/opencontainers/runtime-spec/spec.md
@@ -1,15 +1,15 @@
-# Open Container Initiative Runtime Specification
+# <a name="openContainerInitiativeRuntimeSpecification" />Open Container Initiative Runtime Specification
 
-The [Open Container Initiative](http://www.opencontainers.org/) develops specifications for standards on Operating System process and application containers.
+The [Open Container Initiative][oci] develops specifications for standards on Operating System process and application containers.
 
-# Abstract
+# <a name="ociRuntimeSpecAbstract" />Abstract
 
 The OCI Runtime Specification aims to specify the configuration, execution environment, and lifecycle a container.
 
 A container's configuration is specified as the `config.json` for the supported platforms and details the fields that enable the creation of a container.
 The execution environment is specified to ensure that applications running inside a container have a consistent environment between runtimes along with common actions defined for the container's lifecycle.
 
-# Platforms
+# <a name="ociRuntimeSpecPlatforms" />Platforms
 
 Platforms defined by this specification are:
 
@@ -17,7 +17,7 @@ Platforms defined by this specification are:
 * `solaris`: [runtime.md](runtime.md), [config.md](config.md), and [config-solaris.md](config-solaris.md).
 * `windows`: [runtime.md](runtime.md), [config.md](config.md), and [config-windows.md](config-windows.md).
 
-# Table of Contents
+# <a name="ociRuntimeSpecTOC" />Table of Contents
 
 - [Introduction](spec.md)
     - [Notational Conventions](#notational-conventions)
@@ -31,7 +31,7 @@ Platforms defined by this specification are:
     - [Windows-specific Configuration](config-windows.md)
 - [Glossary](glossary.md)
 
-# Notational Conventions
+# <a name="ociRuntimeSpecNotationalConventions" />Notational Conventions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119][rfc2119].
 
@@ -40,5 +40,7 @@ The key words "unspecified", "undefined", and "implementation-defined" are to be
 An implementation is not compliant for a given CPU architecture if it fails to satisfy one or more of the MUST, REQUIRED, or SHALL requirements for the [platforms](#platforms) it implements.
 An implementation is compliant for a given CPU architecture if it satisfies all the MUST, REQUIRED, and SHALL requirements for the [platforms](#platforms) it implements.
 
+
 [c99-unspecified]: http://www.open-std.org/jtc1/sc22/wg14/www/C99RationaleV5.10.pdf#page=18
+[oci]: http://www.opencontainers.org
 [rfc2119]: http://tools.ietf.org/html/rfc2119

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc4-dev"
+	VersionDev = "-rc5"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/opencontainers/runtime-spec/style.md
+++ b/vendor/github.com/opencontainers/runtime-spec/style.md
@@ -1,29 +1,45 @@
-# Style and conventions
+# <a name="styleAndConventions" />Style and conventions
 
-## One sentence per line
+## <a name="styleOneSentence" />One sentence per line
 
 To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
 This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
 For example, this paragraph will span three lines in the Markdown source.
 
-## Traditionally hex settings should use JSON integers, not JSON strings
+## <a name="styleHex" />Traditionally hex settings should use JSON integers, not JSON strings
 
 For example, [`"classID": 1048577`][class-id] instead of `"classID": "0x100001"`.
 The config JSON isn't enough of a UI to be worth jumping through string <-> integer hoops to support an 0x… form ([source][integer-over-hex]).
 
-## Constant names should keep redundant prefixes
+## <a name="styleConstantNames" />Constant names should keep redundant prefixes
 
 For example, `CAP_KILL` instead of `KILL` in [**`linux.capabilities`**][capabilities].
 The redundancy reduction from removing the namespacing prefix is not useful enough to be worth trimming the upstream identifier ([source][keep-prefix]).
 
-## Optional settings should not have pointer Go types
+## <a name="styleOptionalSettings" />Optional settings should not have pointer Go types
 
 Because in many cases the Go default for the type is a no-op in the spec (sources [here][no-pointer-for-strings], [here][no-pointer-for-slices], and [here][no-pointer-for-boolean]).
 The exceptions are entries where we need to distinguish between “not set” and “set to the Go default for that type” ([source][pointer-when-updates-require-changes]), and this decision should be made on a per-setting case.
 
+## Links
+
+Internal links should be [relative links][markdown-relative-links] when linking to content within the repository.
+Internal links should be used inline.
+
+External links should be collected at the bottom of a markdown file and used as referenced links.
+See 'Referenced Links' in this [markdown quick reference][markdown-quick-reference].
+The use of referenced links in the markdown body helps to keep files clean and organized.
+This also facilitates updates of external link targets on a per-file basis.
+
+Referenced links should be kept in two alphabetically sorted sets, a general reference section followed by a man page section.
+To keep Pandoc happy, duplicate naming of links within pages listed in the Makefile's DOC_FILES variable should be avoided by appending an '_N' to the link tagname, where 'N' is some number not currently in use.
+The organization and style of an existing reference section should be maintained unless it violates these style guidelines.
+
+An exception to these rules is when a URL is needed contextually, for example when showing an explicit link to the reader.
+
 ## Examples
 
-### Anchoring
+### <a name="styleAnchoring" />Anchoring
 
 For any given section that provides a notable example, it is ideal to have it denoted with [markdown headers][markdown-headers].
 The level of header should be such that it is a subheader of the header it is an example of.
@@ -47,7 +63,7 @@ To use Some Topic, ...
 
 ```
 
-### Content
+### <a name="styleContent" />Content
 
 Where necessary, the values in the example can be empty or unset, but accommodate with comments regarding this intention.
 
@@ -86,6 +102,24 @@ Following is a fully populated example (not necessarily for copy/paste use)
 }
 ```
 
+### Links
+
+The following is an example of different types of links.
+This is shown as a complete markdown file, where the referenced links are at the bottom.
+
+```markdown
+The specification repository's [glossary](glossary.md) is where readers can find definitions of commonly used terms.
+
+Readers may click through to the [Open Containers namespace][open-containers] on [GitHub][github].
+
+The URL for the Open Containers link above is: https://github.com/opencontainers
+
+
+[github]: https://github.com
+[open-containers]: https://github.com/opencontainers
+```
+
+
 [capabilities]: config-linux.md#capabilities
 [class-id]: config-linux.md#network
 [integer-over-hex]: https://github.com/opencontainers/runtime-spec/pull/267#r48360013
@@ -95,3 +129,5 @@ Following is a fully populated example (not necessarily for copy/paste use)
 [no-pointer-for-strings]: https://github.com/opencontainers/runtime-spec/pull/653#issue-200439192
 [pointer-when-updates-require-changes]: https://github.com/opencontainers/runtime-spec/pull/317#r50932706
 [markdown-headers]: https://help.github.com/articles/basic-writing-and-formatting-syntax/#headings
+[markdown-quick-reference]: https://en.support.wordpress.com/markdown-quick-reference
+[markdown-relative-links]: https://help.github.com/articles/basic-writing-and-formatting-syntax/#relative-links


### PR DESCRIPTION
Rely on latest virtcontainers version introducing the new vendoring of runtime-spec v1.0.0-rc5. Virtcontainers also includes new structures for compatibility with runtime-spec structures changes between versions 1.0.0-rc4 and 1.0.0-rc5.
This patch also updates the current vendoring of the runtime to the version 1.0.0-rc5.