### PR TITLE
config: Remove unused variable.

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,9 +34,8 @@ const (
 )
 
 const (
-	qemuLite   = "qemu-lite"
-	qemu       = "qemu"
-	shimBinary = "cc-shim"
+	qemuLite = "qemu-lite"
+	qemu     = "qemu"
 )
 
 const (


### PR DESCRIPTION
The "shimBinary" isn't used any longer.

Fixes #286.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>