### PR TITLE
config: Set Q35 as the default machine type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ IMAGEPATH := $(PKGDATADIR)/clear-containers.img
 ifeq (,$(filter-out centos rhel,$(distro)))
 QEMUCMD := qemu-system-x86_64
 else
-QEMUCMD := qemu-lite-system-x86_64
+QEMUCMD := qemu-q35-system-x86_64
 endif
 
 QEMUPATH := $(QEMUBINDIR)/$(QEMUCMD)

--- a/cc-env.go
+++ b/cc-env.go
@@ -30,7 +30,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.0"
+const formatVersion = "1.0.1"
 
 // defaultOutputFile is the default output file to write the gathered
 // information to.
@@ -72,6 +72,12 @@ type RuntimeVersionInfo struct {
 	Semver string
 	Commit string
 	OCI    string
+}
+
+// HypervisorInfo stores hypervisor details
+type HypervisorInfo struct {
+	Location    PathInfo
+	MachineType string
 }
 
 // ProxyInfo stores proxy details
@@ -116,7 +122,7 @@ type HostInfo struct {
 type EnvInfo struct {
 	Meta       MetaInfo
 	Runtime    RuntimeInfo
-	Hypervisor PathInfo
+	Hypervisor HypervisorInfo
 	Image      PathInfo
 	Kernel     PathInfo
 	Proxy      ProxyInfo
@@ -306,9 +312,12 @@ func getEnvInfo(configFile, logfilePath string, config oci.RuntimeConfig) (env E
 		return EnvInfo{}, err
 	}
 
-	hypervisor := PathInfo{
-		Path:     config.HypervisorConfig.HypervisorPath,
-		Resolved: resolvedHypervisor.HypervisorPath,
+	hypervisor := HypervisorInfo{
+		Location: PathInfo{
+			Path:     config.HypervisorConfig.HypervisorPath,
+			Resolved: resolvedHypervisor.HypervisorPath,
+		},
+		MachineType: config.HypervisorConfig.HypervisorMachineType,
 	}
 
 	image := PathInfo{

--- a/cc-env_test.go
+++ b/cc-env_test.go
@@ -240,10 +240,13 @@ model name	: %s
 	return expectedHostDetails, nil
 }
 
-func getExpectedHypervisor(config oci.RuntimeConfig) PathInfo {
-	return PathInfo{
-		Path:     config.HypervisorConfig.HypervisorPath,
-		Resolved: config.HypervisorConfig.HypervisorPath,
+func getExpectedHypervisor(config oci.RuntimeConfig) HypervisorInfo {
+	return HypervisorInfo{
+		Location: PathInfo{
+			Path:     config.HypervisorConfig.HypervisorPath,
+			Resolved: config.HypervisorConfig.HypervisorPath,
+		},
+		MachineType: config.HypervisorConfig.HypervisorMachineType,
 	}
 }
 
@@ -505,7 +508,7 @@ func TestCCEnvGetEnvInfoNoHypervisor(t *testing.T) {
 	expected, err := getExpectedSettings(config, tmpdir, configFile, logFile)
 	assert.NoError(t, err)
 
-	err = os.Remove(expected.Hypervisor.Resolved)
+	err = os.Remove(expected.Hypervisor.Location.Resolved)
 	assert.NoError(t, err)
 
 	_, err = getEnvInfo(configFile, logFile, config)
@@ -890,9 +893,12 @@ func testCCEnvShowSettings(t *testing.T, tmpdir string, tmpfile *os.File) error 
 
 	ccRuntime := RuntimeInfo{}
 
-	ccHypervisor := PathInfo{
-		Path:     "/hypervisor/path",
-		Resolved: "/resolved/hypervisor/path",
+	ccHypervisor := HypervisorInfo{
+		Location: PathInfo{
+			Path:     "/hypervisor/path",
+			Resolved: "/resolved/hypervisor/path",
+		},
+		MachineType: "hypervisor-machine-type",
 	}
 
 	ccImage := PathInfo{

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -1,6 +1,6 @@
 # XXX: Warning: this file is auto-generated from file "@CONFIG_IN@".
 
-[hypervisor.qemu-lite]
+[hypervisor.q35]
 path = "@QEMUPATH@"
 kernel = "@KERNELPATH@"
 image = "@IMAGEPATH@"

--- a/config_test.go
+++ b/config_test.go
@@ -131,12 +131,28 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		}
 	}
 
+	var machineType string
+
+	switch hypervisor {
+	case q35HypervisorTableType:
+		machineType = vc.QemuQ35
+		break
+	case qemuHypervisorTableType:
+		fallthrough
+	case qemuLiteHypervisorTableType:
+		machineType = vc.QemuPCLite
+		break
+	default:
+		return config, err
+	}
+
 	hypervisorConfig := vc.HypervisorConfig{
-		HypervisorPath: hypervisorPath,
-		KernelPath:     kernelPath,
-		ImagePath:      imagePath,
-		DefaultVCPUs:   defaultVCPUCount,
-		DefaultMemSz:   defaultMemSize,
+		HypervisorPath:        hypervisorPath,
+		KernelPath:            kernelPath,
+		ImagePath:             imagePath,
+		HypervisorMachineType: machineType,
+		DefaultVCPUs:          defaultVCPUCount,
+		DefaultMemSz:          defaultMemSize,
 	}
 
 	agentConfig := vc.HyperConfig{
@@ -589,11 +605,12 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 	}
 
 	expectedHypervisorConfig := vc.HypervisorConfig{
-		HypervisorPath: defaultHypervisorPath,
-		KernelPath:     defaultKernelPath,
-		ImagePath:      defaultImagePath,
-		DefaultVCPUs:   defaultVCPUCount,
-		DefaultMemSz:   defaultMemSize,
+		HypervisorPath:        defaultHypervisorPath,
+		KernelPath:            defaultKernelPath,
+		ImagePath:             defaultImagePath,
+		HypervisorMachineType: vc.QemuQ35,
+		DefaultVCPUs:          defaultVCPUCount,
+		DefaultMemSz:          defaultMemSize,
 	}
 
 	expectedAgentConfig := vc.HyperConfig{
@@ -778,6 +795,7 @@ func TestHypervisorDefaults(t *testing.T) {
 	assert.Equal(t, h.path(), defaultHypervisorPath, "default hypervisor path wrong")
 	assert.Equal(t, h.kernel(), defaultKernelPath, "default hypervisor kernel wrong")
 	assert.Equal(t, h.image(), defaultImagePath, "default hypervisor image wrong")
+	assert.Equal(t, h.machineType(), vc.QemuQ35, "default hypervisor machine type wrong")
 	assert.Equal(t, h.defaultVCPUs(), defaultVCPUCount, "default vCPU number is wrong")
 	assert.Equal(t, h.defaultMemSz(), defaultMemSize, "default memory size is wrong")
 
@@ -792,6 +810,10 @@ func TestHypervisorDefaults(t *testing.T) {
 	image := "foo"
 	h.Image = image
 	assert.Equal(t, h.image(), image, "custom hypervisor image wrong")
+
+	machineType := "foo"
+	h.MachineType = machineType
+	assert.Equal(t, h.machineType(), machineType, "custom hypervisor machine type wrong")
 
 	// auto inferring
 	h.DefaultVCPUs = -1

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -143,4 +143,6 @@ type agent interface {
 	// container related to a Pod. If all is true, all processes in
 	// the container will be sent the signal.
 	killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error
+
+	deletePod() error
 }

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -589,7 +589,20 @@ func (h *hyper) stopPauseContainer(podID string) error {
 	if err := h.killOneContainer(pauseContainerName, syscall.SIGKILL, true); err != nil {
 		return err
 	}
+/*
+	removeCommand := hyperstart.RemoveCommand{
+		Container: pauseContainerName,
+	}
 
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.RemoveContainer,
+		message: removeCommand,
+	}
+
+	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
+		return err
+	}
+*/
 	if err := h.removePauseBinary(podID); err != nil {
 		return err
 	}
@@ -644,6 +657,18 @@ func (h *hyper) killOneContainer(cID string, signal syscall.Signal, all bool) er
 	proxyCmd := hyperstartProxyCmd{
 		cmd:     hyperstart.KillContainer,
 		message: killCmd,
+	}
+
+	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *hyper) deletePod() error {
+	proxyCmd := hyperstartProxyCmd{
+		cmd: hyperstart.DestroyPod,
 	}
 
 	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -69,3 +69,7 @@ func (n *noopAgent) stopContainer(pod Pod, c Container) error {
 func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
+
+func (n *noopAgent) deletePod() error {
+	return nil
+}

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -583,6 +583,19 @@ func (q *qemu) startPod(startCh, stopCh chan struct{}) error {
 	return nil
 }
 
+// waitForVMStop will stop the Pod's VM.
+func (q *qemu) waitForVMStop(disconnectCh chan struct{}) error {
+	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
+
+	_, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, disconnectCh)
+	if err != nil {
+		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
+		return err
+	}
+
+	return nil
+}
+
 // stopPod will stop the Pod's VM.
 func (q *qemu) stopPod() error {
 	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -198,3 +198,7 @@ func (s *sshd) stopContainer(pod Pod, c Container) error {
 func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
+
+func (s *sshd) deletePod() error {
+	return nil
+}


### PR DESCRIPTION
This patch implements config.go so that we can really switch between
hypervisor machine types such as pc-lite and q35 for qemu hypervisor.

It also sets q35 as the default machine type because this is the most
upstream and we want this one by default for our runtime.

Fixes #329