### PR TITLE
pullapprove: Don't require doc team sign-off for vendor docs.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -41,7 +41,10 @@ groups:
   documentation:
     conditions:
       files:
-        - "*.md"
+        include:
+          - "*.md"
+        exclude:
+          - "vendor/*"
     required: 1
     teams:
       - documentation


### PR DESCRIPTION
pullapprove was requiring PR sign-off from the documentation team for
documents changed under "vendor/" as a result of re-vendoring.

Change the pullapprove config to only consider document files directly
part of this project.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>