### PR TITLE
config: support kernel parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ PKGLIBEXECDIR := $(LIBEXECDIR)/$(CCDIR)
 KERNELPATH := $(PKGDATADIR)/vmlinux.container
 IMAGEPATH := $(PKGDATADIR)/clear-containers.img
 
+KERNELPARAMS :=
+
 # The CentOS/RHEL hypervisor binary is not called qemu-lite
 ifeq (,$(filter-out centos rhel,$(distro)))
 QEMUCMD := qemu-system-x86_64
@@ -131,6 +133,7 @@ USER_VARS += GLOBALLOGPATH
 USER_VARS += IMAGEPATH
 USER_VARS += MACHINETYPE
 USER_VARS += KERNELPATH
+USER_VARS += KERNELPARAMS
 USER_VARS += LIBEXECDIR
 USER_VARS += LOCALSTATEDIR
 USER_VARS += PAUSEBINRELPATH
@@ -184,6 +187,7 @@ const version = "$(VERSION)"
 const defaultHypervisorPath = "$(QEMUPATH)"
 const defaultImagePath = "$(IMAGEPATH)"
 const defaultKernelPath = "$(KERNELPATH)"
+const defaultKernelParams = "$(KERNELPARAMS)"
 const defaultMachineType = "$(MACHINETYPE)"
 const defaultPauseRootPath = "$(PAUSEROOTPATH)"
 const defaultProxyURL = "$(PROXYURL)"
@@ -235,6 +239,7 @@ $(CONFIG): $(CONFIG_IN)
 		-e "s|@CONFIG_IN@|$(CONFIG_IN)|g" \
 		-e "s|@IMAGEPATH@|$(IMAGEPATH)|g" \
 		-e "s|@KERNELPATH@|$(KERNELPATH)|g" \
+		-e "s|@KERNELPARAMS@|$(KERNELPARAMS)|g" \
 		-e "s|@LOCALSTATEDIR@|$(LOCALSTATEDIR)|g" \
 		-e "s|@PAUSEROOTPATH@|$(PAUSEROOTPATH)|g" \
 		-e "s|@PKGLIBEXECDIR@|$(PKGLIBEXECDIR)|g" \

--- a/cc-env.go
+++ b/cc-env.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	vc "github.com/containers/virtcontainers"
@@ -30,7 +31,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.1"
+const formatVersion = "1.0.2"
 
 // defaultOutputFile is the default output file to write the gathered
 // information to.
@@ -46,6 +47,12 @@ type MetaInfo struct {
 type PathInfo struct {
 	Path     string
 	Resolved string
+}
+
+// KernelInfo stores kernel details
+type KernelInfo struct {
+	Location   PathInfo
+	Parameters string
 }
 
 // CPUInfo stores host CPU details
@@ -124,7 +131,7 @@ type EnvInfo struct {
 	Runtime    RuntimeInfo
 	Hypervisor HypervisorInfo
 	Image      PathInfo
-	Kernel     PathInfo
+	Kernel     KernelInfo
 	Proxy      ProxyInfo
 	Shim       ShimInfo
 	Agent      AgentInfo
@@ -325,9 +332,12 @@ func getEnvInfo(configFile, logfilePath string, config oci.RuntimeConfig) (env E
 		Resolved: resolvedHypervisor.ImagePath,
 	}
 
-	kernel := PathInfo{
-		Path:     config.HypervisorConfig.KernelPath,
-		Resolved: resolvedHypervisor.KernelPath,
+	kernel := KernelInfo{
+		Location: PathInfo{
+			Path:     config.HypervisorConfig.KernelPath,
+			Resolved: resolvedHypervisor.KernelPath,
+		},
+		Parameters: strings.Join(vc.SerializeParams(config.HypervisorConfig.KernelParams, "="), " "),
 	}
 
 	env = EnvInfo{

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -5,6 +5,10 @@ path = "@QEMUPATH@"
 kernel = "@KERNELPATH@"
 image = "@IMAGEPATH@"
 machine_type = "@MACHINETYPE@"
+# Optional space-separated list of options to pass to the guest kernel.
+# For example, use `kernel_params = "vsyscall=emulate"` if you are having
+# trouble running pre-2.15 glibc
+kernel_params = "@KERNELPARAMS@"
 # Default number of vCPUs per POD/VM:
 # unspecified or 0 --> will be set to @DEFVCPUS@
 # < 0              --> will be set to the actual number of physical cores


### PR DESCRIPTION
Add support to pass extra kernel parameters in configuration.

The story behind this feature is, I have trouble running centos:6
/bin/bash and it turns out guest kernel is using vsyscall=none which
breaks old libc.

Fixes: #368

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>