### PR TITLE
run: do not duplicate stdio if it is not a terminal

### DIFF
--- a/console.go
+++ b/console.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -34,6 +35,13 @@ type Console struct {
 
 	master    *os.File
 	slavePath string
+}
+
+// isTerminal returns true if fd is a terminal, else false
+func isTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TCGETS, uintptr(unsafe.Pointer(&termios)))
+	return err == 0
 }
 
 // ConsoleFromFile creates a console from a file

--- a/console_test.go
+++ b/console_test.go
@@ -42,3 +42,21 @@ func TestNewConsole(t *testing.T) {
 		t.Fatalf("console file is nil")
 	}
 }
+
+func TestIsTerminal(t *testing.T) {
+	var fd uintptr = 4
+	if isTerminal(fd) {
+		t.Fatalf("Fd %d is not a terminal", fd)
+	}
+
+	console, err := newConsole()
+	if err != nil {
+		t.Fatalf("failed to create a new console: %s", err)
+	}
+	defer console.Close()
+
+	fd = console.File().Fd()
+	if !isTerminal(fd) {
+		t.Fatalf("Fd %d is a terminal", fd)
+	}
+}


### PR DESCRIPTION
running containers under ginkgo or go test was causing issues
trying to duplicate stdio. with this patch stdio will be
duplicated only if stdio is a terminal

fixes #208

Signed-off-by: Julio Montes <julio.montes@intel.com>