### PR TITLE
scripts: relnotes: fix /bin/bash line

### DIFF
--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 script_dir=$(dirname "$0")
 


### PR DESCRIPTION
The script had the #!/bin/bash not on the first line, where
it should be. Fix with the obvious line move.

Fixes: #515

Signed-off-by: Graham Whaley <graham.whaley@intel.com>