### PR TITLE
cc-check: Make the "/proc/cpuinfo" string a const.

### DIFF
--- a/cc-check.go
+++ b/cc-check.go
@@ -33,6 +33,7 @@ type kernelModule struct {
 }
 
 const (
+	procCPUInfo    = "/proc/cpuinfo"
 	moduleParamDir = "parameters"
 	cpuFlagsTag    = "flags"
 )
@@ -226,7 +227,7 @@ var ccCheckCommand = cli.Command{
 	Name:  "cc-check",
 	Usage: "tests if system can run " + project,
 	Action: func(context *cli.Context) error {
-		err := hostIsClearContainersCapable("/proc/cpuinfo")
+		err := hostIsClearContainersCapable(procCPUInfo)
 		if err != nil {
 			return fmt.Errorf("ERROR: %v", err)
 		}


### PR DESCRIPTION
It is better to define a const for this string since it's safer plus
it is placed near the top of the file for clarity.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>