### PR TITLE
state: Apply indentation to the state output.

### DIFF
--- a/state.go
+++ b/state.go
@@ -55,7 +55,7 @@ func state(containerID string) error {
 		return err
 	}
 
-	stateJSON, err := json.Marshal(state)
+	stateJSON, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The json displayed with container state command is
not idented. Apply indentaion for readability.

Fixes #445

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>