### PR TITLE
Globally improves kill/delete commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "2d66ecacf63f8efc51f73f50b93f2140169ed90c"
+  revision = "17f778503274ed939ebeea62ab315b2a7fa31cfd"
 
 [[projects]]
   branch = "master"

--- a/delete.go
+++ b/delete.go
@@ -80,19 +80,13 @@ func delete(containerID string, force bool) error {
 		return err
 	}
 
-	running, err := processRunning(status.PID)
-	if err != nil {
-		return err
-	}
-
-	if !force && running {
-		return fmt.Errorf("Container still running, should be stopped")
-	}
-
 	forceStop := false
 	if oci.StateToOCIState(status.State) == oci.StateRunning {
+		if !force {
+			return fmt.Errorf("Container still running, should be stopped")
+		}
+
 		forceStop = true
-		ccLog.Info("Force stopping the pod/container before deleting")
 	}
 
 	switch containerType {

--- a/delete.go
+++ b/delete.go
@@ -91,7 +91,7 @@ func delete(containerID string, force bool) error {
 
 	switch containerType {
 	case vc.PodSandbox:
-		if err := deletePod(podID, forceStop); err != nil {
+		if err := deletePod(podID); err != nil {
 			return err
 		}
 	case vc.PodContainer:
@@ -113,11 +113,9 @@ func delete(containerID string, force bool) error {
 	return removeCgroupsPath(cgroupsPathList)
 }
 
-func deletePod(podID string, forceStop bool) error {
-	if forceStop {
-		if _, err := vc.StopPod(podID); err != nil {
-			return err
-		}
+func deletePod(podID string) error {
+	if _, err := vc.StopPod(podID); err != nil {
+		return err
 	}
 
 	if _, err := vc.DeletePod(podID); err != nil {

--- a/exec.go
+++ b/exec.go
@@ -210,19 +210,6 @@ func execute(context *cli.Context) error {
 		return fmt.Errorf("Container %s is not running", params.cID)
 	}
 
-	// Check status of process running inside the container
-	running, err := processRunning(status.PID)
-	if err != nil {
-		return err
-	}
-	if running == false {
-		if err := stopContainer(podID, status); err != nil {
-			return err
-		}
-
-		return fmt.Errorf("Process not running inside container %s", params.cID)
-	}
-
 	envVars, err := oci.EnvVars(params.ociProcess.Env)
 	if err != nil {
 		return err

--- a/kill.go
+++ b/kill.go
@@ -127,19 +127,6 @@ func kill(containerID, signal string, all bool) error {
 		return fmt.Errorf("Container %s is not running", containerID)
 	}
 
-	// Check status of process
-	running, err := processRunning(status.PID)
-	if err != nil {
-		return err
-	}
-	if running == false {
-		if err := stopContainer(podID, status); err != nil {
-			return err
-		}
-
-		return fmt.Errorf("Process not running inside container %s", containerID)
-	}
-
 	if err := vc.KillContainer(podID, containerID, signum, all); err != nil {
 		return err
 	}

--- a/kill.go
+++ b/kill.go
@@ -112,19 +112,8 @@ func kill(containerID, signal string, all bool) error {
 	}
 
 	// container MUST be created or running
-	if status.State.State == vc.StateReady {
-		ccLog.Infof("Container %s state 'created', nothing to do", containerID)
-
-		// force state to be stopped
-		if signum == syscall.SIGKILL || signum == syscall.SIGTERM {
-			if err := stopContainer(podID, status); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	} else if status.State.State != vc.StateRunning {
-		return fmt.Errorf("Container %s is not running", containerID)
+	if status.State.State != vc.StateReady && status.State.State != vc.StateRunning {
+		return fmt.Errorf("Container %s not ready or running, cannot send a signal", containerID)
 	}
 
 	if err := vc.KillContainer(podID, containerID, signum, all); err != nil {

--- a/oci.go
+++ b/oci.go
@@ -145,34 +145,6 @@ func validCreateParams(containerID, bundlePath string) (string, error) {
 	return resolved, nil
 }
 
-func stopContainer(podID string, status vc.ContainerStatus) error {
-	containerType, err := oci.GetContainerType(status.Annotations)
-	if err != nil {
-		return err
-	}
-
-	switch containerType {
-	case vc.PodSandbox:
-		// Calling StopPod allows to make sure the pod is properly
-		// stopped. That way, containers/pod states are updated to
-		// the expected "stopped" state.
-		if _, err := vc.StopPod(podID); err != nil {
-			return err
-		}
-	case vc.PodContainer:
-		// Calling StopContainer allows to make sure the container is
-		// properly stopped and removed from the pod. That way, the
-		// container's state is updated to the expected "stopped" state.
-		if _, err := vc.StopContainer(podID, status.ID); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("Invalid container type found")
-	}
-
-	return nil
-}
-
 // processCgroupsPath process the cgroups path as expected from the
 // OCI runtime specification. It returns a list of complete paths
 // that should be created and used for every specified resource.

--- a/oci.go
+++ b/oci.go
@@ -145,19 +145,6 @@ func validCreateParams(containerID, bundlePath string) (string, error) {
 	return resolved, nil
 }
 
-func processRunning(pid int) (bool, error) {
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false, err
-	}
-
-	if err := process.Signal(syscall.Signal(0)); err != nil {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 func stopContainer(podID string, status vc.ContainerStatus) error {
 	containerType, err := oci.GetContainerType(status.Annotations)
 	if err != nil {

--- a/oci_test.go
+++ b/oci_test.go
@@ -65,26 +65,6 @@ func TestGetExistingContainerInfoContainerIDEmptyFailure(t *testing.T) {
 	}
 }
 
-func testProcessRunning(t *testing.T, pid int, expected bool) {
-	running, err := processRunning(pid)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if running != expected {
-		t.Fatalf("Expecting PID %d to be 'running == %v'", pid, expected)
-	}
-}
-
-func TestProcessRunningFailure(t *testing.T) {
-	testProcessRunning(t, 99999, false)
-}
-
-func TestProcessRunningSuccessful(t *testing.T) {
-	pid := os.Getpid()
-	testProcessRunning(t, pid, true)
-}
-
 func TestStopContainerPodStatusEmptyFailure(t *testing.T) {
 	if err := stopContainer("", vc.ContainerStatus{}); err == nil {
 		t.Fatalf("This test should fail because PodStatus is empty")

--- a/oci_test.go
+++ b/oci_test.go
@@ -24,7 +24,6 @@ import (
 	"syscall"
 	"testing"
 
-	vc "github.com/containers/virtcontainers"
 	"github.com/containers/virtcontainers/pkg/oci"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -62,24 +61,6 @@ func TestGetExistingContainerInfoContainerIDEmptyFailure(t *testing.T) {
 
 	if status.ID != "" {
 		t.Fatalf("Expected blank fullID, but got %v", status.ID)
-	}
-}
-
-func TestStopContainerPodStatusEmptyFailure(t *testing.T) {
-	if err := stopContainer("", vc.ContainerStatus{}); err == nil {
-		t.Fatalf("This test should fail because PodStatus is empty")
-	}
-}
-
-func TestStopContainerTooManyContainerStatusesFailure(t *testing.T) {
-	podStatus := vc.PodStatus{}
-
-	for i := 0; i < 2; i++ {
-		podStatus.ContainersStatus = append(podStatus.ContainersStatus, vc.ContainerStatus{})
-	}
-
-	if err := stopContainer("", vc.ContainerStatus{}); err == nil {
-		t.Fatalf("This test should fail because PodStatus has too many container statuses")
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -44,7 +44,7 @@ instance of a container.`,
 
 func state(containerID string) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	status, podID, err := getExistingContainerInfo(containerID)
+	status, _, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
@@ -53,22 +53,6 @@ func state(containerID string) error {
 	state, err := oci.StatusToOCIState(status)
 	if err != nil {
 		return err
-	}
-
-	// Update status of process
-	running, err := processRunning(state.Pid)
-	if err != nil {
-		return err
-	}
-
-	if running == false && state.Status == oci.StateRunning {
-		ccLog.Infof("Setting container state to %q as process %d is not running",
-			oci.StateStopped, state.Pid)
-		if err := stopContainer(podID, status); err != nil {
-			return err
-		}
-
-		state.Status = oci.StateStopped
 	}
 
 	stateJSON, err := json.Marshal(state)

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -121,6 +121,9 @@ type agent interface {
 	// supported by the agent.
 	capabilities() capabilities
 
+	// createPod will tell the agent to perform necessary setup for a Pod.
+	createPod(pod *Pod) error
+
 	// exec will tell the agent to run a command in an already running container.
 	exec(pod *Pod, c Container, process Process, cmd Cmd) error
 

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -346,6 +346,12 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	// Override pod agent configuration
 	pod.config.AgentConfig = h.config
 
+	h.proxy = pod.proxy
+
+	return nil
+}
+
+func (h *hyper) createPod(pod *Pod) (err error) {
 	for _, volume := range h.config.Volumes {
 		err := pod.hypervisor.addDevice(volume, fsDev)
 		if err != nil {
@@ -374,8 +380,6 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	if err := pod.hypervisor.addDevice(sharedVolume, fsDev); err != nil {
 		return err
 	}
-
-	h.proxy = pod.proxy
 
 	return nil
 }

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -18,6 +18,7 @@ package virtcontainers
 
 import (
 	"fmt"
+	"strings"
 )
 
 // HypervisorType describes an hypervisor type.
@@ -180,7 +181,8 @@ func appendParam(params []Param, parameter string, value string) []Param {
 	return append(params, Param{parameter, value})
 }
 
-func serializeParams(params []Param, delim string) []string {
+// SerializeParams converts []Param to []string
+func SerializeParams(params []Param, delim string) []string {
 	var parameters []string
 
 	for _, p := range params {
@@ -199,6 +201,25 @@ func serializeParams(params []Param, delim string) []string {
 	}
 
 	return parameters
+}
+
+// DeserializeParams converts []string to []Param
+func DeserializeParams(parameters []string) []Param {
+	var params []Param
+
+	for _, param := range parameters {
+		if param == "" {
+			continue
+		}
+		p := strings.SplitN(param, "=", 2)
+		if len(p) == 2 {
+			params = append(params, Param{Key: p[0], Value: p[1]})
+		} else {
+			params = append(params, Param{Key: p[0], Value: ""})
+		}
+	}
+
+	return params
 }
 
 // hypervisor is the virtcontainers hypervisor interface.

--- a/vendor/github.com/containers/virtcontainers/hypervisor_test.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor_test.go
@@ -208,7 +208,7 @@ func TestAppendParams(t *testing.T) {
 }
 
 func testSerializeParams(t *testing.T, params []Param, delim string, expected []string) {
-	result := serializeParams(params, delim)
+	result := SerializeParams(params, delim)
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatal()
 	}
@@ -274,6 +274,58 @@ func TestSerializeParams(t *testing.T) {
 	expected := []string{"param1=value1"}
 
 	testSerializeParams(t, params, "=", expected)
+}
+
+func testDeserializeParams(t *testing.T, parameters []string, expected []Param) {
+	result := DeserializeParams(parameters)
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestDeserializeParamsNil(t *testing.T) {
+	var parameters []string
+	var expected []Param
+
+	testDeserializeParams(t, parameters, expected)
+}
+
+func TestDeserializeParamsNoParamNoValue(t *testing.T) {
+	parameters := []string{
+		"",
+	}
+
+	var expected []Param
+
+	testDeserializeParams(t, parameters, expected)
+}
+
+func TestDeserializeParamsNoValue(t *testing.T) {
+	parameters := []string{
+		"param1",
+	}
+	expected := []Param{
+		{
+			Key: "param1",
+		},
+	}
+
+	testDeserializeParams(t, parameters, expected)
+}
+
+func TestDeserializeParams(t *testing.T) {
+	parameters := []string{
+		"param1=value1",
+	}
+
+	expected := []Param{
+		{
+			Key:   "param1",
+			Value: "value1",
+		},
+	}
+
+	testDeserializeParams(t, parameters, expected)
 }
 
 func TestAddKernelParamValid(t *testing.T) {

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -30,6 +30,11 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// createPod is the Noop agent pod creation implementation. It does nothing.
+func (n *noopAgent) createPod(pod *Pod) error {
+	return nil
+}
+
 // capabilities returns empty capabilities, i.e no capabilties are supported.
 func (n *noopAgent) capabilities() capabilities {
 	return capabilities{}

--- a/vendor/github.com/containers/virtcontainers/noop_shim.go
+++ b/vendor/github.com/containers/virtcontainers/noop_shim.go
@@ -21,5 +21,5 @@ type noopShim struct{}
 // start is the noopShim start implementation for testing purpose.
 // It does nothing.
 func (s *noopShim) start(pod Pod, params ShimParams) (int, error) {
-	return 0, nil
+	return 1000, nil
 }

--- a/vendor/github.com/containers/virtcontainers/noop_shim_test.go
+++ b/vendor/github.com/containers/virtcontainers/noop_shim_test.go
@@ -24,7 +24,7 @@ func TestNoopShimStart(t *testing.T) {
 	s := &noopShim{}
 	pod := Pod{}
 	params := ShimParams{}
-	expected := 0
+	expected := 1000
 
 	pid, err := s.start(pod, params)
 	if err != nil {

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -177,7 +177,7 @@ func (q *qemu) buildKernelParams(config HypervisorConfig) error {
 
 	params = append(params, config.KernelParams...)
 
-	q.kernelParams = serializeParams(params, "=")
+	q.kernelParams = SerializeParams(params, "=")
 
 	return nil
 }

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -105,6 +105,11 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// createPod is the agent pod creation implementation for sshd.
+func (s *sshd) createPod(pod *Pod) error {
+	return nil
+}
+
 func (s *sshd) capabilities() capabilities {
 	return capabilities{}
 }


### PR DESCRIPTION
This PR includes recent changes from virtcontainers. It changes the way `delete` and `kill` commands are implemented and allows `cc-runtime list` to return an accurate result of the container status.
It fixes #376 #377 #378 and #382 