### PR TITLE
config: Make block device usage configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ DEFVCPUS := 1
 # Default memory size in MiB
 DEFMEMSZ := 2048
 
+DEFDISABLEBLOCK := false
+
 SED = sed
 
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
@@ -149,6 +151,7 @@ USER_VARS += SYSCONFDIR
 USER_VARS += PAUSEDESTDIR
 USER_VARS += DEFVCPUS
 USER_VARS += DEFMEMSZ
+USER_VARS += DEFDISABLEBLOCK
 
 
 V              = @
@@ -192,6 +195,7 @@ const pauseBinRelativePath = "$(PAUSEBINRELPATH)"
 
 const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
+const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 
 // Required to be modifiable (for the tests)
 var defaultRuntimeConfiguration = "$(DESTCONFIG)"
@@ -241,6 +245,7 @@ $(CONFIG): $(CONFIG_IN)
 		-e "s|@GLOBALLOGPATH@|$(GLOBALLOGPATH)|g" \
 		-e "s|@DEFVCPUS@|$(DEFVCPUS)|g" \
 		-e "s|@DEFMEMSZ@|$(DEFMEMSZ)|g" \
+		-e "s|@DEFDISABLEBLOCK@|$(DEFDISABLEBLOCK)|g" \
 		$< > $@
 
 generate-config: $(CONFIG)

--- a/cc-env_test.go
+++ b/cc-env_test.go
@@ -45,6 +45,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	machineType := "machineType"
 	shimPath := filepath.Join(prefixDir, "cc-shim")
 	proxyPath := filepath.Join(prefixDir, "cc-proxy")
+	disableBlock := true
 
 	// override
 	defaultProxyPath = proxyPath
@@ -106,7 +107,8 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 		shimPath,
 		agentPauseRoot,
 		testProxyURL,
-		logPath)
+		logPath,
+		disableBlock)
 
 	configFile = path.Join(prefixDir, "runtime.toml")
 	err = createConfig(configFile, runtimeConfig)

--- a/config.go
+++ b/config.go
@@ -73,12 +73,13 @@ type tomlConfig struct {
 }
 
 type hypervisor struct {
-	Path         string `toml:"path"`
-	Kernel       string `toml:"kernel"`
-	Image        string `toml:"image"`
-	MachineType  string `toml:"machine_type"`
-	DefaultVCPUs int32  `toml:"default_vcpus"`
-	DefaultMemSz uint32 `toml:"default_memory"`
+	Path                  string `toml:"path"`
+	Kernel                string `toml:"kernel"`
+	Image                 string `toml:"image"`
+	MachineType           string `toml:"machine_type"`
+	DefaultVCPUs          int32  `toml:"default_vcpus"`
+	DefaultMemSz          uint32 `toml:"default_memory"`
+	DisableBlockDeviceUse bool   `toml:"disable_block_device_use"`
 }
 
 type proxy struct {
@@ -195,6 +196,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		HypervisorMachineType: machineType,
 		DefaultVCPUs:          h.defaultVCPUs(),
 		DefaultMemSz:          h.defaultMemSz(),
+		DisableBlockDeviceUse: h.DisableBlockDeviceUse,
 	}, nil
 }
 

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -13,6 +13,7 @@ default_vcpus = -1
 # Default memory size in MiB for POD/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 #default_memory = @DEFMEMSZ@
+disable_block_device_use = @DEFDISABLEBLOCK@
 
 [proxy.cc]
 url = "@PROXYURL@"


### PR DESCRIPTION
Allow 9pfs to be used instead of block device for devicemapper.
virtcontainers uses this configuration to use 9pfs
instead of block device.

Fixes #361

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>