### PR TITLE
.ci: Fix find flag in go-static-checks.sh

### DIFF
--- a/.ci/go-static-checks.sh
+++ b/.ci/go-static-checks.sh
@@ -81,7 +81,7 @@ go vet $go_packages
 
 cmd="gofmt -s -d -l"
 echo "Running gofmt..."
-diff=$(find . -not -wholename '*/vendor/*' -name '*.go' -name './pause/*'| \
+diff=$(find . -not -wholename '*/vendor/*' -name '*.go' -wholename './pause/*' | \
 	xargs $cmd)
 if [ -n "$diff" -a $(echo "$diff" | wc -l) -ne 0 ]
 then


### PR DESCRIPTION
This patch fix the find flag in go-static-checks.sh in order to
not include any file under ./pause/.

This was causing a warning when running the gofmt.

Fixes #313