### PR TITLE
qemu: Move from pc-lite to pc machine type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ PKGLIBDIR := $(LOCALSTATEDIR)/lib/$(CCDIR)
 PKGRUNDIR := $(LOCALSTATEDIR)/run/$(CCDIR)
 PKGLIBEXECDIR := $(LIBEXECDIR)/$(CCDIR)
 
-KERNELPATH := $(PKGDATADIR)/vmlinux.container
+KERNELPATH := $(PKGDATADIR)/vmlinuz.container
 IMAGEPATH := $(PKGDATADIR)/clear-containers.img
 
 KERNELPARAMS :=
@@ -81,7 +81,7 @@ QEMUCMD := qemu-lite-system-x86_64
 endif
 
 QEMUPATH := $(QEMUBINDIR)/$(QEMUCMD)
-MACHINETYPE := pc-lite
+MACHINETYPE := pc
 
 SHIMCMD := cc-shim
 SHIMPATH := $(PKGLIBEXECDIR)/$(SHIMCMD)


### PR DESCRIPTION
This patch modifies the default configuration provided through the
Makefile so that our runtime will use "pc" machine type for our
Qemu hypervisor. This change implies that we have to use vmlinuz
which is the compressed kernel expected by the BIOS run by "pc"
machine type.

Fixes #329