### PR TITLE
CI: Remove user as project approver

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -34,7 +34,6 @@ groups:
     required: 1
     users:
       - devimc
-      - dlespiau
       - grahamwhaley
       - jodh-intel
       - mcastelino

--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@ reviewers:
 
 approvers:
 - devimc
-- dlespiau
 - grahamwhaley
 - jodh-intel
 - mcastelino


### PR DESCRIPTION
Remove user dlespiau as a project approver as he is no longer a core
maintainer.

Fixes #420.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>