### PR TITLE
create: runtime should not fail if pid file is missing

### DIFF
--- a/create.go
+++ b/create.go
@@ -214,7 +214,8 @@ func createCgroupsFiles(cgroupsPathList []string, pid int) error {
 
 func createPIDFile(pidFilePath string, pid int) error {
 	if pidFilePath == "" {
-		return fmt.Errorf("Missing PID file path")
+		// runtime should not fail since pid file is optional
+		return nil
 	}
 
 	if err := os.RemoveAll(pidFilePath); err != nil {

--- a/create_test.go
+++ b/create_test.go
@@ -89,9 +89,9 @@ func TestCreatePIDFileSuccessful(t *testing.T) {
 	os.RemoveAll(pidFilePath)
 }
 
-func TestCreatePIDFileEmptyPathFailure(t *testing.T) {
+func TestCreatePIDFileEmptyPathSuccessful(t *testing.T) {
 	file := ""
-	if err := createPIDFile(file, testPID); err == nil {
-		t.Fatalf("This test should fail (pidFilePath %q, pid %d)", file, testPID)
+	if err := createPIDFile(file, testPID); err != nil {
+		t.Fatalf("This test should not fail (pidFilePath %q, pid %d)", file, testPID)
 	}
 }


### PR DESCRIPTION
runtime should not fail if pid file is missing since it
is optional

fixes #212

Signed-off-by: Julio Montes <julio.montes@intel.com>