### PR TITLE
tests: Bring utils.go test coverage back to 100%.

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -324,3 +324,36 @@ func TestUtilsResolvePathValidPath(t *testing.T) {
 
 	assert.Equal(t, resolvedTarget, resolvedLink)
 }
+
+func TestUtilsResolvePathENOENT(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := path.Join(dir, "target")
+	linkDir := path.Join(dir, "a/b/c")
+	linkFile := path.Join(linkDir, "link")
+
+	err = createEmptyFile(target)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(linkDir, testDirMode)
+	assert.NoError(t, err)
+
+	err = syscall.Symlink(target, linkFile)
+	assert.NoError(t, err)
+
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(cwd)
+
+	err = os.Chdir(dir)
+	assert.NoError(t, err)
+
+	err = os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	_, err = resolvePath(filepath.Base(linkFile))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
#253 inadvertently removed an os.Chdir test in TestRuntimeConfig() that
was exercising resolvePath().

Add a new test in the correct place to handle this scenario.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>