### PR TITLE
cli: Implement "version" command.

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,13 +57,19 @@ func main() {
 
 	v := make([]string, 0, 3)
 	if version != "" {
-		v = append(v, "runtime  : "+version)
+		v = append(v, name+"  : "+version)
 	}
 	if commit != "" {
 		v = append(v, "   commit   : "+commit)
 	}
 	v = append(v, "   OCI specs: "+specs.Version)
 	app.Version = strings.Join(v, "\n")
+
+	// Override the default function to display version details to
+	// ensure the "--version" option and "version" command are identical.
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Println(c.App.Version)
+	}
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -100,6 +106,7 @@ func main() {
 		runCommand,
 		startCommand,
 		stateCommand,
+		versionCommand,
 	}
 
 	app.Before = func(context *cli.Context) error {
@@ -165,7 +172,7 @@ func userWantsUsage(context *cli.Context) bool {
 		return true
 	}
 
-	if context.NArg() == 1 && context.Args()[0] == "help" {
+	if context.NArg() == 1 && (context.Args()[0] == "help" || context.Args()[0] == "version") {
 		return true
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/urfave/cli"
+)
+
+var versionCommand = cli.Command{
+	Name:  "version",
+	Usage: "display version details",
+	Action: func(context *cli.Context) error {
+		cli.VersionPrinter(context)
+		return nil
+	},
+}


### PR DESCRIPTION
Added a new "version" command with the same output as "--version" for
parity with cc-oci-runtime and docker.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>