### PR TITLE
kill: Allow 'created' to 'stopped' state transition

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,9 +44,10 @@
   revision = "5bbff37294de9dfb33771dac6f53411c88abe62a"
 
 [[projects]]
+  branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "0693a2623cc78adb32f0c01df5ddfe02acd07b6c"
+  revision = "b56b3061518374e9da2790a307a11717bec34a6f"
 
 [[projects]]
   branch = "master"
@@ -129,6 +130,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "761e78b757f867c879c3d53d290e3348e0cdfd27225734143e32c498d5c4fb3b"
+  inputs-digest = "3973113a570424c393905976a8660f2fadd54be00a28242f1f0ecf9178fa7bcf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,6 +96,10 @@
 
 [[constraint]]
   branch = "master"
+  name = "github.com/containers/virtcontainers"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/davecgh/go-spew"
 
 [[constraint]]

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -1152,7 +1152,7 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 	}
 }
 
-func TestStopContainerFailingContNotStarted(t *testing.T) {
+func TestStopContainerFromContReadySuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
@@ -1177,7 +1177,7 @@ func TestStopContainerFailingContNotStarted(t *testing.T) {
 	}
 
 	c, err = StopContainer(p.id, contID)
-	if c != nil || err == nil {
+	if err != nil {
 		t.Fatal()
 	}
 }

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -458,6 +458,17 @@ func (c *Container) stop() error {
 		return err
 	}
 
+	// In case our container is "ready", there is no point in trying to
+	// stop it because nothing has been started. However, this is a valid
+	// case and we handle this by updating the container state only.
+	if state.State == StateReady {
+		if err := state.validTransition(StateReady, StateStopped); err != nil {
+			return err
+		}
+
+		return c.setContainerState(StateStopped)
+	}
+
 	if state.State != StateRunning {
 		return fmt.Errorf("Container not running, impossible to stop")
 	}

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -80,7 +80,7 @@ func (state *State) validTransition(oldState stateString, newState stateString) 
 
 	switch state.State {
 	case StateReady:
-		if newState == StateRunning {
+		if newState == StateRunning || newState == StateStopped {
 			return nil
 		}
 

--- a/vendor/github.com/containers/virtcontainers/pod_test.go
+++ b/vendor/github.com/containers/virtcontainers/pod_test.go
@@ -152,8 +152,8 @@ func TestPodStateRunningStopped(t *testing.T) {
 
 func TestPodStateReadyPaused(t *testing.T) {
 	err := testPodStateTransition(t, StateReady, StateStopped)
-	if err == nil {
-		t.Fatal("Invalid transition from Ready to Paused")
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
In case the container was created but not running, we were doing
nothing. This patch goes one step further by allowing the update
of the container state when the signal intends to terminate this
container, i.e SIGKILL or SIGTERM.