### PR TITLE
build: Make the build more friendly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 TARGET = cc-runtime
 DESTDIR :=
 PREFIX := /usr/local

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+TARGET = cc-runtime
 DESTDIR :=
 PREFIX := /usr/local
 BINDIR := $(PREFIX)/bin
@@ -18,11 +19,29 @@ VERSION := ${shell cat ./VERSION}
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
-TARGET = cc-runtime
 CONFIG_FILE = configuration.toml
 CONFIG = config/$(CONFIG_FILE)
 CONFIG_IN = $(CONFIG).in
 
+DESTBINDIR := $(DESTDIR)/$(BINDIR)
+DESTTARGET := $(abspath $(DESTBINDIR)/$(TARGET))
+
+DESTCONFDIR := $(DESTDIR)/$(SYSCONFDIR)/$(CCDIR)
+DESTCONFIG := $(abspath $(DESTCONFDIR)/$(CONFIG_FILE))
+
+# list of variables the user may wish to override
+USER_VARS += DESTDIR
+USER_VARS += PREFIX
+USER_VARS += BINDIR
+USER_VARS += QEMUBINDIR
+USER_VARS += SYSCONFDIR
+USER_VARS += LIBEXECDIR
+USER_VARS += LOCALSTATEDIR
+USER_VARS += SHAREDIR
+USER_VARS += PKGDATADIR
+USER_VARS += PKGLIBEXECDIR
+USER_VARS += DESTTARGET
+USER_VARS += DESTCONFIG
 
 V            = @
 Q            = $(V:1=)
@@ -34,10 +53,18 @@ QUIET_INST   = $(Q:@=@echo    '     INSTALL '$@;)
 QUIET_TEST   = $(Q:@=@echo    '     TEST    '$@;)
 
 .DEFAULT: $(TARGET)
-$(TARGET): $(SOURCES) Makefile
+$(TARGET): $(SOURCES) Makefile show-summary
 	$(QUIET_BUILD)go build -i -ldflags "-X main.commit=${COMMIT} -X main.version=${VERSION} -X main.libExecDir=${LIBEXECDIR}" -o $@ .
 
-.PHONY: check check-go-static check-go-test coverage
+.PHONY: \
+	check \
+	check-go-static \
+	check-go-test \
+	coverage \
+	show-header \
+	show-summary \
+	show-variables
+
 $(TARGET).coverage: $(SOURCES) Makefile
 	$(QUIET_TEST)go test -o $@ -covermode count
 
@@ -66,8 +93,49 @@ coverage:
 	$(QUIET_TEST).ci/go-test.sh html-coverage
 
 install: $(TARGET) $(CONFIG)
-	$(QUIET_INST)install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
-	$(QUIET_INST)install -D $(CONFIG) $(DESTDIR)$(SYSCONFDIR)/$(CCDIR)/$(CONFIG_FILE)
+	$(QUIET_INST)install -D $(TARGET) $(DESTTARGET)
+	$(QUIET_INST)install -D $(CONFIG) $(DESTCONFIG)
 
 clean:
 	$(QUIET_CLEAN)rm -f $(TARGET) $(CONFIG)
+
+show-usage: show-header
+	@printf "• Overview:\n"
+	@printf "\n"
+	@printf "  To build $(TARGET), just run, \"make\".\n"
+	@printf "\n"
+	@printf "  For a verbose build, run \"make V=1\".\n"
+	@printf "\n"
+	@printf "• Additional targets:\n"
+	@printf "\n"
+	@printf "\tcheck           : run tests\n"
+	@printf "\tclean           : remove built files\n"
+	@printf "\tcoverage        : run coverage tests\n"
+	@printf "\tgenerate-config : create configuration file\n"
+	@printf "\tinstall         : install files\n"
+	@printf "\tshow-summary    : show install locations\n"
+	@printf "\n"
+
+handle_help: show-usage show-variables show-footer
+
+usage: handle_help
+help: handle_help
+
+show-variables:
+	@printf "• Variables affecting the build:\n\n"
+	@printf \
+          "$(sort $(foreach v,$(USER_VARS),\t$(v)=$(value $(v))\n))"
+	@printf "\n"
+
+show-header:
+	@printf "%s - version %s (commit %s)\n\n" $(TARGET) $(VERSION) $(COMMIT)
+
+show-footer:
+	@printf "• Project home: https://github.com/clearcontainers/runtime\n\n"
+
+show-summary: show-header
+	@printf "• Summary:\n"
+	@printf "\n"
+	@printf "  binary install path (DESTTARGET) : %s\n" $(DESTTARGET)
+	@printf "  config install path (DESTCONFIG) : %s\n" $(DESTCONFIG)
+	@printf "\n"


### PR DESCRIPTION
Added a new "make help" target which shows:

- overview.
- available targets.
- variables that users may wish to override.

Also, display a summary for a normal build showing the final destination
for the runtime binary and the configuration file.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>