### PR TITLE
vendor: update virtcontainers vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "3acb5b9124a33a8410d32701c38207f2fcc2c4eec005fd085331a65234904e28"
+memo = "7aed1bd760bb14b7a75babcbb9b95575d4d4b4f13d1ed8bbbd75a8d4eb9140e1"
 
 [[projects]]
   branch = "master"
@@ -33,7 +33,7 @@ memo = "3acb5b9124a33a8410d32701c38207f2fcc2c4eec005fd085331a65234904e28"
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "bcd26936f5051d80384e71682620c8247a18d5bd"
+  revision = "6ca08d8de123bc2157d510013ec675a4634b245c"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -127,6 +127,11 @@ func (c *Container) URL() string {
 	return c.pod.URL()
 }
 
+// GetAnnotations returns container's annotations
+func (c *Container) GetAnnotations() map[string]string {
+	return c.config.Annotations
+}
+
 func (c *Container) startShim() error {
 	proxyInfo, url, err := c.pod.proxy.connect(*(c.pod), true)
 	if err != nil {

--- a/vendor/github.com/containers/virtcontainers/container_test.go
+++ b/vendor/github.com/containers/virtcontainers/container_test.go
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"testing"
+)
+
+func TestGetAnnotations(t *testing.T) {
+	annotations := map[string]string{
+		"annotation1": "abc",
+		"annotation2": "xyz",
+		"annotation3": "123",
+	}
+
+	container := Container{
+		config: &ContainerConfig{
+			Annotations: annotations,
+		},
+	}
+
+	containerAnnotations := container.GetAnnotations()
+
+	for k, v := range containerAnnotations {
+		if annotations[k] != v {
+			t.Fatalf("Expecting ['%s']='%s', Got ['%s']='%s'\n", k, annotations[k], k, v)
+		}
+	}
+}

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -237,7 +237,10 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 
 		Containers: []vc.ContainerConfig{containerConfig},
 
-		Annotations: map[string]string{},
+		Annotations: map[string]string{
+			ConfigPathKey: configPath,
+			BundlePathKey: bundlePath,
+		},
 	}
 
 	return &podConfig, &ocispec, nil

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -107,7 +107,10 @@ func TestMinimalPodConfig(t *testing.T) {
 
 		Containers: []vc.ContainerConfig{expectedContainerConfig},
 
-		Annotations: map[string]string{},
+		Annotations: map[string]string{
+			ConfigPathKey: configPath,
+			BundlePathKey: tempBundlePath,
+		},
 	}
 
 	podConfig, _, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)

--- a/vendor/github.com/containers/virtcontainers/pod_test.go
+++ b/vendor/github.com/containers/virtcontainers/pod_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -755,5 +756,51 @@ func TestGetAllContainers(t *testing.T) {
 		if c.id != containerIDs[i] {
 			t.Fatal()
 		}
+	}
+}
+
+func TestSetAnnotations(t *testing.T) {
+	pod := Pod{
+		id:              "abcxyz123",
+		storage:         &filesystem{},
+		annotationsLock: &sync.RWMutex{},
+		config: &PodConfig{
+			Annotations: map[string]string{
+				"annotation1": "abc",
+			},
+		},
+	}
+
+	keyAnnotation := "annotation2"
+	valueAnnotation := "xyz"
+	newAnnotations := map[string]string{
+		keyAnnotation: valueAnnotation,
+	}
+
+	// Add a new annotation
+	pod.SetAnnotations(newAnnotations)
+
+	v, err := pod.Annotations(keyAnnotation)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if v != valueAnnotation {
+		t.Fatal()
+	}
+
+	//Change the value of an annotation
+	valueAnnotation = "123"
+	newAnnotations[keyAnnotation] = valueAnnotation
+
+	pod.SetAnnotations(newAnnotations)
+
+	v, err = pod.Annotations(keyAnnotation)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if v != valueAnnotation {
+		t.Fatal()
 	}
 }


### PR DESCRIPTION
this new version of virtcontainers contains changes needed to
fix #133 and #144

shortlog:
	8d49dfc oci: copy container's annotations to pod
	8155768 pod: Adds RW lock to access pod's annotations
	c1cb7eb pod: add function to get pod's annotations
	8509c34 pod: add function to set or add annotations
	148ba85 container: Add function to get container's annotations

Signed-off-by: Julio Montes <julio.montes@intel.com>