### PR TITLE
list: Pods can contain more than one containers

### DIFF
--- a/list.go
+++ b/list.go
@@ -208,7 +208,7 @@ func getContainers(context *cli.Context) ([]fullContainerState, error) {
 	var s []fullContainerState
 
 	for _, pod := range podList {
-		if len(pod.ContainersStatus) != 1 {
+		if len(pod.ContainersStatus) == 0 {
 			// ignore empty pods
 			continue
 		}


### PR DESCRIPTION
Pods with more than 1 containers are not empty.

Fixes #248

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>