### PR TITLE
config: Add comment about ncpus >0 <=255

### DIFF
--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -12,7 +12,8 @@ kernel_params = "@KERNELPARAMS@"
 # Default number of vCPUs per POD/VM:
 # unspecified or 0 --> will be set to @DEFVCPUS@
 # < 0              --> will be set to the actual number of physical cores
-# > 255            --> will be set to 255.
+# > 0 <= 255       --> will be set to the specified number
+# > 255            --> will be set to 255
 default_vcpus = -1
 # Default memory size in MiB for POD/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.


### PR DESCRIPTION
The comment section for default_vcpus neglected to mention that
settings between 1 and 255 set the actual number of vcpus created
in the VM.

Fixes: #453

Signed-off-by: Graham Whaley <graham.whaley@intel.com>