### PR TITLE
cli: Implement "pause" and "resume" commands.

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,6 +97,8 @@ func main() {
 		execCommand,
 		killCommand,
 		listCommand,
+		pauseCommand,
+		resumeCommand,
 		runCommand,
 		startCommand,
 		stateCommand,

--- a/pause.go
+++ b/pause.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2014,2015,2016 Docker, Inc.
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var noteText = `Use "` + name + ` list" to identify container statuses.`
+
+var pauseCommand = cli.Command{
+	Name:  "pause",
+	Usage: "suspend all processes in a container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the container name to be paused.`,
+	Description: `The pause command suspends all processes in a container.
+
+	` + noteText,
+	Action: func(context *cli.Context) error {
+		return toggleContainerPause(context.Args().First(), true)
+	},
+}
+
+var resumeCommand = cli.Command{
+	Name:  "resume",
+	Usage: "unpause all previously paused processes in a container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the container name to be resumed.`,
+	Description: `The resume command unpauses all processes in a container.
+
+	` + noteText,
+	Action: func(context *cli.Context) error {
+		return toggleContainerPause(context.Args().First(), false)
+	},
+}
+
+func toggleContainerPause(containerID string, pause bool) error {
+	if containerID == "" {
+		return fmt.Errorf("Missing container ID")
+	}
+
+	signal := "SIGSTOP"
+	if pause == false {
+		signal = "SIGCONT"
+	}
+
+	return kill(containerID, signal, true)
+}


### PR DESCRIPTION
Add new commands "pause" and "resume" to allow all processes
in a container to be suspended and resumed (unpaused).

Fixes #99, #100.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>