### PR TITLE
gitignore: Ignore generated files in the pause directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /coverage.html
 /config-generated.go
 /config/configuration.toml
+/pause/pause
+/pause/pause.o


### PR DESCRIPTION
pause/pause and pause/pause.o are generated files that we should
ignore.

Fixes #309