### PR TITLE
kill: Don't return an error if container state is 'created'

### DIFF
--- a/kill.go
+++ b/kill.go
@@ -106,8 +106,11 @@ func kill(containerID, signal string, all bool) error {
 
 	containerID = status.ID
 
-	// container MUST be running
-	if status.State.State != vc.StateRunning {
+	// container MUST be created or running
+	if status.State.State == vc.StateReady {
+		ccLog.Infof("Container %s state 'created', nothing to do", containerID)
+		return nil
+	} else if status.State.State != vc.StateRunning {
 		return fmt.Errorf("Container %s is not running", containerID)
 	}
 


### PR DESCRIPTION
Regarding a recent update of the OCI specification, we don't want to generate an error when 'kill' command is called on a container which has been created but not started.

This is basically a no-op in our case.