### PR TITLE
Add CI scripts that SemaphoreCI will use in its project settings

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will execute the Clear Containers Test Suite. 
+
+set -e
+
+# Current docker tests:
+# TODO: Move these docker commands to more formal tests in 
+# `clearcontainers/tests` repository. See issue: 
+# https://github.com/clearcontainers/tests/issues/59
+container_id=$(sudo docker create busybox /bin/sleep 60)
+sudo docker ps -a
+sudo docker start ${container_id}
+sudo docker ps -a
+sudo docker exec ${container_id} echo hello
+sudo docker ps -a
+sudo docker stop ${container_id}
+sudo docker ps -a
+sudo docker rm ${container_id}
+sudo docker ps -a
+
+# Execute the tests under `clearcontainers/tests` repository.
+test_repo="github.com/clearcontainers/tests"
+cd "${GOPATH}/src/${test_repo}"
+sudo -E PATH=$PATH make check

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will clone `clearcontainers/tests` repository and 
+# will use the CI scripts that live in that repository to create 
+# a proper environment (Installing dependencies and building the
+# components) to test the Clear Containers project 
+
+set -e
+
+test_repo="github.com/clearcontainers/tests"
+
+# Clone Tests repository.
+go get "$test_repo"
+
+# Setup environment and build components.
+cd "${GOPATH}/src/${test_repo}/"
+sudo -E PATH=$PATH bash .ci/setup.sh

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will get any execution log that may be useful for
+# debugging any issue related to Clear Containers and clean the
+# test environment.
+
+sudo cat /var/lib/clear-containers/runtime/runtime.log
+sudo cat /var/log/upstart/cc-proxy.log
+sudo cat /var/log/upstart/crio.log


### PR DESCRIPTION
Currently, we hardcoded the commands that SemaphoreCI will
execute for building and testing the project, but any change
requires modification via its web page and we cannot track
any change there.

Therefore, these three scripts will be called in the SemaphoreCI
settings and any change should be done to the scripts instead
of changing the settings.

`setup.sh` will be called in the Setup
`run.sh` will be called on Job 1
`teardown.sh` will be called on After Job

fixes #168

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>