### PR TITLE
docs: No need to install the virtcontainers pause package

### DIFF
--- a/docs/fedora-installation-guide.md
+++ b/docs/fedora-installation-guide.md
@@ -21,7 +21,7 @@ For more information on installing Docker please refer to the
 $ source /etc/os-release
 $ sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo \
 http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/Fedora\_$VERSION_ID/home:clearcontainers:clear-containers-3-staging.repo
-$ sudo dnf install cc-runtime cc-proxy cc-shim virtcontainers-pause
+$ sudo dnf install cc-runtime cc-proxy cc-shim
 ```
 
 3.  Configure Docker to use Clear Containers by default with the following commands:

--- a/docs/ubuntu-installation-guide.md
+++ b/docs/ubuntu-installation-guide.md
@@ -29,7 +29,7 @@ For more information on installing Docker please refer to the
 $ sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/cc-runtime.list"
 $ curl -fsSL http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/xUbuntu_16.04/Release.key | sudo apt-key add -
 $ sudo apt-get update
-$ sudo apt-get install -y cc-runtime cc-proxy cc-shim virtcontainers-pause
+$ sudo apt-get install -y cc-runtime cc-proxy cc-shim
 ```
 
 3. Configure Docker to use Clear Containers as the default with the following commands:


### PR DESCRIPTION
The pause binary is now part of cc-runtime-bin.

Fixes #290

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>