### PR TITLE
scripts: relnotes: Add reminder to fixup Changes section

### DIFF
--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -49,6 +49,7 @@ fi
 
 changes(){
 	echo "## Changes"
+	echo "**FIXME - massage this section by hand to produce a summary please**"
 	git log --merges  "$from_commit"..HEAD  | awk '/Merge pull/{getline; getline;print }'  | \
 		while read -r pr
 		do


### PR DESCRIPTION
The Changes section, if left unedited, is pretty much just a copy
of the shortlog. Add a reminder in the auto-generated text that
this section should be edited down to a human readable overview.

Fixes: #517

Signed-off-by: Graham Whaley <graham.whaley@intel.com>