### PR TITLE
cli: Add "cc-check" command.

### DIFF
--- a/cc-check.go
+++ b/cc-check.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+type kernelModule struct {
+	// description
+	desc string
+
+	// maps parameter names to values
+	parameters map[string]string
+}
+
+const (
+	moduleParamDir = "parameters"
+	cpuFlagsTag    = "flags"
+)
+
+// variables rather than consts to allow tests to modify them
+var (
+	sysModuleDir = "/sys/module"
+	modInfoCmd   = "modinfo"
+)
+
+// requiredCPUFlags maps a CPU flag value to search for and a
+// human-readable description of that value.
+var requiredCPUFlags = map[string]string{
+	"vmx":    "Virtualization support",
+	"lm":     "64Bit CPU",
+	"sse4_1": "SSE4.1",
+}
+
+// requiredCPUAttribs maps a CPU (non-CPU flag) attribute value to search for
+// and a human-readable description of that value.
+var requiredCPUAttribs = map[string]string{
+	"GenuineIntel": "Intel Architecture CPU",
+}
+
+// requiredKernelModules maps a required module name to a human-readable
+// description of the modules functionality and an optional list of
+// required module parameters.
+var requiredKernelModules = map[string]kernelModule{
+	"kvm": {
+		desc: "Kernel-based Virtual Machine",
+	},
+	"kvm_intel": {
+		desc: "Intel KVM",
+		parameters: map[string]string{
+			"nested":             "Y",
+			"unrestricted_guest": "Y",
+		},
+	},
+	"vhost": {
+		desc: "Host kernel accelerator for virtio",
+	},
+	"vhost_net": {
+		desc: "Host kernel accelerator for virtio network",
+	},
+}
+
+func getCPUInfo(cpuInfoFile string) (string, error) {
+	text, err := getFileContents(cpuInfoFile)
+	if err != nil {
+		return "", err
+	}
+
+	cpus := strings.SplitAfter(text, "\n\n")
+
+	if len(cpus) == 0 {
+		return "", fmt.Errorf("Cannot determine CPU details")
+	}
+
+	// return details of the first CPU only
+	return cpus[0], nil
+}
+
+func findAnchoredString(haystack, needle string) bool {
+	if haystack == "" || needle == "" {
+		return false
+	}
+
+	// Ensure the search string is anchored
+	pattern := regexp.MustCompile(`\b` + needle + `\b`)
+
+	matched := pattern.MatchString(haystack)
+
+	if matched {
+		return true
+	}
+
+	return false
+}
+
+func getCPUFlags(cpuinfo string) string {
+	for _, line := range strings.Split(cpuinfo, "\n") {
+		if strings.HasPrefix(line, cpuFlagsTag) {
+			fields := strings.Split(line, ":")
+			if len(fields) == 2 {
+				return strings.TrimSpace(fields[1])
+			}
+		}
+	}
+
+	return ""
+}
+
+func haveKernelModule(module string) bool {
+	// First, check to see if the module is already loaded
+	path := filepath.Join(sysModuleDir, module)
+	if fileExists(path) {
+		return true
+	}
+
+	// Now, check if the module is unloaded, but available
+	cmd := exec.Command(modInfoCmd, module)
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
+func checkCPU(tag, cpuinfo string, attribs map[string]string) error {
+	if cpuinfo == "" {
+		return fmt.Errorf("Need cpuinfo")
+	}
+
+	for attrib, desc := range attribs {
+		found := findAnchoredString(cpuinfo, attrib)
+		if found {
+			ccLog.Infof("Found CPU %v %q (%s)", tag, desc, attrib)
+		} else {
+			return fmt.Errorf("CPU does not have required %v: %q (%s)", tag, desc, attrib)
+		}
+	}
+
+	return nil
+}
+func checkCPUFlags(cpuflags string, required map[string]string) error {
+	return checkCPU("flag", cpuflags, required)
+}
+
+func checkCPUAttribs(cpuinfo string, attribs map[string]string) error {
+	return checkCPU("attribute", cpuinfo, attribs)
+}
+
+func checkKernelModules(modules map[string]kernelModule) error {
+	for module, details := range modules {
+		if !haveKernelModule(module) {
+			return fmt.Errorf("kernel module %q (%s) not found", module, details.desc)
+		}
+
+		ccLog.Infof("Found kernel module %q (%s)", details.desc, module)
+
+		for param, expected := range details.parameters {
+			path := filepath.Join(sysModuleDir, module, moduleParamDir, param)
+			value, err := getFileContents(path)
+			if err != nil {
+				return err
+			}
+
+			value = strings.TrimRight(value, "\n\r")
+
+			if value == expected {
+				ccLog.Infof("Kernel module %q parameter %q has correct value", details.desc, param)
+			} else {
+				return fmt.Errorf("kernel module %q parameter %q has value %q (expected %q)", details.desc, param, value, expected)
+			}
+		}
+	}
+
+	return nil
+}
+
+// hostIsClearContainersCapable determines if the system is capable of
+// running Clear Containers.
+func hostIsClearContainersCapable(cpuinfoFile string) error {
+	cpuinfo, err := getCPUInfo(cpuinfoFile)
+	if err != nil {
+		return err
+	}
+
+	if err = checkCPUAttribs(cpuinfo, requiredCPUAttribs); err != nil {
+		return err
+	}
+
+	cpuFlags := getCPUFlags(cpuinfo)
+	if cpuFlags == "" {
+		return fmt.Errorf("Cannot find CPU flags")
+	}
+
+	if err = checkCPUFlags(cpuFlags, requiredCPUFlags); err != nil {
+		return err
+	}
+
+	if err = checkKernelModules(requiredKernelModules); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var ccCheckCommand = cli.Command{
+	Name:  "cc-check",
+	Usage: "tests if system can run " + project,
+	Action: func(context *cli.Context) error {
+		err := hostIsClearContainersCapable("/proc/cpuinfo")
+		if err != nil {
+			return fmt.Errorf("ERROR: %v", err)
+		}
+
+		ccLog.Info("")
+		ccLog.Info("System is capable of running " + project)
+
+		return nil
+	},
+}

--- a/cc-check_data_test.go
+++ b/cc-check_data_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"html/template"
+	"io/ioutil"
+)
+
+const testCPUInfoTemplate = `
+processor	: 0
+vendor_id	: {{.VendorID}}
+cpu family	: 6
+model		: 61
+model name	: Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz
+stepping	: 4
+microcode	: 0x25
+cpu MHz		: 1999.987
+cache size	: 4096 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 20
+wp		: yes
+flags		: {{.Flags}}
+bugs		:
+bogomips	: 5188.36
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: {{.VendorID}}
+cpu family	: 6
+model		: 61
+model name	: Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz
+stepping	: 4
+microcode	: 0x25
+cpu MHz		: 1999.987
+cache size	: 4096 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 20
+wp		: yes
+flags		: {{.Flags}}
+bugs		:
+bogomips	: 5194.90
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+`
+
+func makeCPUInfoFile(path, vendorID, flags string) error {
+	t := template.New("cpuinfo")
+
+	t, err := t.Parse(testCPUInfoTemplate)
+	if err != nil {
+		return err
+	}
+
+	args := map[string]string{
+		"Flags":    flags,
+		"VendorID": vendorID,
+	}
+
+	contents := &bytes.Buffer{}
+
+	err = t.Execute(contents, args)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, contents.Bytes(), testFileMode)
+}

--- a/cc-check_test.go
+++ b/cc-check_test.go
@@ -1,0 +1,448 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createFile(file, contents string) error {
+	return ioutil.WriteFile(file, []byte(contents), testFileMode)
+}
+
+func TestCheckGetCPUInfo(t *testing.T) {
+	type testData struct {
+		contents       string
+		expectedResult string
+	}
+
+	data := []testData{
+		{"", ""},
+		{" ", " "},
+		{"\n", "\n"},
+		{"\n\n", "\n\n"},
+		{"hello\n", "hello\n"},
+		{"hello\n\n", "hello\n\n"},
+		{"hello\n\nworld\n\n", "hello\n\n"},
+		{"foo\n\nbar\nbaz\n\n", "foo\n\n"},
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file := filepath.Join(dir, "cpuinfo")
+	// file doesn't exist
+	_, err = getCPUInfo(file)
+	assert.Error(t, err)
+
+	for _, d := range data {
+		err = ioutil.WriteFile(file, []byte(d.contents), testFileMode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file)
+
+		contents, err := getCPUInfo(file)
+		assert.NoError(t, err, "expected no error")
+
+		assert.Equal(t, d.expectedResult, contents)
+	}
+}
+
+func TestCheckFindAnchoredString(t *testing.T) {
+	type testData struct {
+		haystack      string
+		needle        string
+		expectSuccess bool
+	}
+
+	data := []testData{
+		{"", "", false},
+		{"", "foo", false},
+		{"foo", "", false},
+		{"food", "foo", false},
+		{"foo", "foo", true},
+		{"foo bar", "foo", true},
+		{"foo bar baz", "bar", true},
+	}
+
+	for _, d := range data {
+		result := findAnchoredString(d.haystack, d.needle)
+
+		if d.expectSuccess {
+			assert.True(t, result)
+		} else {
+			assert.False(t, result)
+		}
+	}
+}
+
+func TestCheckGetCPUFlags(t *testing.T) {
+	type testData struct {
+		cpuinfo       string
+		expectedFlags string
+	}
+
+	data := []testData{
+		{"", ""},
+		{"foo", ""},
+		{"foo bar", ""},
+		{":", ""},
+		{"flags", ""},
+		{"flags:", ""},
+		{"flags: a b c", "a b c"},
+		{"flags: a b c foo bar d", "a b c foo bar d"},
+	}
+
+	for _, d := range data {
+		result := getCPUFlags(d.cpuinfo)
+		assert.Equal(t, d.expectedFlags, result)
+	}
+}
+
+func TestCheckCheckCPUFlags(t *testing.T) {
+	type testData struct {
+		cpuflags    string
+		required    map[string]string
+		expectError bool
+	}
+
+	data := []testData{
+		{
+			"",
+			map[string]string{},
+			true,
+		},
+		{
+			"",
+			map[string]string{
+				"a": "A flag",
+			},
+			true,
+		},
+		{
+			"",
+			map[string]string{
+				"a": "A flag",
+				"b": "B flag",
+			},
+			true,
+		},
+		{
+			"a b c",
+			map[string]string{
+				"b": "B flag",
+			},
+			false,
+		},
+	}
+
+	for _, d := range data {
+		err := checkCPUFlags(d.cpuflags, d.required)
+		if d.expectError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestCheckCheckCPUAttribs(t *testing.T) {
+	type testData struct {
+		cpuinfo     string
+		required    map[string]string
+		expectError bool
+	}
+
+	data := []testData{
+		{
+			"",
+			map[string]string{},
+			true,
+		},
+		{
+			"",
+			map[string]string{
+				"a": "",
+			},
+			true,
+		},
+		{
+			"a: b",
+			map[string]string{
+				"b": "B attribute",
+			},
+			false,
+		},
+		{
+			"a: b\nc: d\ne: f",
+			map[string]string{
+				"b": "B attribute",
+			},
+			false,
+		},
+		{
+			"a: b\n",
+			map[string]string{
+				"b": "B attribute",
+				"c": "C attribute",
+				"d": "D attribute",
+			},
+			true,
+		},
+		{
+			"a: b\nc: d\ne: f",
+			map[string]string{
+				"b": "B attribute",
+				"d": "D attribute",
+				"f": "F attribute",
+			},
+			false,
+		},
+	}
+
+	for _, d := range data {
+		err := checkCPUAttribs(d.cpuinfo, d.required)
+		if d.expectError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestCheckHaveKernelModule(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	savedModInfoCmd := modInfoCmd
+	savedSysModuleDir := sysModuleDir
+
+	// XXX: override (fake the modprobe command failing)
+	modInfoCmd = "false"
+	sysModuleDir = filepath.Join(dir, "sys/module")
+
+	defer func() {
+		modInfoCmd = savedModInfoCmd
+		sysModuleDir = savedSysModuleDir
+	}()
+
+	err = os.MkdirAll(sysModuleDir, testDirMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	module := "foo"
+
+	result := haveKernelModule(module)
+	assert.False(t, result)
+
+	// XXX: override - make our fake "modprobe" succeed
+	modInfoCmd = "true"
+
+	result = haveKernelModule(module)
+	assert.True(t, result)
+
+	// disable "modprobe" again
+	modInfoCmd = "false"
+
+	fooDir := filepath.Join(sysModuleDir, module)
+	err = os.MkdirAll(fooDir, testDirMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result = haveKernelModule(module)
+	assert.True(t, result)
+}
+
+func TestCheckCheckKernelModules(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	savedModInfoCmd := modInfoCmd
+	savedSysModuleDir := sysModuleDir
+
+	// XXX: override (fake the modprobe command failing)
+	modInfoCmd = "false"
+	sysModuleDir = filepath.Join(dir, "sys/module")
+
+	defer func() {
+		modInfoCmd = savedModInfoCmd
+		sysModuleDir = savedSysModuleDir
+	}()
+
+	err = os.MkdirAll(sysModuleDir, testDirMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testData := map[string]kernelModule{
+		"foo": {
+			desc:       "desc",
+			parameters: map[string]string{},
+		},
+		"bar": {
+			desc: "desc",
+			parameters: map[string]string{
+				"param1": "hello",
+				"param2": "world",
+				"param3": "a",
+				"param4": ".",
+			},
+		},
+	}
+
+	err = checkKernelModules(map[string]kernelModule{})
+	// No required modules means no error
+	assert.NoError(t, err)
+
+	err = checkKernelModules(testData)
+	// No modules exist
+	assert.Error(t, err)
+
+	for module, details := range testData {
+		path := filepath.Join(sysModuleDir, module)
+		err = os.MkdirAll(path, testDirMode)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		paramDir := filepath.Join(path, "parameters")
+		err = os.MkdirAll(paramDir, testDirMode)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for param, value := range details.parameters {
+			paramPath := filepath.Join(paramDir, param)
+			err = createFile(paramPath, value)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	err = checkKernelModules(testData)
+	assert.NoError(t, err)
+}
+
+func TestCheckHostIsClearContainersCapable(t *testing.T) {
+	type testModuleData struct {
+		path     string
+		isDir    bool
+		contents string
+	}
+
+	type testCPUData struct {
+		vendorID    string
+		flags       string
+		expectError bool
+	}
+
+	cpuData := []testCPUData{
+		{"", "", true},
+		{"Intel", "", true},
+		{"GenuineIntel", "", true},
+		{"GenuineIntel", "lm", true},
+		{"GenuineIntel", "lm vmx", true},
+		{"GenuineIntel", "lm vmx sse4_1", false},
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file := filepath.Join(dir, "cpuinfo")
+
+	savedSysModuleDir := sysModuleDir
+
+	// XXX: override
+	sysModuleDir = filepath.Join(dir, "sys/module")
+
+	defer func() {
+		sysModuleDir = savedSysModuleDir
+	}()
+
+	err = os.MkdirAll(sysModuleDir, testDirMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	moduleData := []testModuleData{
+		{filepath.Join(sysModuleDir, "kvm"), true, ""},
+		{filepath.Join(sysModuleDir, "kvm_intel"), true, ""},
+		{filepath.Join(sysModuleDir, "kvm_intel/parameters/nested"), false, "Y"},
+		{filepath.Join(sysModuleDir, "kvm_intel/parameters/unrestricted_guest"), false, "Y"},
+	}
+
+	for _, d := range moduleData {
+		var dir string
+
+		if d.isDir {
+			dir = d.path
+		} else {
+			dir = path.Dir(d.path)
+		}
+
+		err = os.MkdirAll(dir, testDirMode)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !d.isDir {
+			err = createFile(d.path, d.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		err = hostIsClearContainersCapable(file)
+		// file doesn't exist
+		assert.Error(t, err)
+	}
+
+	// all the modules file have now been created, so deal with the
+	// cpuinfo data.
+
+	for _, d := range cpuData {
+		err = makeCPUInfoFile(file, d.vendorID, d.flags)
+		assert.NoError(t, err)
+
+		err = hostIsClearContainersCapable(file)
+		if d.expectError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,10 @@ import (
 )
 
 // name holds the name of this program
-const name = "cc-runtime"
+const (
+	name    = "cc-runtime"
+	project = "Intel® Clear Containers"
+)
 
 // version is the runtime version. It is be specified at compilation time (see
 // Makefile).
@@ -41,10 +44,17 @@ var commit = ""
 // specConfig is the name of the file holding the containers configuration
 const specConfig = "config.json"
 
-const usage = `Clear Containers runtime
+const usage = project + ` runtime
 
 cc-runtime is a command line program for running applications packaged
 according to the Open Container Initiative (OCI).`
+
+const notes = `
+NOTES:
+
+- Commands starting "cc-" and options starting "--cc-" are ` + project + ` extensions.
+
+`
 
 var defaultRootDirectory = "/run/clear-containers"
 
@@ -54,6 +64,8 @@ func main() {
 	app := cli.NewApp()
 	app.Name = name
 	app.Usage = usage
+
+	cli.AppHelpTemplate = fmt.Sprintf(`%s%s`, cli.AppHelpTemplate, notes)
 
 	v := make([]string, 0, 3)
 	if version != "" {
@@ -74,7 +86,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "cc-config",
-			Usage: "clear containers config file path",
+			Usage: project + " config file path",
 		},
 		cli.BoolFlag{
 			Name:  "debug",
@@ -98,6 +110,7 @@ func main() {
 	}
 
 	app.Commands = []cli.Command{
+		ccCheckCommand,
 		createCommand,
 		deleteCommand,
 		execCommand,
@@ -110,9 +123,11 @@ func main() {
 	}
 
 	app.Before = func(context *cli.Context) error {
-		if userWantsUsage(context) {
+		if userWantsUsage(context) || (context.NArg() == 1 && (context.Args()[0] == "cc-check")) {
 			// No setup required if the user just
-			// wants to see the usage statement.
+			// wants to see the usage statement or are
+			// running a command that does not manipulate
+			// containers.
 			return nil
 		}
 
@@ -197,12 +212,4 @@ type fatalWriter struct {
 func (f *fatalWriter) Write(p []byte) (n int, err error) {
 	ccLog.Error(string(p))
 	return f.cliErrWriter.Write(p)
-}
-
-func fileExists(path string) bool {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+func getFileContents(file string) (string, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileExists(t *testing.T) {
+	dir, err := ioutil.TempDir(testDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file := filepath.Join(dir, "foo")
+
+	assert.False(t, fileExists(file),
+		fmt.Sprintf("File %q should not exist", file))
+
+	err = createEmptyFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, fileExists(file),
+		fmt.Sprintf("File %q should exist", file))
+}
+
+func TestGetFileContents(t *testing.T) {
+	type testData struct {
+		contents string
+	}
+
+	data := []testData{
+		{""},
+		{" "},
+		{"\n"},
+		{"\n\n"},
+		{"\n\n\n"},
+		{"foo"},
+		{"foo\nbar"},
+		{"processor   : 0\nvendor_id   : GenuineIntel\n"},
+	}
+
+	dir, err := ioutil.TempDir(testDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file := filepath.Join(dir, "foo")
+
+	// file doesn't exist
+	_, err = getFileContents(file)
+	assert.Error(t, err)
+
+	for _, d := range data {
+		// create the file
+		err = ioutil.WriteFile(file, []byte(d.contents), testFileMode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file)
+
+		contents, err := getFileContents(file)
+		assert.NoError(t, err)
+		assert.Equal(t, contents, d.contents)
+	}
+}


### PR DESCRIPTION
This replaces the "clear-linux-check-config.sh" script by providing a
built-in way of determining if the host system is capable of running
Clear Containers.

Fixes #204.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
Signed-off-by: Gabriel Briones Sayeg <gabriel.briones.sayeg@intel.com>