### PR TITLE
console: Don't link the shell to the shim if detach and tty are enabled

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "e01ebd015f77b3e822b597088e6efc102a7e6d9a"
+  revision = "cfe8504aee2d22812dba5d8de17e545359c4a2fa"
 
 [[projects]]
   branch = "master"

--- a/create.go
+++ b/create.go
@@ -175,7 +175,7 @@ func createPod(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 		}
 	}
 
-	podConfig, err := oci.PodConfig(ociSpec, runtimeConfig, bundlePath, containerID, console)
+	podConfig, err := oci.PodConfig(ociSpec, runtimeConfig, bundlePath, containerID, console, true)
 	if err != nil {
 		return vc.Process{}, err
 	}
@@ -196,7 +196,7 @@ func createPod(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 	console string) (vc.Process, error) {
 
-	contConfig, err := oci.ContainerConfig(ociSpec, bundlePath, containerID, console)
+	contConfig, err := oci.ContainerConfig(ociSpec, bundlePath, containerID, console, true)
 	if err != nil {
 		return vc.Process{}, err
 	}

--- a/exec.go
+++ b/exec.go
@@ -240,6 +240,7 @@ func execute(context *cli.Context) error {
 		User:        params.ociProcess.User.Username,
 		Interactive: params.ociProcess.Terminal,
 		Console:     consolePath,
+		Detach:      noNeedForOutput(params.detach, params.ociProcess.Terminal),
 	}
 
 	_, _, process, err := vc.EnterContainer(podID, params.cID, cmd)

--- a/oci.go
+++ b/oci.go
@@ -350,3 +350,15 @@ func setupConsole(consolePath, consoleSockPath string) (string, error) {
 
 	return console.slavePath, nil
 }
+
+func noNeedForOutput(detach bool, tty bool) bool {
+	if !detach {
+		return false
+	}
+
+	if !tty {
+		return false
+	}
+
+	return true
+}

--- a/oci_test.go
+++ b/oci_test.go
@@ -313,3 +313,26 @@ func TestSetupConsoleNotExistingSocketPathFailure(t *testing.T) {
 		t.Fatalf("This test should fail because the console socket path does not exist")
 	}
 }
+
+func testNoNeedForOutput(t *testing.T, detach bool, tty bool, expected bool) {
+	result := noNeedForOutput(detach, tty)
+	if result != expected {
+		t.Fatalf("Expecting %t, Got %t", expected, result)
+	}
+}
+
+func TestNoNeedForOutputDetachTrueTtyTrue(t *testing.T) {
+	testNoNeedForOutput(t, true, true, true)
+}
+
+func TestNoNeedForOutputDetachFalseTtyTrue(t *testing.T) {
+	testNoNeedForOutput(t, false, true, false)
+}
+
+func TestNoNeedForOutputDetachFalseTtyFalse(t *testing.T) {
+	testNoNeedForOutput(t, false, false, false)
+}
+
+func TestNoNeedForOutputDetachTrueTtyFalse(t *testing.T) {
+	testNoNeedForOutput(t, true, false, false)
+}

--- a/run.go
+++ b/run.go
@@ -86,7 +86,7 @@ func run(containerID, bundle, console, consoleSocket, pidFile string, detach boo
 		return err
 	}
 
-	if err := create(containerID, bundle, consolePath, pidFile, runtimeConfig); err != nil {
+	if err := create(containerID, bundle, consolePath, pidFile, detach, runtimeConfig); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/containers/virtcontainers/.pullapprove.yml
+++ b/vendor/github.com/containers/virtcontainers/.pullapprove.yml
@@ -39,10 +39,14 @@ groups:
   approvers:
     required: 1
     users:
+      - dlespiau
       - sameo
       - sboeuf
+      - amshinde
 
   reviewers:
     required: 1
     teams:
       - virtcontainers-maintainers
+    users:
+      - amshinde

--- a/vendor/github.com/containers/virtcontainers/Makefile
+++ b/vendor/github.com/containers/virtcontainers/Makefile
@@ -49,10 +49,10 @@ binaries: virtc pause hook shim
 check: check-go-static check-go-test
 
 check-go-static:
-	.ci/go-lint.sh
+	bash .ci/go-lint.sh
 
 check-go-test:
-	.ci/go-test.sh \
+	bash .ci/go-test.sh \
 		$(TEST_BIN_DIR)/$(SHIM_BIN) \
 		$(TEST_BIN_DIR)/$(HOOK_BIN)
 

--- a/vendor/github.com/containers/virtcontainers/OWNERS
+++ b/vendor/github.com/containers/virtcontainers/OWNERS
@@ -2,5 +2,6 @@ reviewers:
 - virtcontainers-maintainers
 
 approvers:
+- dlespiau
 - sameo
 - sboeuf

--- a/vendor/github.com/containers/virtcontainers/cc_shim.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim.go
@@ -61,9 +61,11 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 	cmd := exec.Command(config.Path, "-t", params.Token, "-u", params.URL)
 	cmd.Env = os.Environ()
 
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if !params.Detach {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 
 	var f *os.File
 	var err error

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -191,7 +191,7 @@ func (c *Container) startShim() error {
 		return err
 	}
 
-	process, err := c.createShimProcess(proxyInfo.Token, url, c.config.Cmd.Console)
+	process, err := c.createShimProcess(proxyInfo.Token, url, c.config.Cmd)
 	if err != nil {
 		return err
 	}
@@ -537,7 +537,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 	}
 	defer c.pod.proxy.disconnect()
 
-	process, err := c.createShimProcess(proxyInfo.Token, url, cmd.Console)
+	process, err := c.createShimProcess(proxyInfo.Token, url, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func (c *Container) kill(signal syscall.Signal, all bool) error {
 	return nil
 }
 
-func (c *Container) createShimProcess(token, url, console string) (*Process, error) {
+func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, error) {
 	if c.pod.state.URL != url {
 		return &Process{}, fmt.Errorf("Pod URL %s and URL from proxy %s MUST be identical", c.pod.state.URL, url)
 	}
@@ -580,7 +580,8 @@ func (c *Container) createShimProcess(token, url, console string) (*Process, err
 	shimParams := ShimParams{
 		Token:   token,
 		URL:     url,
-		Console: console,
+		Console: cmd.Console,
+		Detach:  cmd.Detach,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -164,6 +164,8 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 	return true, nil
 }
 
+// AddKernelParam allows the addition of new kernel parameters to an existing
+// hypervisor configuration.
 func (conf *HypervisorConfig) AddKernelParam(p Param) error {
 	if p.Key == "" {
 		return fmt.Errorf("Empty kernel parameter")

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -102,6 +102,8 @@ type RuntimeConfig struct {
 	Console string
 }
 
+// AddKernelParam allows the addition of new kernel parameters to an existing
+// hypervisor configuration stored inside the current runtime configuration.
 func (config *RuntimeConfig) AddKernelParam(p vc.Param) error {
 	return config.HypervisorConfig.AddKernelParam(p)
 }
@@ -286,8 +288,8 @@ func (spec *CompatOCISpec) PodID() (string, error) {
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, console string) (vc.PodConfig, error) {
-	containerConfig, err := ContainerConfig(ocispec, bundlePath, cid, console)
+func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, console string, detach bool) (vc.PodConfig, error) {
+	containerConfig, err := ContainerConfig(ocispec, bundlePath, cid, console, detach)
 	if err != nil {
 		return vc.PodConfig{}, err
 	}
@@ -334,7 +336,7 @@ func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, co
 
 // ContainerConfig converts an OCI compatible runtime configuration
 // file to a virtcontainers container configuration structure.
-func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string) (vc.ContainerConfig, error) {
+func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, detach bool) (vc.ContainerConfig, error) {
 	configPath := getConfigPath(bundlePath)
 
 	rootfs := ocispec.Root.Path
@@ -351,6 +353,7 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string) (vc
 		PrimaryGroup: strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
 		Interactive:  ocispec.Process.Terminal,
 		Console:      console,
+		Detach:       detach,
 	}
 
 	cmd.SupplementaryGroups = []string{}

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -147,7 +147,7 @@ func TestMinimalPodConfig(t *testing.T) {
 		t.Fatalf("Could not parse config.json: %v", err)
 	}
 
-	podConfig, err := PodConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath)
+	podConfig, err := PodConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath, false)
 	if err != nil {
 		t.Fatalf("Could not create Pod configuration %v", err)
 	}

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -259,6 +259,7 @@ type Cmd struct {
 
 	Interactive bool
 	Console     string
+	Detach      bool
 }
 
 // Resources describes VM resources configuration.
@@ -730,6 +731,7 @@ func (p *Pod) startShims() error {
 			Token:   proxyInfos[idx].Token,
 			URL:     url,
 			Console: p.containers[idx].config.Cmd.Console,
+			Detach:  p.containers[idx].config.Cmd.Detach,
 		}
 
 		pid, err := p.shim.start(*p, shimParams)

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -40,6 +40,7 @@ type ShimParams struct {
 	Token   string
 	URL     string
 	Console string
+	Detach  bool
 }
 
 // Set sets a shim type based on the input string.


### PR DESCRIPTION
In case our runtime is used in standalone mode with the --detach
and tty flags enabled, we should not get any output on the current
shell. We should still be able to get some outputs if a console has
been provided though.

This patch relies on the latest virtcontainers vendoring to be
able to indicate if we are in case of a detached command or not.

Fixes #326