### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "cfe8504aee2d22812dba5d8de17e545359c4a2fa"
+  revision = "2d66ecacf63f8efc51f73f50b93f2140169ed90c"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/cc_shim_test.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim_test.go
@@ -19,7 +19,9 @@ package virtcontainers
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -87,6 +89,17 @@ func TestCCShimStartShimPathEmptyFailure(t *testing.T) {
 	testCCShimStart(t, pod, ShimParams{}, true)
 }
 
+func TestCCShimStartShimTypeInvalid(t *testing.T) {
+	pod := Pod{
+		config: &PodConfig{
+			ShimType:   "foo",
+			ShimConfig: CCShimConfig{},
+		},
+	}
+
+	testCCShimStart(t, pod, ShimParams{}, true)
+}
+
 func TestCCShimStartParamsTokenEmptyFailure(t *testing.T) {
 	pod := Pod{
 		config: &PodConfig{
@@ -112,6 +125,32 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 
 	params := ShimParams{
 		Token: "testToken",
+	}
+
+	testCCShimStart(t, pod, params, true)
+}
+
+func TestCCShimStartParamsInvalidCommand(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	cmd := filepath.Join(dir, "does-not-exist")
+
+	pod := Pod{
+		config: &PodConfig{
+			ShimType: CCShimType,
+			ShimConfig: CCShimConfig{
+				Path: cmd,
+			},
+		},
+	}
+
+	params := ShimParams{
+		Token: "testToken",
+		URL:   "http://foo",
 	}
 
 	testCCShimStart(t, pod, params, true)

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -508,6 +508,11 @@ func (c *Container) stop() error {
 		return err
 	}
 
+	// Wait for the end of container
+	if err := waitForShim(c.process.Pid); err != nil {
+		return err
+	}
+
 	err = c.pod.agent.stopContainer(*(c.pod), *c)
 	if err != nil {
 		return err

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -458,25 +458,6 @@ func (h *hyper) startPod(pod Pod) error {
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
 func (h *hyper) stopPod(pod Pod) error {
-	for _, c := range pod.containers {
-		state, err := pod.storage.fetchContainerState(pod.id, c.id)
-		if err != nil {
-			return err
-		}
-
-		if state.State != StateRunning {
-			continue
-		}
-
-		if err := h.killOneContainer(c.id, syscall.SIGKILL, true); err != nil {
-			return err
-		}
-
-		if err := h.stopOneContainer(pod.id, *c); err != nil {
-			return err
-		}
-	}
-
 	if err := h.stopPauseContainer(pod.id); err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -904,6 +904,30 @@ func (p *Pod) stop() error {
 	}
 	defer p.proxy.disconnect()
 
+	for _, c := range p.containers {
+		state, err := p.storage.fetchContainerState(p.id, c.id)
+		if err != nil {
+			return err
+		}
+
+		if state.State != StateRunning {
+			continue
+		}
+
+		if err := p.agent.killContainer(*p, *c, syscall.SIGKILL, true); err != nil {
+			return err
+		}
+
+		// Wait for the end of container
+		if err := waitForShim(c.process.Pid); err != nil {
+			return err
+		}
+
+		if err := p.agent.stopContainer(*p, *c); err != nil {
+			return err
+		}
+	}
+
 	if err := p.agent.stopPod(*p); err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -60,6 +60,9 @@ const (
 	// QemuPCLite is the QEMU pc-lite machine type
 	QemuPCLite = defaultQemuMachineType
 
+	// QemuPC is the QEMU pc machine type
+	QemuPC = "pc"
+
 	// QemuQ35 is the QEMU Q35 machine type
 	QemuQ35 = "q35"
 )
@@ -67,12 +70,17 @@ const (
 // Mapping between machine types and QEMU binary paths.
 var qemuPaths = map[string]string{
 	QemuPCLite: "/usr/bin/qemu-lite-system-x86_64",
-	QemuQ35:    defaultQemuPath,
+	QemuPC:     defaultQemuPath,
+	QemuQ35:    "/usr/bin/qemu-35-system-x86_64",
 }
 
 var supportedQemuMachines = []ciaoQemu.Machine{
 	{
 		Type:         QemuPCLite,
+		Acceleration: "kvm,kernel_irqchip,nvdimm",
+	},
+	{
+		Type:         QemuPC,
 		Acceleration: "kvm,kernel_irqchip,nvdimm",
 	},
 	{

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -497,9 +497,11 @@ func TestQemuMachineTypes(t *testing.T) {
 
 	data := []testData{
 		{"pc-lite", true},
+		{"pc", true},
 		{"q35", true},
 
 		{"PC-LITE", false},
+		{"PC", false},
 		{"Q35", false},
 		{"", false},
 		{" ", false},


### PR DESCRIPTION
Shortlog of what have been added since the last vendoring:

57bec7d stop: Wait for end of container process before to remove
284dd91 qemu: Add pc machine type as supported
8d8ccbd hyperstart: Move generic pod stopping code
b22c37f tests: Increase unit test coverage for hook.go
1b3d2f0 tests: Add option to panic mock hook
6b29134 tests: Increase unit test coverage for cc_shim.go.

Fixes #355