### PR TITLE
tests: Produce a coverage file with atomic mode

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -17,7 +17,7 @@ function test_html_coverage
 
 function test_coverage
 {
-	echo "mode: count" > profile.cov
+	echo "mode: atomic" > profile.cov
 
 	for pkg in $test_packages; do
 		go test $go_test_flags -covermode=atomic -coverprofile=profile_tmp.cov $pkg


### PR DESCRIPTION
We're actually using the atomic counters when running our tests because
we run them with -race (2 lines later). We should set the mode of the
resulting coverage file to match this.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>