### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "8aeee1901c7bb4988c53db9dc56dfb60b011f46e"
+  revision = "add4d7434b13ea7fc5f1c8d43e4864a67cf329a8"
 
 [[projects]]
   branch = "master"
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci"]
-  revision = "17f778503274ed939ebeea62ab315b2a7fa31cfd"
+  revision = "6abb9c66c2ddef07dbf898c496e0e06fe15bd03d"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/01org/ciao/.travis.yml
+++ b/vendor/github.com/01org/ciao/.travis.yml
@@ -5,8 +5,8 @@ services:
   - docker
 
 go:
-    - 1.7
     - 1.8
+    - go1.9beta2
     - tip
 
 env:
@@ -14,6 +14,7 @@ env:
 matrix:
   allow_failures:
   - go: tip
+  - go: go1.9beta2
 
 go_import_path: github.com/01org/ciao
 
@@ -24,8 +25,8 @@ before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/pierrre/gotestcover
   - go get github.com/google/gofuzz github.com/stretchr/testify
-  - go get -u github.com/alecthomas/gometalinter
-  - gometalinter --install
+  - go get -u gopkg.in/alecthomas/gometalinter.v1
+  - gometalinter.v1 --install
   - pip install ansible
 
 # We need to create and install SSNTP certs for the SSNTP and controller tests
@@ -54,9 +55,9 @@ script:
    - sudo docker pull debian
    - sudo ip link add testdummy type dummy
    - sudo ip addr add 198.51.100.1/24 dev testdummy
-   - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=deadcode ./...
+   - gometalinter.v1 --deadline=5m --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=deadcode --enable=varcheck --enable=structcheck ./...
    - cd _release/bat
-   - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=deadcode ./...
+   - gometalinter.v1 --deadline=5m --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=deadcode --enable=varcheck --enable=structcheck ./...
    - cd ../..
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo mkdir -p /var/lib/ciao/data/controller/workloads
@@ -65,12 +66,6 @@ script:
    - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/... github.com/01org/ciao/ciao-storage/... github.com/01org/ciao/deviceinfo github.com/01org/ciao/osprepare github.com/01org/ciao/templateutils
    - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
-   # API Documentation is automated by swagger, every PR will verify the documentation can be generated
-   # verify ciao-controller api documentation can be generated with swagger
-   - go get golang.org/x/sys/unix
-   - go get github.com/gorilla/context
-   - go get github.com/yvasiyarov/swagger
-   - $GOPATH/bin/swagger  -apiPackage=github.com/01org/ciao/ciao-controller -mainApiFile=github.com/01org/ciao/ciao-controller/main.go -format=markdown -contentsTable=false -models=false -vendoringPath $HOME/gopath/src/github.com/01org/ciao/vendor
    # Test ansible playbooks
    - ansible-playbook -i _DeploymentAndDistroPackaging/ansible/tests/hosts _DeploymentAndDistroPackaging/ansible/ciao.yml --syntax-check
 

--- a/vendor/github.com/01org/ciao/DeveloperQuickStart.md
+++ b/vendor/github.com/01org/ciao/DeveloperQuickStart.md
@@ -105,9 +105,9 @@ completely self contained.
 On the host install the latest release of go for your distribution
 [Installing Go](https://golang.org/doc/install).
 
-> NOTE: Go version 1.7 or later is required for Ciao. Ciao will not work with 
+> NOTE: Go version 1.8 or later is required for Ciao. Ciao will not work with 
 older version of Go. Hence it is best you download and install the latest 
-version of Go if you distro is not on Go 1.7.
+version of Go if you distro is not on Go 1.8.
 
 You should also ensure that your GOPATH environment variable is set.
 
@@ -117,20 +117,20 @@ ciao-down is a small utility for setting up a VM that contains
 everything you need to run ciao's Single VM. All you need to have
 installed on your machine is:
 
-- Go 1.7 or greater
+- Go 1.8 or greater
 
 Once Go is installed you simply need to type
 
 ```
 go get github.com/01org/ciao/testutil/ciao-down
-$GOPATH/bin/ciao-down prepare
+$GOPATH/bin/ciao-down create ciao
 ```
 
 ciao-down will install some needed dependencies on your local PC such
 as qemu and xorriso. It will then download an Ubuntu Cloud Image and
 create a VM based on this image. It will boot the VM and install in that
 VM everything you need to run ciao Single VM, including docker, ceph,
-go, gcc, etc. When ciao-down prepare has finished you can connect to the
+go, gcc, etc. When ciao-down create has finished you can connect to the
 newly created VM with
 
 ```
@@ -144,7 +144,7 @@ the ciao code on your host machine and test in Single VM.
 ## Proxies
 
 One of the nice things about using ciao-down is that it is proxy aware.
-When you run ciao-down prepare, ciao-down looks in its environment for
+When you run ciao-down create, ciao-down looks in its environment for
 proxy variables such as http_proxy, https_proxy and no_proxy.  If it
 finds them it ensures that these proxies are correctly configured for
 all the software that it installs and uses inside the VM, e.g., apt, docker,
@@ -155,17 +155,17 @@ before running ciao-down.
 ## Ciao-webui
 
 Ciao has a webui called ciao-webui (https://github.com/01org/ciao-webui).
-When ciao-down prepare is run, ciao-down downloads the source code for
+When ciao-down create is run, ciao-down downloads the source code for
 the ciao-webui and all the development tools needed to build it.  By
 default, ciao-down stores the code for the web-ui in ~/ciao-webui.
 
 If you wish to actively work on the sources of ciao-webui you can ask
-ciao-down prepare to mount a host directory containing the webui sources
-into the VM.  This is done using the -ui-path option of ciao-down prepare.
+ciao-down create to mount a host directory containing the webui sources
+into the VM.  This is done using the -ui-path option of ciao-down create.
 For example
 
 ```
-ciao-down prepare --ui-path $HOME/src/ciao-webui
+ciao-down create --ui-path $HOME/src/ciao-webui ciao
 ```
 
 would mount the $HOME/src/ciao-webui directory inside the VM at the

--- a/vendor/github.com/01org/ciao/README.md
+++ b/vendor/github.com/01org/ciao/README.md
@@ -43,14 +43,12 @@ set of [payloads](https://github.com/01org/ciao/blob/master/payloads).
 
 This GitHub repository contains documentation on the
 various sub-components of ciao in their respective
-subdirectories.  A comprehensive [ciao cluster setup
-document](https://clearlinux.org/documentation/ciao-cluster-setup.html)
-is also available.
+subdirectories.
 
 If you would like to contribute to ciao, check our [Contributing
 guide](https://github.com/01org/ciao/blob/master/CONTRIBUTING.md).
-The [wiki](https://github.com/01org/ciao/wiki/Single-Machine-Development-Environment)
-page ilustrates how to easily setup a development environment without
+There's a [wiki page](https://github.com/01org/ciao/blob/master/DeveloperQuickStart.md)
+that illustrates how to easily setup a development environment without
 needing a cluster. We also recommend taking a look at the ['janitorial'
 bugs](https://github.com/01org/ciao/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
 in our list of open issues as these bugs can be solved without an

--- a/vendor/github.com/01org/ciao/packages.json
+++ b/vendor/github.com/01org/ciao/packages.json
@@ -74,6 +74,16 @@
 		"version": "248dadf",
 		"license": "BSD (2-clause)"
 	},
+	"github.com/spf13/cobra": {
+		"url": "https://github.com/spf13/cobra.git",
+		"version": "b26b538",
+		"license": "Apache v2.0"
+	},
+	"github.com/spf13/pflag": {
+		"url": "https://github.com/spf13/pflag.git",
+		"version": "e57e3ee",
+		"license": "BSD (3 clause)"
+	},
 	"github.com/vishvananda/netlink": {
 		"url": "https://github.com/vishvananda/netlink.git",
 		"version": "1890b34",
@@ -83,6 +93,11 @@
 		"url": "https://github.com/vishvananda/netns.git",
 		"version": "2c9454e",
 		"license": "Apache v2.0"
+	},
+	"golang.org/x/crypto": {
+		"url": "https://github.com/golang/crypto",
+		"version": "558b687",
+		"license": "BSD 3-clause"
 	},
 	"golang.org/x/net": {
 		"url": "https://go.googlesource.com/net",

--- a/vendor/github.com/01org/ciao/qemu/qemu.go
+++ b/vendor/github.com/01org/ciao/qemu/qemu.go
@@ -202,6 +202,9 @@ type FSDevice struct {
 
 	// SecurityModel is the security model for this filesystem device.
 	SecurityModel SecurityModelType
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the FSDevice structure is valid and complete.
@@ -220,6 +223,9 @@ func (fsdev FSDevice) QemuParams(config *Config) []string {
 	var qemuParams []string
 
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", fsdev.Driver))
+	if fsdev.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf(",fsdev=%s", fsdev.ID))
 	deviceParams = append(deviceParams, fmt.Sprintf(",mount_tag=%s", fsdev.MountTag))
 
@@ -276,6 +282,9 @@ type CharDevice struct {
 	ID   string
 	Path string
 	Name string
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the CharDevice structure is valid and complete.
@@ -294,6 +303,9 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	var qemuParams []string
 
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", cdev.Driver))
+	if cdev.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
 	if cdev.Bus != "" {
 		deviceParams = append(deviceParams, fmt.Sprintf(",bus=%s", cdev.Bus))
 	}
@@ -366,6 +378,9 @@ type NetDevice struct {
 
 	// MACAddress is the networking device interface MAC address.
 	MACAddress string
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the NetDevice structure is valid and complete.
@@ -390,7 +405,13 @@ func (netdev NetDevice) QemuParams(config *Config) []string {
 	var deviceParams []string
 	var qemuParams []string
 
+	if netdev.Driver == VirtioNetPCI {
+		deviceParams = append(deviceParams, "driver=")
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", netdev.Driver))
+	if netdev.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf(",netdev=%s", netdev.ID))
 	deviceParams = append(deviceParams, fmt.Sprintf(",mac=%s", netdev.MACAddress))
 
@@ -451,6 +472,9 @@ type SerialDevice struct {
 
 	// ID is the serial device identifier.
 	ID string
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the SerialDevice structure is valid and complete.
@@ -468,6 +492,9 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 	var qemuParams []string
 
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", dev.Driver))
+	if dev.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", dev.ID))
 
 	qemuParams = append(qemuParams, "-device")
@@ -516,6 +543,9 @@ type BlockDevice struct {
 	Format    BlockDeviceFormat
 	SCSI      bool
 	WCE       bool
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the BlockDevice structure is valid and complete.
@@ -534,6 +564,9 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	var qemuParams []string
 
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", blkdev.Driver))
+	if blkdev.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf(",drive=%s", blkdev.ID))
 	if blkdev.SCSI == false {
 		deviceParams = append(deviceParams, ",scsi=off")

--- a/vendor/github.com/01org/ciao/qemu/qemu_test.go
+++ b/vendor/github.com/01org/ciao/qemu/qemu_test.go
@@ -104,7 +104,7 @@ func TestAppendDeviceNVDIMM(t *testing.T) {
 	testAppend(object, deviceNVDIMMString, t)
 }
 
-var deviceFSString = "-device virtio-9p-pci,fsdev=workload9p,mount_tag=rootfs -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none"
+var deviceFSString = "-device virtio-9p-pci,disable-modern=true,fsdev=workload9p,mount_tag=rootfs -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none"
 
 func TestAppendDeviceFS(t *testing.T) {
 	fsdev := FSDevice{
@@ -114,12 +114,13 @@ func TestAppendDeviceFS(t *testing.T) {
 		Path:          "/var/lib/docker/devicemapper/mnt/e31ebda2",
 		MountTag:      "rootfs",
 		SecurityModel: None,
+		DisableModern: true,
 	}
 
 	testAppend(fsdev, deviceFSString, t)
 }
 
-var deviceNetworkString = "-device virtio-net,netdev=tap0,mac=01:02:de:ad:be:ef -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
+var deviceNetworkString = "-device virtio-net,disable-modern=true,netdev=tap0,mac=01:02:de:ad:be:ef -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
 
 func TestAppendDeviceNetwork(t *testing.T) {
 	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
@@ -129,21 +130,22 @@ func TestAppendDeviceNetwork(t *testing.T) {
 	defer os.Remove(bar.Name())
 
 	netdev := NetDevice{
-		Driver:     VirtioNet,
-		Type:       TAP,
-		ID:         "tap0",
-		IFName:     "ceth0",
-		Script:     "no",
-		DownScript: "no",
-		FDs:        []*os.File{foo, bar},
-		VHost:      true,
-		MACAddress: "01:02:de:ad:be:ef",
+		Driver:        VirtioNet,
+		Type:          TAP,
+		ID:            "tap0",
+		IFName:        "ceth0",
+		Script:        "no",
+		DownScript:    "no",
+		FDs:           []*os.File{foo, bar},
+		VHost:         true,
+		MACAddress:    "01:02:de:ad:be:ef",
+		DisableModern: true,
 	}
 
 	testAppend(netdev, deviceNetworkString, t)
 }
 
-var deviceNetworkPCIString = "-device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
+var deviceNetworkPCIString = "-device driver=virtio-net-pci,disable-modern=true,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
 
 func TestAppendDeviceNetworkPCI(t *testing.T) {
 	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
@@ -153,28 +155,30 @@ func TestAppendDeviceNetworkPCI(t *testing.T) {
 	defer os.Remove(bar.Name())
 
 	netdev := NetDevice{
-		Driver:     VirtioNetPCI,
-		Type:       TAP,
-		ID:         "tap0",
-		IFName:     "ceth0",
-		Bus:        "/pci-bus/pcie.0",
-		Addr:       "255",
-		Script:     "no",
-		DownScript: "no",
-		FDs:        []*os.File{foo, bar},
-		VHost:      true,
-		MACAddress: "01:02:de:ad:be:ef",
+		Driver:        VirtioNetPCI,
+		Type:          TAP,
+		ID:            "tap0",
+		IFName:        "ceth0",
+		Bus:           "/pci-bus/pcie.0",
+		Addr:          "255",
+		Script:        "no",
+		DownScript:    "no",
+		FDs:           []*os.File{foo, bar},
+		VHost:         true,
+		MACAddress:    "01:02:de:ad:be:ef",
+		DisableModern: true,
 	}
 
 	testAppend(netdev, deviceNetworkPCIString, t)
 }
 
-var deviceSerialString = "-device virtio-serial-pci,id=serial0"
+var deviceSerialString = "-device virtio-serial-pci,disable-modern=true,id=serial0"
 
 func TestAppendDeviceSerial(t *testing.T) {
 	sdev := SerialDevice{
-		Driver: VirtioSerial,
-		ID:     "serial0",
+		Driver:        VirtioSerial,
+		ID:            "serial0",
+		DisableModern: true,
 	}
 
 	testAppend(sdev, deviceSerialString, t)
@@ -195,18 +199,19 @@ func TestAppendDeviceSerialPort(t *testing.T) {
 	testAppend(chardev, deviceSerialPortString, t)
 }
 
-var deviceBlockString = "-device virtio-blk,drive=hd0,scsi=off,config-wce=off -drive id=hd0,file=/var/lib/ciao.img,aio=threads,format=qcow2,if=none"
+var deviceBlockString = "-device virtio-blk,disable-modern=true,drive=hd0,scsi=off,config-wce=off -drive id=hd0,file=/var/lib/ciao.img,aio=threads,format=qcow2,if=none"
 
 func TestAppendDeviceBlock(t *testing.T) {
 	blkdev := BlockDevice{
-		Driver:    VirtioBlock,
-		ID:        "hd0",
-		File:      "/var/lib/ciao.img",
-		AIO:       Threads,
-		Format:    QCOW2,
-		Interface: NoInterface,
-		SCSI:      false,
-		WCE:       false,
+		Driver:        VirtioBlock,
+		ID:            "hd0",
+		File:          "/var/lib/ciao.img",
+		AIO:           Threads,
+		Format:        QCOW2,
+		Interface:     NoInterface,
+		SCSI:          false,
+		WCE:           false,
+		DisableModern: true,
 	}
 
 	testAppend(blkdev, deviceBlockString, t)

--- a/vendor/github.com/01org/ciao/qemu/qmp.go
+++ b/vendor/github.com/01org/ciao/qemu/qmp.go
@@ -107,8 +107,7 @@ type QMPEvent struct {
 }
 
 type qmpResult struct {
-	err  error
-	data map[string]interface{}
+	err error
 }
 
 type qmpCommand struct {
@@ -128,6 +127,7 @@ type QMP struct {
 	cfg            QMPConfig
 	connectedCh    chan<- *QMPVersion
 	disconnectedCh chan struct{}
+	version        *QMPVersion
 }
 
 // QMPVersion contains the version number and the capabailities of a QEMU
@@ -534,7 +534,6 @@ func QMPStart(ctx context.Context, socket string, cfg QMPConfig, disconnectedCh 
 
 	connectedCh := make(chan *QMPVersion)
 
-	var version *QMPVersion
 	q := startQMPLoop(conn, cfg, connectedCh, disconnectedCh)
 	select {
 	case <-ctx.Done():
@@ -543,13 +542,13 @@ func QMPStart(ctx context.Context, socket string, cfg QMPConfig, disconnectedCh 
 		return nil, nil, fmt.Errorf("Canceled by caller")
 	case <-disconnectedCh:
 		return nil, nil, fmt.Errorf("Lost connection to VM")
-	case version = <-connectedCh:
-		if version == nil {
+	case q.version = <-connectedCh:
+		if q.version == nil {
 			return nil, nil, fmt.Errorf("Failed to find QMP version information")
 		}
 	}
 
-	return q, version, nil
+	return q, q.version, nil
 }
 
 // Shutdown closes the domain socket used to monitor a QEMU instance and
@@ -603,16 +602,26 @@ func (q *QMP) ExecuteQuit(ctx context.Context) error {
 // used to name the device.  As this identifier will be passed directly to QMP,
 // it must obey QMP's naming rules, e,g., it must start with a letter.
 func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string) error {
-	args := map[string]interface{}{
-		"options": map[string]interface{}{
-			"driver": "raw",
-			"file": map[string]interface{}{
-				"driver":   "file",
-				"filename": device,
-			},
-			"id": blockdevID,
+	var args map[string]interface{}
+
+	blockdevArgs := map[string]interface{}{
+		"driver": "raw",
+		"file": map[string]interface{}{
+			"driver":   "file",
+			"filename": device,
 		},
 	}
+
+	if q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 9) {
+		blockdevArgs["node-name"] = blockdevID
+		args = blockdevArgs
+	} else {
+		blockdevArgs["id"] = blockdevID
+		args = map[string]interface{}{
+			"options": blockdevArgs,
+		}
+	}
+
 	return q.executeCommand(ctx, "blockdev-add", args, nil)
 }
 

--- a/vendor/github.com/01org/ciao/ssntp/server.go
+++ b/vendor/github.com/01org/ciao/ssntp/server.go
@@ -72,7 +72,6 @@ type Server struct {
 	stopped       boolFlag
 	stoppedChan   chan struct{}
 	role          Role
-	roleVerify    bool
 	clientWg      sync.WaitGroup
 
 	forwardRules frameForward

--- a/vendor/github.com/01org/ciao/ssntp/ssntp_test.go
+++ b/vendor/github.com/01org/ciao/ssntp/ssntp_test.go
@@ -189,9 +189,6 @@ type ssntpClient struct {
 	cmdTracedChannel   chan string
 	cmdDurationChannel chan time.Duration
 	cmdDumpChannel     chan struct{}
-	staTracedChannel   chan string
-	evtTracedChannel   chan string
-	errTracedChannel   chan string
 }
 
 func (client *ssntpClient) ConnectNotify() {

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "8aeee1901c7bb4988c53db9dc56dfb60b011f46e"
+  revision = "add4d7434b13ea7fc5f1c8d43e4864a67cf329a8"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/Makefile
+++ b/vendor/github.com/containers/virtcontainers/Makefile
@@ -32,7 +32,7 @@ virtc:
 	$(QUIET_GOBUILD)go build -o $(VIRTC_DIR)/$@ $(VIRTC_DIR)/*.go
 
 pause:
-	make -C $@
+	$(QUIET_GOBUILD)go build -o $(PAUSE_DIR)/$(PAUSE_BIN) pause/*.go
 
 hook:
 	$(QUIET_GOBUILD)go build -o $(HOOK_DIR)/$@ $(HOOK_DIR)/*.go
@@ -100,7 +100,7 @@ uninstall:
 
 clean:
 	rm -f $(VIRTC_DIR)/$(VIRTC_BIN)
-	make -C $(PAUSE_BIN) clean
+	rm -f $(PAUSE_DIR)/$(PAUSE_BIN)
 	rm -f $(HOOK_DIR)/$(HOOK_BIN)
 	rm -f $(SHIM_DIR)/$(SHIM_BIN)
 

--- a/vendor/github.com/containers/virtcontainers/NEWS
+++ b/vendor/github.com/containers/virtcontainers/NEWS
@@ -1,3 +1,10 @@
+1.0.0-rc.4:
+	Added new project approvers
+	Fixed gometalinter
+	Increased unit test coverage
+	Added "pc" machine type for Qemu hypervisor
+	Fixed "kill" and "stop" container
+
 1.0.0-rc.3:
 	Added support for assigning the container rootfs underlying block device to the VM (when using devicemapper)
 	Changed qemu to use virtio-net vhost by default

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containers/virtcontainers/pkg/hyperstart"
 )
 
-var defaultSockPathTemplates = []string{"/tmp/hyper-pod-%s.sock", "/tmp/tty-pod%s.sock"}
+var defaultSockPathTemplates = []string{"%s/%s/hyper.sock", "%s/%s/tty.sock"}
 var defaultChannelTemplate = "sh.hyper.channel.%d"
 var defaultDeviceIDTemplate = "channel%d"
 var defaultIDTemplate = "charch%d"
@@ -58,8 +58,8 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		virtLog.Infof("No sockets from configuration")
 
 		podSocketPaths := []string{
-			fmt.Sprintf(defaultSockPathTemplates[0], pod.id),
-			fmt.Sprintf(defaultSockPathTemplates[1], pod.id),
+			fmt.Sprintf(defaultSockPathTemplates[0], runStoragePath, pod.id),
+			fmt.Sprintf(defaultSockPathTemplates[1], runStoragePath, pod.id),
 		}
 
 		c.SockCtlName = podSocketPaths[0]
@@ -114,10 +114,13 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperstart.Process, error)
 	}
 
 	process := &hyperstart.Process{
-		Terminal: cmd.Interactive,
-		Args:     cmd.Args,
-		Envs:     envVars,
-		Workdir:  cmd.WorkDir,
+		Terminal:         cmd.Interactive,
+		Args:             cmd.Args,
+		Envs:             envVars,
+		Workdir:          cmd.WorkDir,
+		User:             cmd.User,
+		Group:            cmd.PrimaryGroup,
+		AdditionalGroups: cmd.SupplementaryGroups,
 	}
 
 	return process, nil

--- a/vendor/github.com/containers/virtcontainers/hypervisor_test.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor_test.go
@@ -18,6 +18,9 @@ package virtcontainers
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -351,5 +354,146 @@ func TestAddKernelParamInvalid(t *testing.T) {
 	err := config.AddKernelParam(invalid[0])
 	if err == nil {
 		t.Fatal()
+	}
+}
+
+func TestGetHostMemorySizeKb(t *testing.T) {
+
+	type testData struct {
+		contents       string
+		expectedResult int
+		expectError    bool
+	}
+
+	data := []testData{
+		{
+			`
+			MemTotal:      1 kB
+			MemFree:       2 kB
+			SwapTotal:     3 kB
+			SwapFree:      4 kB
+			`,
+			1024,
+			false,
+		},
+		{
+			`
+			MemFree:       2 kB
+			SwapTotal:     3 kB
+			SwapFree:      4 kB
+			`,
+			0,
+			true,
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file := filepath.Join(dir, "meminfo")
+	if _, err := getHostMemorySizeKb(file); err == nil {
+		t.Fatalf("expected failure as file %q does not exist", file)
+	}
+
+	for _, d := range data {
+		if err := ioutil.WriteFile(file, []byte(d.contents), os.FileMode(0640)); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file)
+
+		hostMemKb, err := getHostMemorySizeKb(file)
+
+		if (d.expectError && err == nil) || (!d.expectError && err != nil) {
+			t.Fatalf("got %d, input %v", hostMemKb, d)
+		}
+
+		if reflect.DeepEqual(hostMemKb, d.expectedResult) {
+			t.Fatalf("got %d, input %v", hostMemKb, d)
+		}
+	}
+}
+
+var dataFlagsFieldWithoutHypervisor = []byte(`
+fpu_exception   : yes
+cpuid level     : 20
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology eagerfpu pni pclmulqdq vmx ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch tpr_shadow vnmi ept vpid fsgsbase bmi1 hle avx2 smep bmi2 erms rtm rdseed adx smap xsaveopt
+bugs            :
+bogomips        : 4589.35
+`)
+
+var dataFlagsFieldWithHypervisor = []byte(`
+fpu_exception   : yes
+cpuid level     : 20
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology eagerfpu pni pclmulqdq vmx ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch tpr_shadow vnmi ept vpid fsgsbase bmi1 hle avx2 smep bmi2 erms rtm rdseed adx smap xsaveopt
+bugs            :
+bogomips        : 4589.35
+`)
+
+var dataWithoutFlagsField = []byte(`
+fpu_exception   : yes
+cpuid level     : 20
+wp              : yes
+bugs            :
+bogomips        : 4589.35
+`)
+
+func testRunningOnVMMSuccessful(t *testing.T, cpuInfoContent []byte, expectedErr bool, expected bool) {
+	f, err := ioutil.TempFile("", "cpuinfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	n, err := f.Write(cpuInfoContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(cpuInfoContent) {
+		t.Fatalf("Only %d bytes written out of %d expected", n, len(cpuInfoContent))
+	}
+
+	running, err := RunningOnVMM(f.Name())
+	if !expectedErr && err != nil {
+		t.Fatalf("This test should succeed: %v", err)
+	} else if expectedErr && err == nil {
+		t.Fatalf("This test should fail")
+	}
+
+	if running != expected {
+		t.Fatalf("Expecting running on VMM = %t, Got %t", expected, running)
+	}
+}
+
+func TestRunningOnVMMFalseSuccessful(t *testing.T) {
+	testRunningOnVMMSuccessful(t, dataFlagsFieldWithoutHypervisor, false, false)
+}
+
+func TestRunningOnVMMTrueSuccessful(t *testing.T) {
+	testRunningOnVMMSuccessful(t, dataFlagsFieldWithHypervisor, false, true)
+}
+
+func TestRunningOnVMMNoFlagsFieldFailure(t *testing.T) {
+	testRunningOnVMMSuccessful(t, dataWithoutFlagsField, true, false)
+}
+
+func TestRunningOnVMMNotExistingCPUInfoPathFailure(t *testing.T) {
+	f, err := ioutil.TempFile("", "cpuinfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := f.Name()
+
+	f.Close()
+	os.Remove(filePath)
+
+	if _, err := RunningOnVMM(filePath); err == nil {
+		t.Fatalf("Should fail because %q file path does not exist", filePath)
 	}
 }

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -98,9 +98,11 @@ func TestQemuBuildKernelParamsFoo(t *testing.T) {
 	}
 }
 
-func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Device, devType deviceType) {
+func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Device, devType deviceType, nestedVM bool) {
 	var devices []ciaoQemu.Device
-	q := &qemu{}
+	q := &qemu{
+		nestedRun: nestedVM,
+	}
 
 	switch s := structure.(type) {
 	case Volume:
@@ -126,6 +128,7 @@ func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Dev
 func TestQemuAppendVolume(t *testing.T) {
 	mountTag := "testMountTag"
 	hostPath := "testHostPath"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.FSDevice{
@@ -135,6 +138,7 @@ func TestQemuAppendVolume(t *testing.T) {
 			Path:          hostPath,
 			MountTag:      mountTag,
 			SecurityModel: ciaoQemu.None,
+			DisableModern: nestedVM,
 		},
 	}
 
@@ -143,7 +147,7 @@ func TestQemuAppendVolume(t *testing.T) {
 		HostPath: hostPath,
 	}
 
-	testQemuAppend(t, volume, expectedOut, -1)
+	testQemuAppend(t, volume, expectedOut, -1, nestedVM)
 }
 
 func TestQemuAppendSocket(t *testing.T) {
@@ -151,6 +155,7 @@ func TestQemuAppendSocket(t *testing.T) {
 	id := "charchTest"
 	hostPath := "/tmp/hyper_test.sock"
 	name := "sh.hyper.channel.test"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.CharDevice{
@@ -170,22 +175,24 @@ func TestQemuAppendSocket(t *testing.T) {
 		Name:     name,
 	}
 
-	testQemuAppend(t, socket, expectedOut, -1)
+	testQemuAppend(t, socket, expectedOut, -1, nestedVM)
 }
 
 func TestQemuAppendBlockDevice(t *testing.T) {
 	id := "blockDevTest"
 	file := "/root"
 	format := "raw"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.BlockDevice{
-			Driver:    ciaoQemu.VirtioBlock,
-			ID:        id,
-			File:      "/root",
-			AIO:       ciaoQemu.Threads,
-			Format:    ciaoQemu.BlockDeviceFormat(format),
-			Interface: "none",
+			Driver:        ciaoQemu.VirtioBlock,
+			ID:            id,
+			File:          "/root",
+			AIO:           ciaoQemu.Threads,
+			Format:        ciaoQemu.BlockDeviceFormat(format),
+			Interface:     "none",
+			DisableModern: nestedVM,
 		},
 	}
 
@@ -195,7 +202,7 @@ func TestQemuAppendBlockDevice(t *testing.T) {
 		ID:     id,
 	}
 
-	testQemuAppend(t, drive, expectedOut, -1)
+	testQemuAppend(t, drive, expectedOut, -1, nestedVM)
 }
 
 func TestQemuAppendFSDevices(t *testing.T) {
@@ -204,6 +211,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 	contRootFs := "testContRootFs"
 	volMountTag := "testVolMountTag"
 	volHostPath := "testVolHostPath"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.FSDevice{
@@ -213,6 +221,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 			Path:          fmt.Sprintf("%s.1", contRootFs),
 			MountTag:      "ctr-rootfs-0",
 			SecurityModel: ciaoQemu.None,
+			DisableModern: nestedVM,
 		},
 		ciaoQemu.FSDevice{
 			Driver:        ciaoQemu.Virtio9P,
@@ -221,6 +230,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 			Path:          fmt.Sprintf("%s.2", contRootFs),
 			MountTag:      "ctr-rootfs-1",
 			SecurityModel: ciaoQemu.None,
+			DisableModern: nestedVM,
 		},
 		ciaoQemu.FSDevice{
 			Driver:        ciaoQemu.Virtio9P,
@@ -229,6 +239,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 			Path:          fmt.Sprintf("%s.1", volHostPath),
 			MountTag:      fmt.Sprintf("%s.1", volMountTag),
 			SecurityModel: ciaoQemu.None,
+			DisableModern: nestedVM,
 		},
 		ciaoQemu.FSDevice{
 			Driver:        ciaoQemu.Virtio9P,
@@ -237,6 +248,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 			Path:          fmt.Sprintf("%s.2", volHostPath),
 			MountTag:      fmt.Sprintf("%s.2", volMountTag),
 			SecurityModel: ciaoQemu.None,
+			DisableModern: nestedVM,
 		},
 	}
 
@@ -268,16 +280,18 @@ func TestQemuAppendFSDevices(t *testing.T) {
 		Containers: containers,
 	}
 
-	testQemuAppend(t, podConfig, expectedOut, fsDev)
+	testQemuAppend(t, podConfig, expectedOut, fsDev, nestedVM)
 }
 
 func TestQemuAppendConsoles(t *testing.T) {
 	podID := "testPodID"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.SerialDevice{
-			Driver: ciaoQemu.VirtioSerial,
-			ID:     "serial0",
+			Driver:        ciaoQemu.VirtioSerial,
+			ID:            "serial0",
+			DisableModern: nestedVM,
 		},
 		ciaoQemu.CharDevice{
 			Driver:   ciaoQemu.Console,
@@ -293,7 +307,7 @@ func TestQemuAppendConsoles(t *testing.T) {
 		Containers: []ContainerConfig{},
 	}
 
-	testQemuAppend(t, podConfig, expectedOut, consoleDev)
+	testQemuAppend(t, podConfig, expectedOut, consoleDev, nestedVM)
 }
 
 func TestQemuAppendImage(t *testing.T) {
@@ -395,10 +409,16 @@ func TestQemuSetMemoryResources(t *testing.T) {
 
 	q := &qemu{}
 
+	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	memMax := fmt.Sprintf("%dM", int(float64(hostMemKb)/1024)+maxMemoryOffset)
+
 	expectedOut := ciaoQemu.Memory{
 		Size:   "1000M",
 		Slots:  uint8(2),
-		MaxMem: "1500M",
+		MaxMem: memMax,
 	}
 
 	vmConfig := Resources{
@@ -409,15 +429,20 @@ func TestQemuSetMemoryResources(t *testing.T) {
 		VMConfig: vmConfig,
 	}
 
-	memory := q.setMemoryResources(podConfig)
+	memory, err := q.setMemoryResources(podConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if reflect.DeepEqual(memory, expectedOut) == false {
 		t.Fatalf("Got %v\nExpecting %v", memory, expectedOut)
 	}
 }
 
-func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []ciaoQemu.Device) {
-	q := &qemu{}
+func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []ciaoQemu.Device, nestedVM bool) {
+	q := &qemu{
+		nestedRun: nestedVM,
+	}
 
 	err := q.addDevice(devInfo, devType)
 	if err != nil {
@@ -432,6 +457,7 @@ func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, ex
 func TestQemuAddDeviceFsDev(t *testing.T) {
 	mountTag := "testMountTag"
 	hostPath := "testHostPath"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.FSDevice{
@@ -441,6 +467,7 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 			Path:          hostPath,
 			MountTag:      mountTag,
 			SecurityModel: ciaoQemu.None,
+			DisableModern: nestedVM,
 		},
 	}
 
@@ -449,7 +476,7 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 		HostPath: hostPath,
 	}
 
-	testQemuAddDevice(t, volume, fsDev, expectedOut)
+	testQemuAddDevice(t, volume, fsDev, expectedOut, nestedVM)
 }
 
 func TestQemuAddDeviceSerialPordDev(t *testing.T) {
@@ -457,6 +484,7 @@ func TestQemuAddDeviceSerialPordDev(t *testing.T) {
 	id := "charchTest"
 	hostPath := "/tmp/hyper_test.sock"
 	name := "sh.hyper.channel.test"
+	nestedVM := true
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.CharDevice{
@@ -476,7 +504,7 @@ func TestQemuAddDeviceSerialPordDev(t *testing.T) {
 		Name:     name,
 	}
 
-	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
+	testQemuAddDevice(t, socket, serialPortDev, expectedOut, nestedVM)
 }
 
 func TestQemuGetPodConsole(t *testing.T) {


### PR DESCRIPTION
Shortlog of what have been added since the last vendoring:

e99f6b2 qemu: Enable specific flags if running on VMM
3b40bc0 hyperstart: add suport for user, group and additional groups
f7be1c0 hypervisor: Detect if running on a VMM
b79ccb4 vendor: Update ciao vendoring
47c6912 pause: Rewrite pause binary in go.
f82fc60 pkg: oci: support OCI spec cpu quota/period
1b02f69 pkg: oci: support OCI spec memory limit
d0bb122 qemu: set maxmem to host memory size
4dce315 hyperstart: move hyper and tty socket to per-pod runtime
2018d1a 1.0.0-rc.4 release
1140aca hypervisor: export SerializeParams and DeserializeParams
89577b2 pod: Allow to stop a pod in ready state as a special case
8fdcb90 pod: Ignore container ready or stopped when stopping the pod
72a0be6 pod: Factorize pod stop() function
7f61c04 container: Don't issue an error if trying to stop a stopped
10c592f container: Signal a ready container is valid but not stopping
ae8fcbb api: Update the container status when retrieving its status

The vendoring of ciao package has also been updated because
virtcontainers relies on latest ciao version.

Fixes #436