### PR TITLE
scripts: relnotes: fix path to limitations.md

### DIFF
--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -65,7 +65,7 @@ changes(){
 }
 
 limitations(){
-	 grep -P '^###\s|^####\s|See issue' "${script_dir}/limitations.md"
+	 grep -P '^###\s|^####\s|See issue' "${script_dir}/../docs/limitations.md"
 }
 
 cat << EOT


### PR DESCRIPTION
When we moved the script to a new directory we broke the relpath
link to the limitations.md file. Fix it.

Fixes: #519

Signed-off-by: Graham Whaley <graham.whaley@intel.com>