### PR TITLE
tests: Run unit tests as root and non-root.

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -6,7 +6,24 @@ root_dir=`dirname $script_dir`
 test_packages="."
 go_test_flags="-v -race -timeout 5s"
 
-echo Running go test on packages "'$test_packages'" with flags "'$go_test_flags'"
+# Run a command as either root or non-root (current user).
+#
+# If the first argument is "root", run using sudo, else run as normal.
+# All arguments after the first will be treated as the command to run.
+function run_as_user
+{
+	user="$1"
+	shift
+	cmd=$*
+
+	if [ "$user" = root ]
+	then
+		# use a shell to ensure PATH is correct.
+		sudo -E PATH="$PATH" sh -c "$cmd"
+	else
+		$cmd
+	fi
+}
 
 function test_html_coverage
 {
@@ -17,12 +34,26 @@ function test_html_coverage
 
 function test_coverage
 {
-	echo "mode: atomic" > profile.cov
+	cov_file="profile.cov"
+	tmp_cov_file="profile_tmp.cov"
+
+	echo "mode: atomic" > "$cov_file"
 
 	for pkg in $test_packages; do
-		go test $go_test_flags -covermode=atomic -coverprofile=profile_tmp.cov $pkg
-		[ -f profile_tmp.cov ] && tail -n +2 profile_tmp.cov >> profile.cov;
-		rm -f profile_tmp.cov
+
+		# Run the unit-tests *twice* (since some must run as root and
+		# others must run as non-root), combining the resulting test
+		# coverage files.
+		for user in non-root root; do
+			printf "INFO: Running 'go test' as %s user on packages '%s' with flags '%s'\n" "$user" "$test_packages" "$go_test_flags"
+
+			run_as_user "$user" go test $go_test_flags -covermode=atomic -coverprofile="$tmp_cov_file" $pkg
+			if [ -f "${tmp_cov_file}" ]; then
+				run_as_user "$user" chmod 644 "$tmp_cov_file"
+				tail -n +2 "$tmp_cov_file" >> "$cov_file"
+				run_as_user "$user" rm -f "$tmp_cov_file"
+			fi
+		done
 	done
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
 - make
-- sudo env "PATH=$PATH" make check
+- make check
 
 after_success:
 - sudo env "PATH=$PATH" go get github.com/mattn/goveralls


### PR DESCRIPTION
Some of the unit tests require root privileges to run. Conversely, some must
be run as a non-root user.

Modify the unit-tests to run twice, once as a non-root user and again
as the root user, and combine the resulting unit-test coverage files to
get a true unit-test coverage figure.

Fixes #483.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>