### PR TITLE
qemu: Move from qemu-lite to qemu-cc binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,11 @@ IMAGEPATH := $(PKGDATADIR)/clear-containers.img
 
 KERNELPARAMS :=
 
-# The CentOS/RHEL hypervisor binary is not called qemu-lite
-ifeq (,$(filter-out centos rhel,$(distro)))
+# The RHEL hypervisor binary is not called qemu-cc
+ifeq (,$(filter-out rhel,$(distro)))
 QEMUCMD := qemu-system-x86_64
 else
-QEMUCMD := qemu-lite-system-x86_64
+QEMUCMD := qemu-cc-system-x86_64
 endif
 
 QEMUPATH := $(QEMUBINDIR)/$(QEMUCMD)


### PR DESCRIPTION
Because we want to run Clear Containers on the most recent and
maintained version of qemu-lite, we are going to rely on qemu-cc
binary which is the packaged version of qemu-lite-q35 (or most
commonly known as 2.9.0).

Basically we are moving from qemu-lite 2.7 to 2.9.

Fixes #407