### PR TITLE
docs: Add installation guides for Ubuntu and Fedora

### DIFF
--- a/docs/fedora-installation-guide.md
+++ b/docs/fedora-installation-guide.md
@@ -1,0 +1,53 @@
+# Installing Clear Containers 3.0 Alpha on Fedora
+
+Clear Containers **3.0-alpha** is available for Fedora\* versions **24** and **25**.
+
+This step is only required in case Docker is not installed on the system.
+1. Install the latest version of Docker with the following commands:
+
+```
+$ sudo dnf -y install dnf-plugins-core
+$ sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+$ sudo dnf makecache fast
+$ sudo dnf install docker-ce
+```
+
+For more information on installing Docker please refer to the
+[Docker Guide](https://docs.docker.com/engine/installation/linux/fedora)
+
+2. Install the Clear Containers 3.0 components with the following commands:
+
+```
+$ source /etc/os-release
+$ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo \
+http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/Fedora\_$VERSION_ID/home:clearcontainers:clear-containers-3-staging.repo
+$ sudo dnf install cc-runtime cc-proxy cc-shim virtcontainers-pause
+```
+
+3.  Configure Docker to use Clear Containers by default with the following commands:
+
+```
+$ sudo mkdir -p /etc/systemd/system/docker.service.d/
+$ cat << EOF | sudo tee /etc/systemd/system/docker.service.d/clr-containers.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -D --add-runtime cc3=/usr/bin/cc-runtime --default-runtime=cc3
+EOF
+```
+
+4. Restart the Docker and Clear Containers systemd services with the following commands:
+
+```
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart docker
+$ sudo systemctl enable cc-proxy.socket
+$ sudo systemctl start cc-proxy.socket
+```
+
+5. Run Clear Containers 3.0.
+
+You are now ready to run Clear Containers 3.0. For example:
+
+```
+$ sudo docker run -ti fedora bash
+```

--- a/docs/ubuntu-installation-guide.md
+++ b/docs/ubuntu-installation-guide.md
@@ -1,0 +1,61 @@
+# Installing Clear Containers 3.0 Alpha on Ubuntu
+
+Clear Containers **3.0-alpha** is available for Ubuntu\* **16.04**.
+
+This step is only required in case Docker is not installed on the system.
+1. Install the latest version of Docker with the following commands:
+
+```
+$ sudo apt-get install \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	software-properties-common
+$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+$ sudo add-apt-repository \
+	"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+	$(lsb_release -cs) \
+	stable"
+$ sudo apt-get update
+$ sudo apt-get install docker-ce
+```
+
+For more information on installing Docker please refer to the
+[Docker Guide](https://docs.docker.com/engine/installation/linux/ubuntu)
+
+2. Install the Clear Containers 3.0 components with the following commands:
+
+```
+$ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/cc-runtime.list"
+$ curl -fsSL http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/xUbuntu_16.04/Release.key | sudo apt-key add -
+$ sudo apt-get update
+$ sudo apt-get install -y cc-runtime cc-proxy cc-shim virtcontainers-pause
+```
+
+3. Configure Docker to use Clear Containers as the default with the following commands:
+
+```
+$ sudo mkdir -p /etc/systemd/system/docker.service.d/
+$ cat << EOF | sudo tee /etc/systemd/system/docker.service.d/clr-containers.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -D --add-runtime cc3=/usr/bin/cc-runtime --default-runtime=cc3
+EOF
+```
+
+4. Restart the Docker and Clear Containers systemd services with the following commands:
+
+```
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart docker
+$ sudo systemctl enable cc-proxy.socket
+$ sudo systemctl start cc-proxy.socket
+```
+
+5. Run Clear Containers 3.0.
+
+You are now ready to run Clear Containers 3.0. For example:
+
+```
+$ sudo docker run -ti fedora bash
+```


### PR DESCRIPTION
This documentation guides you through the steps needed to run
Clear Containers 3.0 by installing the available packages from
OBS.

Fixes #241

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>