### PR TITLE
build: Ensure user doesn't run "go build".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /config/configuration.toml
 /pause/pause
 /pause/pause.o
+/error-run-make-not-go-build.go

--- a/error-run-make-not-go-build.go
+++ b/error-run-make-not-go-build.go
@@ -1,0 +1,10 @@
+package main
+
+// XXX: This file is a sign that you should not run "go build" directly.
+//
+// XXX: Please just run 'make'.
+
+import (
+	"ERROR: use 'go get -d' rather than 'go get'"
+	"ERROR: use 'make' rather than 'go build'"
+)


### PR DESCRIPTION
The project must be built using "make", so enforce it.

Fixes #271.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>