### PR TITLE
list: Rename option "--all" to "--cc-all".

### DIFF
--- a/list.go
+++ b/list.go
@@ -104,8 +104,8 @@ To list containers created using a non-default value for "--root":
 			Usage: "display only container IDs",
 		},
 		cli.BoolFlag{
-			Name:  "all, a",
-			Usage: "display all available information",
+			Name:  "cc-all",
+			Usage: "display all available " + project + " information",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -115,7 +115,7 @@ To list containers created using a non-default value for "--root":
 		}
 
 		file := os.Stdout
-		showAll := context.Bool("all")
+		showAll := context.Bool("cc-all")
 
 		if context.Bool("quiet") {
 			return (&formatIDList{}).Write(s, showAll, file)


### PR DESCRIPTION
The list command currently provided a "--all" option, but it should be
called "--cc-all" for consistency with the other extensions.

Also, improve the description of the option and drop the "-a" short-form
(since short options cannot be made Clear Containers specific).

Fixes #295.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>