### PR TITLE
tests: Increase unit-test coverage for list.go

### DIFF
--- a/cc-env.go
+++ b/cc-env.go
@@ -33,10 +33,6 @@ import (
 // (meaning any change to the EnvInfo type).
 const formatVersion = "1.0.2"
 
-// defaultOutputFile is the default output file to write the gathered
-// information to.
-var defaultOutputFile = os.Stdout
-
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
 	// output format version

--- a/list.go
+++ b/list.go
@@ -113,7 +113,7 @@ To list containers created using a non-default value for "--root":
 			return err
 		}
 
-		file := os.Stdout
+		file := defaultOutputFile
 		showAll := context.Bool("cc-all")
 
 		if context.Bool("quiet") {
@@ -244,17 +244,33 @@ func getContainers(context *cli.Context) ([]fullContainerState, error) {
 //
 // It ensures all paths are fully expanded.
 func getHypervisorDetails(runtimeConfig oci.RuntimeConfig) (hypervisorDetails, error) {
-	hypervisorPath, err := filepath.EvalSymlinks(runtimeConfig.HypervisorConfig.HypervisorPath)
+	initialHypervisorPath := runtimeConfig.HypervisorConfig.HypervisorPath
+	initialKernelPath := runtimeConfig.HypervisorConfig.KernelPath
+	initialImagePath := runtimeConfig.HypervisorConfig.ImagePath
+
+	if initialHypervisorPath == "" {
+		return hypervisorDetails{}, fmt.Errorf("Need hypervisor path")
+	}
+
+	if initialKernelPath == "" {
+		return hypervisorDetails{}, fmt.Errorf("Need kernel path")
+	}
+
+	if initialImagePath == "" {
+		return hypervisorDetails{}, fmt.Errorf("Need image path")
+	}
+
+	hypervisorPath, err := filepath.EvalSymlinks(initialHypervisorPath)
 	if err != nil {
 		return hypervisorDetails{}, err
 	}
 
-	kernelPath, err := filepath.EvalSymlinks(runtimeConfig.HypervisorConfig.KernelPath)
+	kernelPath, err := filepath.EvalSymlinks(initialKernelPath)
 	if err != nil {
 		return hypervisorDetails{}, err
 	}
 
-	imagePath, err := filepath.EvalSymlinks(runtimeConfig.HypervisorConfig.ImagePath)
+	imagePath, err := filepath.EvalSymlinks(initialImagePath)
 	if err != nil {
 		return hypervisorDetails{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,10 @@ var virtcontainersImpl = &vc.VCImpl{}
 // the tests to allow virtcontainers to be mocked.
 var vci vc.VC = virtcontainersImpl
 
+// defaultOutputFile is the default output file to write the gathered
+// information to.
+var defaultOutputFile = os.Stdout
+
 func beforeSubcommands(context *cli.Context) error {
 	if userWantsUsage(context) || (context.NArg() == 1 && (context.Args()[0] == "cc-check")) {
 		// No setup required if the user just


### PR DESCRIPTION
Increase unit-test coverage on list.go to 98.6%.

Once https://github.com/containers/virtcontainers/pull/355 lands and is
re-vendored into the runtime, coverage will be 100% for this file.

Fixes #404.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>