### PR TITLE
cli: Implement pause and resume commands.

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -28,6 +28,28 @@ sudo docker start ${container_id}
 sudo docker ps -a
 sudo docker exec ${container_id} echo hello
 sudo docker ps -a
+
+# try to unpause a container that isn't paused a few times
+for i in 1 2 3
+do
+	{ sudo docker unpause ${container_id}; ret=$?; } || true
+	[ $ret -eq 1 ]
+done
+
+sudo docker pause ${container_id}
+sudo docker inspect ${container_id}|grep -i "\"Paused\":.*true"
+
+# try to pause an already paused container a few times
+for i in 1 2 3
+do
+	{ sudo docker pause ${container_id}; ret=$?; } || true
+	[ $ret -eq 1 ]
+done
+
+sudo docker unpause ${container_id}
+sudo docker inspect ${container_id}|grep -i "\"Paused\":.*false"
+
+sudo docker ps -a
 sudo docker stop ${container_id}
 sudo docker ps -a
 sudo docker rm ${container_id}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,8 @@ func main() {
 		killCommand,
 		listCommand,
 		runCommand,
+		pauseCommand,
+		resumeCommand,
 		startCommand,
 		stateCommand,
 		versionCommand,

--- a/pause.go
+++ b/pause.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2014,2015,2016 Docker, Inc.
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	vc "github.com/containers/virtcontainers"
+	"github.com/urfave/cli"
+)
+
+var noteText = `Use "` + name + ` list" to identify container statuses.`
+
+var pauseCommand = cli.Command{
+	Name:  "pause",
+	Usage: "suspend all processes in a container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the container name to be paused.`,
+	Description: `The pause command suspends all processes in a container.
+
+	` + noteText,
+	Action: func(context *cli.Context) error {
+		return toggleContainerPause(context.Args().First(), true)
+	},
+}
+
+var resumeCommand = cli.Command{
+	Name:  "resume",
+	Usage: "unpause all previously paused processes in a container",
+	ArgsUsage: `<container-id>
+
+Where "<container-id>" is the container name to be resumed.`,
+	Description: `The resume command unpauses all processes in a container.
+
+	` + noteText,
+	Action: func(context *cli.Context) error {
+		return toggleContainerPause(context.Args().First(), false)
+	},
+}
+
+func toggleContainerPause(containerID string, pause bool) (err error) {
+	// Checks the MUST and MUST NOT from OCI runtime specification
+	_, podID, err := getExistingContainerInfo(containerID)
+	if err != nil {
+		return err
+	}
+
+	if pause {
+		_, err = vc.PausePod(podID)
+	} else {
+		_, err = vc.ResumePod(podID)
+	}
+
+	return err
+}


### PR DESCRIPTION
Add two new commands: "pause" and "resume". The first suspends all
processes in a container, whilst the second "unpauses" or resumes a
container, allowing all processes within it to continue executing.

Fixes #99, #100.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>