### PR TITLE
HTML code coverage report

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -11,7 +11,7 @@ echo Running go test on packages "'$test_packages'" with flags "'$go_test_flags'
 function test_html_coverage
 {
 	test_coverage
-	go tool cover -html=profile.cov
+	go tool cover -html=profile.cov -o coverage.html
 	rm -f profile.cov
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /cc-runtime
+/coverage.html

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONFIG = configuration.toml
 $(TARGET): $(SOURCES) Makefile
 	go build -i -ldflags "-X main.commit=${COMMIT} -X main.version=${VERSION}" -o $@ .
 
-.PHONY: check check-go-static
+.PHONY: check check-go-static check-go-test
 check: check-go-static check-go-test
 
 check-go-test:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONFIG = configuration.toml
 $(TARGET): $(SOURCES) Makefile
 	go build -i -ldflags "-X main.commit=${COMMIT} -X main.version=${VERSION}" -o $@ .
 
-.PHONY: check check-go-static check-go-test
+.PHONY: check check-go-static check-go-test coverage
 check: check-go-static check-go-test
 
 check-go-test:
@@ -23,6 +23,9 @@ check-go-test:
 
 check-go-static:
 	.ci/go-static-checks.sh $(GO_STATIC_CHECKS_ARGS)
+
+coverage:
+	.ci/go-test.sh html-coverage
 
 install:
 	$(QUIET_INST)install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)


### PR DESCRIPTION
Unfortunately, this is a bit awkward because one needs to be root to run the tests at the moment.
    
With an xhost + and run as root though, make coverage does open a browser with the coverage report.
