### PR TITLE
vendor: Update virtcontainers and ciao vendored packages.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "add4d7434b13ea7fc5f1c8d43e4864a67cf329a8"
+  revision = "da22c6ccce00e942d37212717d112105fa174588"
 
 [[projects]]
   branch = "master"
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/vcMock"]
-  revision = "e2c760d303ac0616f9e4fba774dbde93514c9556"
+  revision = "355a162e595764ef99d3aa3355c9483267532a24"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/01org/ciao/.travis.yml
+++ b/vendor/github.com/01org/ciao/.travis.yml
@@ -6,15 +6,18 @@ services:
 
 go:
     - 1.8
-    - go1.9beta2
+    - 1.9
     - tip
 
-env:
-    - COVERALLS_TOKEN=mwTn1pOFqEOUT13vylZNHq53NanoMznO7
+env: #need empty
 matrix:
+  include:
+    - go: 1.9
+      env: TEST_CASES_FLAGS=-race
   allow_failures:
   - go: tip
-  - go: go1.9beta2
+  - go: 1.9
+    env: TEST_CASES_FLAGS=-race
 
 go_import_path: github.com/01org/ciao
 
@@ -27,12 +30,12 @@ before_install:
   - go get github.com/google/gofuzz github.com/stretchr/testify
   - go get -u gopkg.in/alecthomas/gometalinter.v1
   - gometalinter.v1 --install
-  - pip install ansible
 
 # We need to create and install SSNTP certs for the SSNTP and controller tests
 before_script:
    - sudo mkdir -p /etc/pki/ciao/
    - sudo mkdir -p /var/lib/ciao/logs/scheduler
+   - sudo -E $GOPATH/bin/ciao-deploy auth setup
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor -role scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent
@@ -62,12 +65,10 @@ script:
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo mkdir -p /var/lib/ciao/data/controller/workloads
    - sudo chmod 0777 -R /var/lib/ciao
-   - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
-   - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/... github.com/01org/ciao/ciao-storage/... github.com/01org/ciao/deviceinfo github.com/01org/ciao/osprepare github.com/01org/ciao/templateutils
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
-   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
-   # Test ansible playbooks
-   - ansible-playbook -i _DeploymentAndDistroPackaging/ansible/tests/hosts _DeploymentAndDistroPackaging/ansible/ciao.yml --syntax-check
+   - test-cases $TEST_CASES_FLAGS -v -timeout 9 -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
+   - test-cases $TEST_CASES_FLAGS -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/... github.com/01org/ciao/ciao-storage/... github.com/01org/ciao/deviceinfo github.com/01org/ciao/osprepare
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases $TEST_CASES_FLAGS -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -race -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out

--- a/vendor/github.com/01org/ciao/DeveloperQuickStart.md
+++ b/vendor/github.com/01org/ciao/DeveloperQuickStart.md
@@ -52,14 +52,12 @@ ciao-down mode, it refers to the host system in the case of the bare metal mode.
       2. Scheduler 	
       3. Compute+Network Node Agent (i.e. CN + NN Launcher)
       4. Workloads (Containers and VMs)
-      5. WebUI
-      6. Mock Openstack Services
-      7. Machine Local DHCP Server
+      5. Mock Openstack Services
+      6. Machine Local DHCP Server
       ...
 
 The machine acts as the Ciao compute node, network node, ciao-controller, 
-ciao-scheduler and also hosts the ciao-webui as well as other openstack 
-and dhcp services.
+ciao-scheduler and also hosts other openstack and dhcp services.
 
 ## Graphical Overview
 
@@ -71,31 +69,31 @@ completely self contained.
 
 ```
    
-   ____________________________________________________________________________________________ 
-  |                                                                                            |
-  |                                                                                            |
-  |                                                                                            |
-  |                                                                  [Tenant VMs]  [CNCI VMs]  |
-  |                                                                     |  |  |       ||       |
-  |                                                     Tenant Bridges ----------     ||       |
-  |                                                                         |         ||       |
-  |                                                                         |         ||       |
-  | [ciao-webui] [scheduler] [controller] [keystone] [CN+NN Launcher]       |         ||       |
-  |    ||             ||       ||          ||           ||                  |         ||       |
-  |    ||             ||       ||          ||           ||                  |         ||       |
-  |    ||             ||       ||          ||           ||                  |         ||       |
-  |    ||             ||       ||          ||           ||                  |         ||       |
-  |    ||             ||       ||          ||           ||                  |         ||       |
-  |    ||             ||       ||          ||           ||      [DHCP/DNS   |         ||       |
-  |    ||             ||       ||          ||           ||        Server]   |         ||       |
-  |    ||             ||       ||          ||           ||           ||     |         ||       |
-  |  --------------------------------------------------------------------------------------    |              
-  |           Host Local Network Bridge + macvlan (ciao_br, ciaovlan)                          |
-  |                                                                                            |
-  |                                                                                            |
-  |____________________________________________________________________________________________|
+   ____________________________________________________________________________
+  |                                                                            |
+  |                                                                            |
+  |                                                                            |
+  |                                                [Tenant VMs]  [CNCI VMs]    |
+  |                                                   |  |  |       ||         |
+  |                                   Tenant Bridges ----------     ||         |
+  |                                                       |         ||         |
+  |                                                       |         ||         |
+  |      [scheduler] [controller]  [CN+NN Launcher]       |         ||         |
+  |           ||       ||             ||                  |         ||         |
+  |           ||       ||             ||                  |         ||         |
+  |           ||       ||             ||                  |         ||         |
+  |           ||       ||             ||                  |         ||         |
+  |           ||       ||             ||                  |         ||         |
+  |           ||       ||             ||      [DHCP/DNS   |         ||         |
+  |           ||       ||             ||        Server]   |         ||         |
+  |           ||       ||             ||           ||     |         ||         |
+  |  ------------------------------------------------------------------------  |
+  |           Host Local Network Bridge + macvlan (ciao_br, ciaovlan)          |
+  |                                                                            |
+  |                                                                            |
+  |____________________________________________________________________________|
                                                                                                        
-                                Development Machine
+                              Development Machine
 
 ```
 
@@ -148,34 +146,9 @@ When you run ciao-down create, ciao-down looks in its environment for
 proxy variables such as http_proxy, https_proxy and no_proxy.  If it
 finds them it ensures that these proxies are correctly configured for
 all the software that it installs and uses inside the VM, e.g., apt, docker,
-npm, wget, ciao-cli.  So if your development machine is sitting
+wget, ciao-cli.  So if your development machine is sitting
 behind a proxy, ensure you have your proxy environment variables set
 before running ciao-down.
-
-## Ciao-webui
-
-Ciao has a webui called ciao-webui (https://github.com/01org/ciao-webui).
-When ciao-down create is run, ciao-down downloads the source code for
-the ciao-webui and all the development tools needed to build it.  By
-default, ciao-down stores the code for the web-ui in ~/ciao-webui.
-
-If you wish to actively work on the sources of ciao-webui you can ask
-ciao-down create to mount a host directory containing the webui sources
-into the VM.  This is done using the -ui-path option of ciao-down create.
-For example
-
-```
-ciao-down create --ui-path $HOME/src/ciao-webui ciao
-```
-
-would mount the $HOME/src/ciao-webui directory inside the VM at the
-same location as the directory appears on your host.  You can then
-modify the ciao-webui code on your host and build inside the VM.
-
-
-For more details and full set of capabilities of ciao-down see the full 
-[ciao-down documentation ](https://github.com/01org/ciao/blob/master/testutil/ciao-down/README.md) 
-
 
 # Getting Started with Bare Metal
 
@@ -296,29 +269,6 @@ To check everything is working try the following command
 ```
 ciao-cli workload list
 ```
-
-# Running ciao-webui
-
-The easiest way to develop and run the ciao-webui is inside a VM built by 
-ciao-down.  Not only does ciao-down download the web-ui code for you but it 
-also downloads and configures all of the dependencies needed to develop the 
-ciao-webui, such as npm.
-
-To run the webui in a ciao-down VM simply execute the following commands
-
-```
-cd ~/ciao-webui
-./deploy.sh production --config_file=$HOME/local/webui_config.json
-```
-
-And then point your host's browser at https://localhost:3000.  The
-certificate used by the web-ui inside ciao-down is self signed so you
-will need to accept the certificate in your browser before you can view
-the web-ui.
-
-Ciao-down configures an account for you to use.  The user name is 'csr'
-and the password is 'hello'.  Enter these credentials in the login screen
-to start managing your cluster.
 
 # Running the BAT tests
 

--- a/vendor/github.com/01org/ciao/README.md
+++ b/vendor/github.com/01org/ciao/README.md
@@ -34,8 +34,7 @@ connectivity for workload instances and insures tenant isolation.
 Workloads (whether container or VM) are automatically placed in a unified
 L2 network, one such network per tenant.
 
-A [cli](https://github.com/01org/ciao/tree/master/ciao-cli) and
-[webui](https://github.com/01org/ciao-webui) are available.
+A [cli](https://github.com/01org/ciao/tree/master/ciao-cli) is available.
 
 All ciao components communicate with each other via
 [SSNTP](https://github.com/01org/ciao/blob/master/ssntp/README.md) using a

--- a/vendor/github.com/01org/ciao/packages.json
+++ b/vendor/github.com/01org/ciao/packages.json
@@ -54,6 +54,11 @@
 		"version": "757bef9",
 		"license": "BSD (3 clause)"
 	},
+	"github.com/intel/tfortools": {
+		"url": "https://github.com/intel/tfortools.git",
+		"version": "2aef60e",
+		"license": "Apache v2.0"
+	},
 	"github.com/mattn/go-sqlite3": {
 		"url": "https://github.com/mattn/go-sqlite3.git",
 		"version": "6f2749a",

--- a/vendor/github.com/01org/ciao/qemu/qmp_test.go
+++ b/vendor/github.com/01org/ciao/qemu/qmp_test.go
@@ -406,8 +406,8 @@ func TestQMPXBlockdevDel(t *testing.T) {
 	buf.AddCommand("x-blockdev-del", nil, "return", nil)
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
-	checkVersion(t, connectedCh)
-	err := q.ExecuteXBlockdevDel(context.Background(),
+	q.version = checkVersion(t, connectedCh)
+	err := q.ExecuteBlockdevDel(context.Background(),
 		fmt.Sprintf("drive_%s", testutil.VolumeUUID))
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "add4d7434b13ea7fc5f1c8d43e4864a67cf329a8"
+  revision = "9453e376b8ad6d67fd0dafb3dffd0d515a1f9feb"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/capabilities.go
+++ b/vendor/github.com/containers/virtcontainers/capabilities.go
@@ -18,6 +18,7 @@ package virtcontainers
 
 const (
 	blockDeviceSupport = 1 << iota
+	blockDeviceHotplugSupport
 )
 
 type capabilities struct {
@@ -33,4 +34,15 @@ func (caps *capabilities) isBlockDeviceSupported() bool {
 
 func (caps *capabilities) setBlockDeviceSupport() {
 	caps.flags = caps.flags | blockDeviceSupport
+}
+
+func (caps *capabilities) isBlockDeviceHotplugSupported() bool {
+	if caps.flags&blockDeviceHotplugSupport != 0 {
+		return true
+	}
+	return false
+}
+
+func (caps *capabilities) setBlockDeviceHotplugSupport() {
+	caps.flags |= blockDeviceHotplugSupport
 }

--- a/vendor/github.com/containers/virtcontainers/capabilities_test.go
+++ b/vendor/github.com/containers/virtcontainers/capabilities_test.go
@@ -31,3 +31,17 @@ func TestBlockDeviceCapability(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestBlockDeviceHotplugCapability(t *testing.T) {
+	var caps capabilities
+
+	if caps.isBlockDeviceHotplugSupported() {
+		t.Fatal()
+	}
+
+	caps.setBlockDeviceHotplugSupport()
+
+	if !caps.isBlockDeviceHotplugSupported() {
+		t.Fatal()
+	}
+}

--- a/vendor/github.com/containers/virtcontainers/container_test.go
+++ b/vendor/github.com/containers/virtcontainers/container_test.go
@@ -17,7 +17,13 @@
 package virtcontainers
 
 import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -55,4 +61,178 @@ func TestContainerPod(t *testing.T) {
 	if !reflect.DeepEqual(pod, expectedPod) {
 		t.Fatalf("Expecting %+v\nGot %+v", expectedPod, pod)
 	}
+}
+
+func TestContainerRemoveDrive(t *testing.T) {
+	pod := &Pod{}
+
+	container := Container{
+		pod: pod,
+		id:  "testContainer",
+	}
+
+	container.state.Fstype = ""
+	err := container.removeDrive()
+
+	// hotplugRemoveDevice for hypervisor should not be called.
+	// test should pass without a hypervisor created for the container's pod.
+	if err != nil {
+		t.Fatal("")
+	}
+
+	container.state.Fstype = "xfs"
+	container.state.HotpluggedDrive = false
+	err = container.removeDrive()
+
+	// hotplugRemoveDevice for hypervisor should not be called.
+	if err != nil {
+		t.Fatal("")
+	}
+
+	container.state.HotpluggedDrive = true
+	pod.hypervisor = &mockHypervisor{}
+	err = container.removeDrive()
+
+	if err != nil {
+		t.Fatal()
+	}
+}
+
+func testSetupFakeRootfs(t *testing.T) (testRawFile, loopDev, mntDir string, err error) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testRawFile = filepath.Join(tmpDir, "raw.img")
+	if _, err := os.Stat(testRawFile); !os.IsNotExist(err) {
+		os.Remove(testRawFile)
+	}
+
+	output, err := exec.Command("losetup", "-f").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Skipping test since no loop device available for tests : %s, %s", output, err)
+		return
+	}
+	loopDev = strings.TrimSpace(string(output[:]))
+
+	output, err = exec.Command("fallocate", "-l", "256K", testRawFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("fallocate failed %s %s", output, err)
+	}
+
+	output, err = exec.Command("mkfs.ext4", "-F", testRawFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("mkfs.ext4 failed for %s:  %s, %s", testRawFile, output, err)
+	}
+
+	output, err = exec.Command("losetup", loopDev, testRawFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("Losetup for %s at %s failed : %s, %s ", loopDev, testRawFile, output, err)
+		return
+	}
+
+	mntDir = filepath.Join(tmpDir, "rootfs")
+	err = os.Mkdir(mntDir, dirMode)
+	if err != nil {
+		t.Fatalf("Error creating dir %s: %s", mntDir, err)
+	}
+
+	err = syscall.Mount(loopDev, mntDir, "ext4", uintptr(0), "")
+	if err != nil {
+		t.Fatalf("Error while mounting loop device %s at %s: %s", loopDev, mntDir, err)
+	}
+	return
+}
+
+func cleanupFakeRootfsSetup(testRawFile, loopDev, mntDir string) {
+	// unmount loop device
+	if mntDir != "" {
+		syscall.Unmount(mntDir, 0)
+	}
+
+	// detach loop device
+	if loopDev != "" {
+		exec.Command("losetup", "-d", loopDev).CombinedOutput()
+	}
+
+	if _, err := os.Stat(testRawFile); err == nil {
+		tmpDir := filepath.Dir(testRawFile)
+		os.RemoveAll(tmpDir)
+	}
+}
+
+func TestContainerAddDriveDir(t *testing.T) {
+	testRawFile, loopDev, fakeRootfs, err := testSetupFakeRootfs(t)
+
+	defer cleanupFakeRootfsSetup(testRawFile, loopDev, fakeRootfs)
+
+	if err != nil {
+		t.Fatalf("Error while setting up fake rootfs: %v, Skipping test", err)
+	}
+
+	fs := &filesystem{}
+	pod := &Pod{
+		id:         testPodID,
+		storage:    fs,
+		hypervisor: &mockHypervisor{},
+	}
+
+	contID := "100"
+	container := Container{
+		pod:    pod,
+		id:     contID,
+		rootFs: fakeRootfs,
+	}
+
+	// create state file
+	path := filepath.Join(runStoragePath, testPodID, container.ID())
+	err = os.MkdirAll(path, dirMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(path)
+
+	stateFilePath := filepath.Join(path, stateFile)
+	os.Remove(stateFilePath)
+
+	_, err = os.Create(stateFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(stateFilePath)
+
+	// Make the checkStorageDriver func variable point to a fake check function
+	savedFunc := checkStorageDriver
+	checkStorageDriver = func(major, minor int) (bool, error) {
+		return true, nil
+	}
+
+	defer func() {
+		checkStorageDriver = savedFunc
+	}()
+
+	err = container.addDrive(true)
+	if err != nil {
+		t.Fatalf("Error with addDrive :%v", err)
+	}
+
+	if container.state.Fstype == "" || container.state.HotpluggedDrive {
+		t.Fatal()
+	}
+
+	container.state.Fstype = ""
+	container.state.HotpluggedDrive = false
+
+	// hotplugged case, when create is passed as false
+	err = container.addDrive(false)
+	if err != nil {
+		t.Fatalf("Error with addDrive :%v", err)
+	}
+
+	if container.state.Fstype == "" || !container.state.HotpluggedDrive {
+		t.Fatal()
+	}
+
 }

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -84,7 +84,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		c.PauseBinPath = filepath.Join(defaultPauseBinDir, pauseBinName)
 	}
 
-	virtLog.Infof("Hyperstart config %v", c)
+	virtLog.Debugf("Hyperstart config %v", c)
 
 	return true
 }
@@ -428,7 +428,7 @@ func (h *hyper) startPod(pod Pod) error {
 		return err
 	}
 
-	hostname := pod.id
+	hostname := pod.config.Hostname
 	if len(hostname) > maxHostnameLen {
 		hostname = hostname[:maxHostnameLen]
 	}

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -315,5 +315,8 @@ type hypervisor interface {
 	pausePod() error
 	resumePod() error
 	addDevice(devInfo interface{}, devType deviceType) error
+	hotplugAddDevice(devInfo interface{}, devType deviceType) error
+	hotplugRemoveDevice(devInfo interface{}, devType deviceType) error
 	getPodConsole(podID string) string
+	capabilities() capabilities
 }

--- a/vendor/github.com/containers/virtcontainers/mock_hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/mock_hypervisor.go
@@ -28,6 +28,10 @@ func (m *mockHypervisor) init(config HypervisorConfig) error {
 	return nil
 }
 
+func (m *mockHypervisor) capabilities() capabilities {
+	return capabilities{}
+}
+
 func (m *mockHypervisor) createPod(podConfig PodConfig) error {
 	return nil
 }
@@ -51,6 +55,14 @@ func (m *mockHypervisor) resumePod() error {
 }
 
 func (m *mockHypervisor) addDevice(devInfo interface{}, devType deviceType) error {
+	return nil
+}
+
+func (m *mockHypervisor) hotplugAddDevice(devInfo interface{}, devType deviceType) error {
+	return nil
+}
+
+func (m *mockHypervisor) hotplugRemoveDevice(devInfo interface{}, devType deviceType) error {
 	return nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/mount.go
+++ b/vendor/github.com/containers/virtcontainers/mount.go
@@ -184,6 +184,8 @@ func getDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err e
 
 var blockFormatTemplate = "/sys/dev/block/%d:%d/dm"
 
+var checkStorageDriver = isDeviceMapper
+
 // isDeviceMapper checks if the device with the major and minor numbers is a devicemapper block device
 func isDeviceMapper(major, minor int) (bool, error) {
 

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -351,6 +351,8 @@ func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, co
 	podConfig := vc.PodConfig{
 		ID: cid,
 
+		Hostname: ocispec.Hostname,
+
 		Hooks: containerHooks(ocispec),
 
 		VMConfig: resources,

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -124,7 +124,8 @@ func TestMinimalPodConfig(t *testing.T) {
 	}
 
 	expectedPodConfig := vc.PodConfig{
-		ID: containerID,
+		ID:       containerID,
+		Hostname: "testHostname",
 
 		HypervisorType: vc.QemuHypervisor,
 		AgentType:      vc.HyperstartAgent,

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test_config.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test_config.go
@@ -56,7 +56,7 @@ const minimalConfig = `
 		"path": "rootfs",
 		"readonly": true
 	},
-	"hostname": "runc",
+	"hostname": "testHostname",
 	"mounts": [
 		{
 			"destination": "/proc",

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -560,3 +560,38 @@ func TestQemuMachineTypes(t *testing.T) {
 		}
 	}
 }
+
+func TestQemuBlockHotplugCapabilities(t *testing.T) {
+	type testData struct {
+		machineType     string
+		expectedSupport bool
+	}
+
+	data := []testData{
+		{"pc-lite", false},
+		{"q35", false},
+		{"pc", true},
+
+		{"PC-LITE", false},
+		{"PC", false},
+		{"Q35", false},
+		{"", false},
+		{" ", false},
+		{".", false},
+		{"0", false},
+		{"1", false},
+		{"-1", false},
+	}
+
+	q := &qemu{}
+
+	for _, d := range data {
+		q.qemuConfig.Machine.Type = d.machineType
+
+		caps := q.capabilities()
+		isSupported := caps.isBlockDeviceHotplugSupported()
+		if isSupported != d.expectedSupport {
+			t.Fatalf("expected blockdevice hotplug support : %v, got %v", d.expectedSupport, isSupported)
+		}
+	}
+}


### PR DESCRIPTION
Virtcontainers update includes support for hotplugging drives,
fix for container hostname and declutter of logs.
Ciao update includes a fix for hot unplugging block devices
for qemu>=2.9

Shortlog for virtcontainers:

fc19dad log: Be less chatty at Info level
aa2cab9 qemu: Typo fix
67b0def oci: Set hostname to the one passed in spec file
559e470 Merge pull request #358 from amshinde/test-for-add-drive
9a190fa tests: Add test for addDrive in container.go
389d979 docs: Create CODE_OF_CONDUCT.md
25bac0d state: Add bool variable to indicate if drive was hotplugged
ee7ac26 hotplug: Hotunplug drive when container is stopped.
4f7150d vendor: Vendor latest ciao package
86bd45f hotplug: Hotplug drive when container is started
91dd21c capabilities: Add a capabilities interface for hypervisor
c1440f9 storage: hotplug drives when vm has been started
8eee05d hotplug: Add a hypervisor interface for hotplugging devices.
6e22ae9 storage: Refactor addDrives

Fixes #532
Fixes #533

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>