### PR TITLE
docs: Remove call to groupadd

### DIFF
--- a/docs/fedora-installation-guide.md
+++ b/docs/fedora-installation-guide.md
@@ -9,7 +9,6 @@ This step is only required in case Docker is not installed on the system.
 $ sudo dnf -y install dnf-plugins-core
 $ sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 $ sudo dnf makecache fast
-$ sudo groupadd docker
 $ sudo dnf -y install docker-ce
 ```
 


### PR DESCRIPTION
Adding the user to the docker group using groupadd(8) may not be a good
idea from a security perspective, so continue to use sudo(8) in all docs
to access docker.

Fixes #513.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>