### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "7aed1bd760bb14b7a75babcbb9b95575d4d4b4f13d1ed8bbbd75a8d4eb9140e1"
+memo = "3acb5b9124a33a8410d32701c38207f2fcc2c4eec005fd085331a65234904e28"
 
 [[projects]]
   branch = "master"
@@ -33,7 +33,7 @@ memo = "7aed1bd760bb14b7a75babcbb9b95575d4d4b4f13d1ed8bbbd75a8d4eb9140e1"
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "6ca08d8de123bc2157d510013ec675a4634b245c"
+  revision = "d23b31719e42001bd91c1aa9a8f133e3974136fc"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/kill.go
+++ b/kill.go
@@ -138,7 +138,7 @@ func kill(containerID, signal string, all bool) error {
 		return err
 	}
 
-	if err := vc.KillContainer(containerID, podStatus.ContainersStatus[0].ID, signum); err != nil {
+	if err := vc.KillContainer(containerID, podStatus.ContainersStatus[0].ID, signum, all); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -135,6 +135,8 @@ type agent interface {
 	// stopContainer will tell the agent to stop a container related to a Pod.
 	stopContainer(pod Pod, c Container) error
 
-	// killContainer will tell the agent to send a signal to a container related to a Pod.
-	killContainer(pod Pod, c Container, signal syscall.Signal) error
+	// killContainer will tell the agent to send a signal to a
+	// container related to a Pod. If all is true, all processes in
+	// the container will be sent the signal.
+	killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error
 }

--- a/vendor/github.com/containers/virtcontainers/api.go
+++ b/vendor/github.com/containers/virtcontainers/api.go
@@ -657,8 +657,9 @@ func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 }
 
 // KillContainer is the virtcontainers entry point to send a signal
-// to a container running inside a pod.
-func KillContainer(podID, containerID string, signal syscall.Signal) error {
+// to a container running inside a pod. If all is true, all processes in
+// the container will be sent the signal.
+func KillContainer(podID, containerID string, signal syscall.Signal, all bool) error {
 	if podID == "" {
 		return errNeedPodID
 	}
@@ -685,7 +686,7 @@ func KillContainer(podID, containerID string, signal syscall.Signal) error {
 	}
 
 	// Send a signal to the process.
-	err = c.kill(signal)
+	err = c.kill(signal, all)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -52,6 +52,9 @@ type ContainerConfig struct {
 	// RootFs is the container workload image on the host.
 	RootFs string
 
+	// ReadOnlyRootfs indicates if the rootfs should be mounted readonly
+	ReadonlyRootfs bool
+
 	// Cmd specifies the command to run on a container
 	Cmd Cmd
 
@@ -426,7 +429,7 @@ func (c *Container) stop() error {
 	}
 	defer c.pod.proxy.disconnect()
 
-	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGTERM)
+	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGTERM, true)
 	if err != nil {
 		return err
 	}
@@ -472,7 +475,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 	return process, nil
 }
 
-func (c *Container) kill(signal syscall.Signal) error {
+func (c *Container) kill(signal syscall.Signal, all bool) error {
 	state, err := c.fetchState("signal")
 	if err != nil {
 		return err
@@ -487,7 +490,7 @@ func (c *Container) kill(signal syscall.Signal) error {
 	}
 	defer c.pod.proxy.disconnect()
 
-	err = c.pod.agent.killContainer(*(c.pod), *c, signal)
+	err = c.pod.agent.killContainer(*(c.pod), *c, signal, all)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -61,6 +61,6 @@ func (n *noopAgent) stopContainer(pod Pod, c Container) error {
 }
 
 // killContainer is the Noop agent Container signaling implementation. It does nothing.
-func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal) error {
+func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -58,8 +58,9 @@ type FileCommand struct {
 // KillCommand is the structure corresponding to the format expected by
 // hyperstart to kill a container on the guest.
 type KillCommand struct {
-	Container string         `json:"container"`
-	Signal    syscall.Signal `json:"signal"`
+	Container    string         `json:"container"`
+	Signal       syscall.Signal `json:"signal"`
+	AllProcesses bool           `json:"allProcesses"`
 }
 
 // ExecCommand is the structure corresponding to the format expected by

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -191,6 +191,6 @@ func (s *sshd) stopContainer(pod Pod, c Container) error {
 }
 
 // killContainer is the agent Container signaling implementation for sshd.
-func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal) error {
+func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }


### PR DESCRIPTION
virtcontainers changes:

  725de4d api: Add 'all' parameter to KillContainer().
  b42fa98 tests: Add test to verify read-only bind mounts
  b51fd53 rootfs: Support mounting the rootfs as readonly

The change is required to fix #159. In fact the required update to
"kill.go" to make use of the new virtcontainers KillContainers() API
fixes #159, making "kill --all" functional.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>