### PR TITLE
ci: Add scripts to run cc tests

### DIFF
--- a/.ci/install_cc_runtime.sh
+++ b/.ci/install_cc_runtime.sh
@@ -57,6 +57,8 @@ bash .ci/install_cc_shim.sh
 
 bash .ci/install_virtcontainers.sh
 
+bash .ci/install_cc_tests.sh
+
 popd
 
 echo "Start cc-proxy service"

--- a/.ci/install_cc_tests.sh
+++ b/.ci/install_cc_tests.sh
@@ -1,0 +1,21 @@
+# Copyright (c) 2017 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/bin/bash
+
+set -e
+
+echo "Retrieve cc-tests repository"
+go get -d github.com/clearcontainers/tests


### PR DESCRIPTION
This will install the cc-test repository as well as all the
dependencies for the functional tests.

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>