### PR TITLE
.ci: Increase go test timeout to prevent from false negative tests

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -4,7 +4,7 @@ script_dir=$(cd `dirname $0`; pwd)
 root_dir=`dirname $script_dir`
 
 test_packages="."
-go_test_flags="-v -race -timeout 2s"
+go_test_flags="-v -race -timeout 5s"
 
 echo Running go test on packages "'$test_packages'" with flags "'$go_test_flags'"
 


### PR DESCRIPTION
Because travis CI can be slow sometimes, the tests can be inconsistent
and fail after a 2 seconds timeout. In order to avoid those behaviors,
this patch increase the timeout from 2 to 5 seconds.

Fixes #312