### PR TITLE
vendor: Update virtcontainers vendoring for updated StatusToOCIState

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/vcMock"]
-  revision = "913f9e723e3a4e1226534df650fe45e6285f074c"
+  revision = "e2c760d303ac0616f9e4fba774dbde93514c9556"
 
 [[projects]]
   branch = "master"

--- a/list.go
+++ b/list.go
@@ -213,10 +213,7 @@ func getContainers(context *cli.Context) ([]fullContainerState, error) {
 		}
 
 		for _, container := range pod.ContainersStatus {
-			ociState, err := oci.StatusToOCIState(container)
-			if err != nil {
-				return nil, err
-			}
+			ociState := oci.StatusToOCIState(container)
 
 			s = append(s, fullContainerState{
 				containerState: containerState{

--- a/state.go
+++ b/state.go
@@ -50,10 +50,7 @@ func state(containerID string) error {
 	}
 
 	// Convert the status to the expected State structure
-	state, err := oci.StatusToOCIState(status)
-	if err != nil {
-		return err
-	}
+	state := oci.StatusToOCIState(status)
 
 	stateJSON, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/hyperstart.go
@@ -439,7 +439,7 @@ func (h *Hyperstart) CodeFromCmd(cmd string) (uint32, error) {
 func (h *Hyperstart) CheckReturnedCode(recvCode, expectedCode uint32) error {
 	if recvCode != expectedCode {
 		if recvCode == ErrorCode {
-			return fmt.Errorf("ERROR received from Hyperstart")
+			return fmt.Errorf("ERROR received from VM agent")
 		}
 
 		return fmt.Errorf("CMD ID received %d not matching expected %d", recvCode, expectedCode)

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -431,8 +431,8 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 }
 
 // StatusToOCIState translates a virtcontainers container status into an OCI state.
-func StatusToOCIState(status vc.ContainerStatus) (spec.State, error) {
-	state := spec.State{
+func StatusToOCIState(status vc.ContainerStatus) spec.State {
+	return spec.State{
 		Version:     spec.Version,
 		ID:          status.ID,
 		Status:      StateToOCIState(status.State),
@@ -440,8 +440,6 @@ func StatusToOCIState(status vc.ContainerStatus) (spec.State, error) {
 		Bundle:      status.Annotations[BundlePathKey],
 		Annotations: status.Annotations,
 	}
-
-	return state, nil
 }
 
 // StateToOCIState translates a virtcontainers container state into an OCI one.

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -230,10 +230,7 @@ func TestVmConfig(t *testing.T) {
 }
 
 func testStatusToOCIStateSuccessful(t *testing.T, cStatus vc.ContainerStatus, expected specs.State) {
-	ociState, err := StatusToOCIState(cStatus)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ociState := StatusToOCIState(cStatus)
 
 	if reflect.DeepEqual(ociState, expected) == false {
 		t.Fatalf("Got %v\n expecting %v", ociState, expected)


### PR DESCRIPTION
Shortlog of what have been added since the last vendoring:

    ed778ce oci: Remove error return from StatusToOCIState()
    3758c22 agent: Make the error message from agent generic.

Fixes #479.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>