### PR TITLE
logging: Add path to config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func beforeSubcommands(context *cli.Context) error {
 	}
 
 	ccLog.Infof("%v (version %v, commit %v) called as: %v", name, version, commit, context.Args())
+	ccLog.Infof("Using configuration file %q", configFile)
 
 	// make the data accessible to the sub-commands.
 	context.App.Metadata = map[string]interface{}{


### PR DESCRIPTION
Log the full path to the configuration file being used by the runtime
as a debug aide.

Fixes #357.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>