### PR TITLE
tests: Add test for exit.go

### DIFF
--- a/.ci/go-no-os-exit.sh
+++ b/.ci/go-no-os-exit.sh
@@ -6,6 +6,8 @@ for f in $candidates; do
 	filename=`basename $f`
 	# skip exit.go where, the only file we should call os.Exit() from.
 	[[ $filename == "exit.go" ]] && continue
+	# skip exit_test.go
+	[[ $filename == "exit_test.go" ]] && continue
 	# skip main_test.go
 	[[ $filename == "main_test.go" ]] && continue
 	files="$f $files"


### PR DESCRIPTION
Replace os.Exit() call in exit() with a call to function
variable exitFunc  that is assigned to os.Exit()

In the test assign exitFunc to a test function to help
test exit() with 0 and more atexit functions.

Fixes #402

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>