### PR TITLE
tests: switchable virtcontainers implementation

### DIFF
--- a/create.go
+++ b/create.go
@@ -183,7 +183,7 @@ func createPod(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 		return vc.Process{}, err
 	}
 
-	pod, err := vc.CreatePod(podConfig)
+	pod, err := vci.CreatePod(podConfig)
 	if err != nil {
 		return vc.Process{}, err
 	}
@@ -209,7 +209,7 @@ func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 		return vc.Process{}, err
 	}
 
-	_, c, err := vc.CreateContainer(podID, contConfig)
+	_, c, err := vci.CreateContainer(podID, contConfig)
 	if err != nil {
 		return vc.Process{}, err
 	}

--- a/delete.go
+++ b/delete.go
@@ -114,11 +114,11 @@ func delete(containerID string, force bool) error {
 }
 
 func deletePod(podID string) error {
-	if _, err := vc.StopPod(podID); err != nil {
+	if _, err := vci.StopPod(podID); err != nil {
 		return err
 	}
 
-	if _, err := vc.DeletePod(podID); err != nil {
+	if _, err := vci.DeletePod(podID); err != nil {
 		return err
 	}
 
@@ -127,12 +127,12 @@ func deletePod(podID string) error {
 
 func deleteContainer(podID, containerID string, forceStop bool) error {
 	if forceStop {
-		if _, err := vc.StopContainer(podID, containerID); err != nil {
+		if _, err := vci.StopContainer(podID, containerID); err != nil {
 			return err
 		}
 	}
 
-	if _, err := vc.DeleteContainer(podID, containerID); err != nil {
+	if _, err := vci.DeleteContainer(podID, containerID); err != nil {
 		return err
 	}
 

--- a/exec.go
+++ b/exec.go
@@ -230,7 +230,7 @@ func execute(context *cli.Context) error {
 		Detach:      noNeedForOutput(params.detach, params.ociProcess.Terminal),
 	}
 
-	_, _, process, err := vc.EnterContainer(podID, params.cID, cmd)
+	_, _, process, err := vci.EnterContainer(podID, params.cID, cmd)
 	if err != nil {
 		return err
 	}

--- a/kill.go
+++ b/kill.go
@@ -116,7 +116,7 @@ func kill(containerID, signal string, all bool) error {
 		return fmt.Errorf("Container %s not ready or running, cannot send a signal", containerID)
 	}
 
-	if err := vc.KillContainer(podID, containerID, signum, all); err != nil {
+	if err := vci.KillContainer(podID, containerID, signum, all); err != nil {
 		return err
 	}
 

--- a/list.go
+++ b/list.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/urfave/cli"
 
-	vc "github.com/containers/virtcontainers"
 	oci "github.com/containers/virtcontainers/pkg/oci"
 )
 
@@ -200,7 +199,7 @@ func getContainers(context *cli.Context) ([]fullContainerState, error) {
 		return nil, err
 	}
 
-	podList, err := vc.ListPod()
+	podList, err := vci.ListPod()
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,14 @@ NOTES:
 
 var ccLog = logrus.New()
 
+// concrete virtcontainer implementation
+var virtcontainersImpl = &vc.VCImpl{}
+
+// vci is used to access a particular virtcontainers implementation.
+// Normally, it refers to the official package, but is re-assigned in
+// the tests to allow virtcontainers to be mocked.
+var vci vc.VC = virtcontainersImpl
+
 func beforeSubcommands(context *cli.Context) error {
 	if userWantsUsage(context) || (context.NArg() == 1 && (context.Args()[0] == "cc-check")) {
 		// No setup required if the user just
@@ -80,7 +88,7 @@ func beforeSubcommands(context *cli.Context) error {
 	}
 
 	// Set virtcontainers logger.
-	vc.SetLogger(ccLog)
+	vci.SetLogger(ccLog)
 
 	ignoreLogging := false
 	if context.NArg() == 1 && context.Args()[0] == "cc-env" {

--- a/main_test.go
+++ b/main_test.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/containers/virtcontainers/pkg/vcMock"
 	"github.com/dlespiau/covertool/pkg/cover"
 )
 
@@ -36,6 +37,14 @@ const (
 
 // package variables set in TestMain
 var testDir = ""
+
+// testingImpl is a concrete mock RVC implementation used for testing
+var testingImpl = &vcMock.VCMock{}
+
+func init() {
+	fmt.Printf("INFO: switching to fake virtcontainers implementation for testing\n")
+	vci = testingImpl
+}
 
 func runUnitTests(m *testing.M) {
 	var err error

--- a/oci.go
+++ b/oci.go
@@ -62,7 +62,7 @@ func getContainerInfo(containerID string) (vc.ContainerStatus, string, error) {
 		return vc.ContainerStatus{}, "", fmt.Errorf("Missing container ID")
 	}
 
-	podStatusList, err := vc.ListPod()
+	podStatusList, err := vci.ListPod()
 	if err != nil {
 		return vc.ContainerStatus{}, "", err
 	}

--- a/pause.go
+++ b/pause.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	vc "github.com/containers/virtcontainers"
 	"github.com/urfave/cli"
 )
 
@@ -58,9 +57,9 @@ func toggleContainerPause(containerID string, pause bool) (err error) {
 	}
 
 	if pause {
-		_, err = vc.PausePod(podID)
+		_, err = vci.PausePod(podID)
 	} else {
-		_, err = vc.ResumePod(podID)
+		_, err = vci.ResumePod(podID)
 	}
 
 	return err

--- a/start.go
+++ b/start.go
@@ -63,10 +63,10 @@ func start(containerID string) (vc.VCPod, error) {
 	}
 
 	if containerType.IsPod() {
-		return vc.StartPod(podID)
+		return vci.StartPod(podID)
 	}
 
-	c, err := vc.StartContainer(podID, containerID)
+	c, err := vci.StartContainer(podID, containerID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make the virtcontainers implementation switchable for testing.

By default, the official virtcontainers implementation is used, but
switch to the VCMock implementation for testing.

Fixes #449.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>