### PR TITLE
gitignore: Add generated config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /cc-runtime
 /coverage.html
+/config-generated.go
+/config/configuration.toml


### PR DESCRIPTION
We don't want to stage and commit those generated config files by mistake. Then let's add them to .gitignore file.