### PR TITLE
run: runtime should forward container exit code to the system

### DIFF
--- a/run.go
+++ b/run.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/containers/virtcontainers/pkg/oci"
 	"github.com/docker/docker/pkg/term"
@@ -146,6 +147,9 @@ func run(context *cli.Context) error {
 		// close and restore console
 		console.Close()
 		term.RestoreTerminal(os.Stdin.Fd(), consoleState)
+
+		//runtime should forward container exit code to the system
+		return cli.NewExitError("", ps.Sys().(syscall.WaitStatus).ExitStatus())
 	}
 
 	return nil


### PR DESCRIPTION
running in attach mode runtime should wait for the shim and
forward its exit code to the system

fixes #202

Signed-off-by: Julio Montes <julio.montes@intel.com>