### PR TITLE
runtime: Switch to the new agent

### DIFF
--- a/create.go
+++ b/create.go
@@ -156,7 +156,7 @@ func createPod(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 		},
 		{
 			Key:   "systemd.unit",
-			Value: "cc-agent.target",
+			Value: "clear-containers.target",
 		},
 		{
 			Key:   "systemd.mask",

--- a/versions.txt
+++ b/versions.txt
@@ -1,0 +1,1 @@
+cc_agent_version=0fca1509afbaa18c5a0ddf213f2e377c7b87dcc7


### PR DESCRIPTION
This commit modifies the systemd target to use, so that it will use
cc-agent instead of hyperstart agent.

Fixes #348