### PR TITLE
build: Add containers/virtcontainers pause binary

### DIFF
--- a/.ci/go-static-checks.sh
+++ b/.ci/go-static-checks.sh
@@ -79,7 +79,7 @@ go vet $go_packages
 
 cmd="gofmt -s -d -l"
 echo "Running gofmt..."
-diff=$(find . -not -wholename '*/vendor/*' -name '*.go' | \
+diff=$(find . -not -wholename '*/vendor/*' -name '*.go' -name './pause/*'| \
 	xargs $cmd)
 if [ -n "$diff" -a $(echo "$diff" | wc -l) -ne 0 ]
 then

--- a/docs/developers-clear-containers-install.md
+++ b/docs/developers-clear-containers-install.md
@@ -9,13 +9,13 @@ process.
 
   * [go 1.8.3](https://golang.org/)
   * [glibc-static](https://www.gnu.org/software/libc/libc.html)
+  * [gcc](https://gcc.gnu.org/)
 
 ## Clear Containers 3.0 components
 
   * [Runtime](https://github.com/clearcontainers/runtime)
   * [Proxy](https://github.com/clearcontainers/proxy)
   * [Shim](https://github.com/clearcontainers/shim)
-  * [Virtcontainers](https://github.com/containers/virtcontainers)
 
 **IMPORTANT:** Do not combine [Clear Containers 2.1](https://github.com/01org/cc-oci-runtime) and [Clear Containers 3.0](https://github.com/clearcontainers).
 Both projects ship ``cc-proxy`` and they are not compatible with each other.
@@ -73,20 +73,6 @@ For more details on the runtime's build system, run:
 
 ```bash
 $ make help
-```
-
-4. Virtcontainers
-
-This step will only install the ``pause`` binary included in [https://github.com/containers/virtcontainers](https://github.com/containers/virtcontainers)
-
-The ``pause`` binary is required to allow the creation of an "empty" pod.
-The pod does not contain any containers; it simply provides the environment
-to allow their creation.
-
-```bash
-$ sudo yum install -y glibc-static
-$ cd $GOPATH/src/github.com/clearcontainers/runtime/.ci/
-$ ./install_virtcontainers.sh
 ```
 
 ## Enable Clear Containers 3.0 for Docker

--- a/pause/README.md
+++ b/pause/README.md
@@ -1,0 +1,9 @@
+## Virtcontainers' pause binary
+
+This directory provides the ``pause`` binary included in [https://github.com/containers/virtcontainers](https://github.com/containers/virtcontainers)
+
+The ``pause`` binary is required to allow the creation of an "empty" pod.
+The pod does not contain any containers; it simply provides the environment
+to allow their creation.
+
+The build step for this file is included in the top-level Makefile.

--- a/pause/pause.c
+++ b/pause/pause.c
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void sigdown(int signo) {
+	psignal(signo, "shutting down, got signal");
+	exit(0);
+}
+
+int main() {
+	if (signal(SIGINT, sigdown) == SIG_ERR)
+		return 1;
+	if (signal(SIGTERM, sigdown) == SIG_ERR)
+		return 2;
+	for (;;) pause();
+	fprintf(stderr, "error: infinite loop terminated\n");
+	return 42;
+}


### PR DESCRIPTION
This commit adds the pause.c source file which provides
the "pause" binary.
- The build/install/clean rules were added to the top-level
Makefile.
- Instructions to the developers' documentation were modified.
- An exception to the ci static checks was added.

Fixes https://github.com/clearcontainers/runtime/issues/277

