### PR TITLE
config: Make hypervisor machine type configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ QEMUCMD := qemu-lite-system-x86_64
 endif
 
 QEMUPATH := $(QEMUBINDIR)/$(QEMUCMD)
+MACHINETYPE := pc-lite
 
 SHIMCMD := cc-shim
 SHIMPATH := $(PKGLIBEXECDIR)/$(SHIMCMD)
@@ -126,6 +127,7 @@ USER_VARS += DESTDIR
 USER_VARS += DESTTARGET
 USER_VARS += GLOBALLOGPATH
 USER_VARS += IMAGEPATH
+USER_VARS += MACHINETYPE
 USER_VARS += KERNELPATH
 USER_VARS += LIBEXECDIR
 USER_VARS += LOCALSTATEDIR
@@ -179,6 +181,7 @@ const version = "$(VERSION)"
 const defaultHypervisorPath = "$(QEMUPATH)"
 const defaultImagePath = "$(IMAGEPATH)"
 const defaultKernelPath = "$(KERNELPATH)"
+const defaultMachineType = "$(MACHINETYPE)"
 const defaultPauseRootPath = "$(PAUSEROOTPATH)"
 const defaultProxyURL = "$(PROXYURL)"
 const defaultRootDirectory = "$(PKGRUNDIR)"
@@ -233,6 +236,7 @@ $(CONFIG): $(CONFIG_IN)
 		-e "s|@PKGLIBEXECDIR@|$(PKGLIBEXECDIR)|g" \
 		-e "s|@PROXYURL@|$(PROXYURL)|g" \
 		-e "s|@QEMUPATH@|$(QEMUPATH)|g" \
+		-e "s|@MACHINETYPE@|$(MACHINETYPE)|g" \
 		-e "s|@SHIMPATH@|$(SHIMPATH)|g" \
 		-e "s|@GLOBALLOGPATH@|$(GLOBALLOGPATH)|g" \
 		-e "s|@DEFVCPUS@|$(DEFVCPUS)|g" \

--- a/cc-env_test.go
+++ b/cc-env_test.go
@@ -42,6 +42,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	hypervisorPath := filepath.Join(prefixDir, "hypervisor")
 	kernelPath := filepath.Join(prefixDir, "kernel")
 	imagePath := filepath.Join(prefixDir, "image")
+	machineType := "machineType"
 	shimPath := filepath.Join(prefixDir, "cc-shim")
 	proxyPath := filepath.Join(prefixDir, "cc-proxy")
 
@@ -97,10 +98,11 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	}
 
 	runtimeConfig := makeRuntimeConfigFileData(
-		"qemu-lite",
+		"qemu",
 		hypervisorPath,
 		kernelPath,
 		imagePath,
+		machineType,
 		shimPath,
 		agentPauseRoot,
 		testProxyURL,

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -1,9 +1,10 @@
 # XXX: Warning: this file is auto-generated from file "@CONFIG_IN@".
 
-[hypervisor.qemu-lite]
+[hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELPATH@"
 image = "@IMAGEPATH@"
+machine_type = "@MACHINETYPE@"
 # Default number of vCPUs per POD/VM:
 # unspecified or 0 --> will be set to @DEFVCPUS@
 # < 0              --> will be set to the actual number of physical cores


### PR DESCRIPTION
This patch implements config.go in order to switch between different
hypervisor machine types such as pc-lite, pc or q35.

Fixes #350