### PR TITLE
cc-env: Add machine type to hypervisor information

### DIFF
--- a/cc-env.go
+++ b/cc-env.go
@@ -30,7 +30,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.0"
+const formatVersion = "1.0.1"
 
 // defaultOutputFile is the default output file to write the gathered
 // information to.
@@ -72,6 +72,12 @@ type RuntimeVersionInfo struct {
 	Semver string
 	Commit string
 	OCI    string
+}
+
+// HypervisorInfo stores hypervisor details
+type HypervisorInfo struct {
+	Location    PathInfo
+	MachineType string
 }
 
 // ProxyInfo stores proxy details
@@ -116,7 +122,7 @@ type HostInfo struct {
 type EnvInfo struct {
 	Meta       MetaInfo
 	Runtime    RuntimeInfo
-	Hypervisor PathInfo
+	Hypervisor HypervisorInfo
 	Image      PathInfo
 	Kernel     PathInfo
 	Proxy      ProxyInfo
@@ -306,9 +312,12 @@ func getEnvInfo(configFile, logfilePath string, config oci.RuntimeConfig) (env E
 		return EnvInfo{}, err
 	}
 
-	hypervisor := PathInfo{
-		Path:     config.HypervisorConfig.HypervisorPath,
-		Resolved: resolvedHypervisor.HypervisorPath,
+	hypervisor := HypervisorInfo{
+		Location: PathInfo{
+			Path:     config.HypervisorConfig.HypervisorPath,
+			Resolved: resolvedHypervisor.HypervisorPath,
+		},
+		MachineType: config.HypervisorConfig.HypervisorMachineType,
 	}
 
 	image := PathInfo{

--- a/cc-env_test.go
+++ b/cc-env_test.go
@@ -240,10 +240,13 @@ model name	: %s
 	return expectedHostDetails, nil
 }
 
-func getExpectedHypervisor(config oci.RuntimeConfig) PathInfo {
-	return PathInfo{
-		Path:     config.HypervisorConfig.HypervisorPath,
-		Resolved: config.HypervisorConfig.HypervisorPath,
+func getExpectedHypervisor(config oci.RuntimeConfig) HypervisorInfo {
+	return HypervisorInfo{
+		Location: PathInfo{
+			Path:     config.HypervisorConfig.HypervisorPath,
+			Resolved: config.HypervisorConfig.HypervisorPath,
+		},
+		MachineType: config.HypervisorConfig.HypervisorMachineType,
 	}
 }
 
@@ -505,7 +508,7 @@ func TestCCEnvGetEnvInfoNoHypervisor(t *testing.T) {
 	expected, err := getExpectedSettings(config, tmpdir, configFile, logFile)
 	assert.NoError(t, err)
 
-	err = os.Remove(expected.Hypervisor.Resolved)
+	err = os.Remove(expected.Hypervisor.Location.Resolved)
 	assert.NoError(t, err)
 
 	_, err = getEnvInfo(configFile, logFile, config)
@@ -890,9 +893,12 @@ func testCCEnvShowSettings(t *testing.T, tmpdir string, tmpfile *os.File) error 
 
 	ccRuntime := RuntimeInfo{}
 
-	ccHypervisor := PathInfo{
-		Path:     "/hypervisor/path",
-		Resolved: "/resolved/hypervisor/path",
+	ccHypervisor := HypervisorInfo{
+		Location: PathInfo{
+			Path:     "/hypervisor/path",
+			Resolved: "/resolved/hypervisor/path",
+		},
+		MachineType: "hypervisor-machine-type",
 	}
 
 	ccImage := PathInfo{


### PR DESCRIPTION
The purpose of this commit is to add some useful info related to the
hypervisor now that we have the machine type available.

EnvInfo structure has been modified so that it expects HypervisorInfo
structure instead of the generic PathInfo regarding the information
about the hypervisor.

Fixes #351