### PR TITLE
[RFC] create: support oci spec memory limit

### DIFF
--- a/create.go
+++ b/create.go
@@ -98,6 +98,10 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 		return err
 	}
 
+	if err := ociResourceUpdateRuntimeConfig(ociSpec, &runtimeConfig); err != nil {
+		return err
+	}
+
 	containerType, err := ociSpec.ContainerType()
 	if err != nil {
 		return err


### PR DESCRIPTION
We should run VM(container) regarding oci config.json memory limit.

Fixes #381 

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>