### PR TITLE
docs: Remove references to alpha version

### DIFF
--- a/docs/fedora-installation-guide.md
+++ b/docs/fedora-installation-guide.md
@@ -1,6 +1,6 @@
-# Installing Clear Containers 3.0 Alpha on Fedora
+# Installing Clear Containers 3.0 on Fedora
 
-Clear Containers **3.0-alpha** is available for Fedora\* versions **24** and **25**.
+Clear Containers **3.0** is available for Fedora\* versions **24** and **25**.
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:

--- a/docs/ubuntu-installation-guide.md
+++ b/docs/ubuntu-installation-guide.md
@@ -1,6 +1,6 @@
-# Installing Clear Containers 3.0 Alpha on Ubuntu
+# Installing Clear Containers 3.0 on Ubuntu
 
-Clear Containers **3.0-alpha** is available for Ubuntu\* **16.04**.
+Clear Containers **3.0** is available for Ubuntu\* **16.04**.
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:


### PR DESCRIPTION
The installation guides have references to alpha versions
in them. Now, that we will be moving to beta, remove these
references.

Fixes #418

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>