### PR TITLE
Configuration: Enable support for memory pre-allocation and swap. Also enable support for debug mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ DEFMEMSZ := 2048
 
 DEFDISABLEBLOCK := false
 DEFENABLEMEMPREALLOC := false
+DEFENABLESWAP := false
 
 SED = sed
 
@@ -177,6 +178,7 @@ USER_VARS += DEFVCPUS
 USER_VARS += DEFMEMSZ
 USER_VARS += DEFDISABLEBLOCK
 USER_VARS += DEFENABLEMEMPREALLOC
+USER_VARS += DEFENABLESWAP
 
 
 V              = @
@@ -226,6 +228,7 @@ const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
 const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 const defaultEnableMemPrealloc bool = $(DEFENABLEMEMPREALLOC)
+const defaultEnableSwap bool = $(DEFENABLESWAP)
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(DESTCONFIG)"
@@ -285,6 +288,7 @@ $(CONFIG): $(CONFIG_IN) $(GENERATED_FILES)
 		-e "s|@DEFMEMSZ@|$(DEFMEMSZ)|g" \
 		-e "s|@DEFDISABLEBLOCK@|$(DEFDISABLEBLOCK)|g" \
 		-e "s|@DEFENABLEMEMPREALLOC@|$(DEFENABLEMEMPREALLOC)|g" \
+		-e "s|@DEFENABLEMSWAP@|$(DEFENABLESWAP)|g" \
 		$< > $@
 
 generate-config: $(CONFIG)

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ DEFVCPUS := 1
 DEFMEMSZ := 2048
 
 DEFDISABLEBLOCK := false
+DEFENABLEMEMPREALLOC := false
 
 SED = sed
 
@@ -175,6 +176,7 @@ USER_VARS += PAUSEDESTDIR
 USER_VARS += DEFVCPUS
 USER_VARS += DEFMEMSZ
 USER_VARS += DEFDISABLEBLOCK
+USER_VARS += DEFENABLEMEMPREALLOC
 
 
 V              = @
@@ -223,6 +225,7 @@ const pauseBinRelativePath = "$(PAUSEBINRELPATH)"
 const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
 const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
+const defaultEnableMemPrealloc bool = $(DEFENABLEMEMPREALLOC)
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(DESTCONFIG)"
@@ -281,6 +284,7 @@ $(CONFIG): $(CONFIG_IN) $(GENERATED_FILES)
 		-e "s|@DEFVCPUS@|$(DEFVCPUS)|g" \
 		-e "s|@DEFMEMSZ@|$(DEFMEMSZ)|g" \
 		-e "s|@DEFDISABLEBLOCK@|$(DEFDISABLEBLOCK)|g" \
+		-e "s|@DEFENABLEMEMPREALLOC@|$(DEFENABLEMEMPREALLOC)|g" \
 		$< > $@
 
 generate-config: $(CONFIG)

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ DEFMEMSZ := 2048
 DEFDISABLEBLOCK := false
 DEFENABLEMEMPREALLOC := false
 DEFENABLESWAP := false
+DEFENABLEDEBUG := false
 
 SED = sed
 
@@ -179,6 +180,7 @@ USER_VARS += DEFMEMSZ
 USER_VARS += DEFDISABLEBLOCK
 USER_VARS += DEFENABLEMEMPREALLOC
 USER_VARS += DEFENABLESWAP
+USER_VARS += DEFENABLEDEBUG
 
 
 V              = @
@@ -229,6 +231,7 @@ const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
 const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 const defaultEnableMemPrealloc bool = $(DEFENABLEMEMPREALLOC)
 const defaultEnableSwap bool = $(DEFENABLESWAP)
+const defaultEnableDebug bool = $(DEFENABLEDEBUG)
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(DESTCONFIG)"
@@ -289,6 +292,7 @@ $(CONFIG): $(CONFIG_IN) $(GENERATED_FILES)
 		-e "s|@DEFDISABLEBLOCK@|$(DEFDISABLEBLOCK)|g" \
 		-e "s|@DEFENABLEMEMPREALLOC@|$(DEFENABLEMEMPREALLOC)|g" \
 		-e "s|@DEFENABLEMSWAP@|$(DEFENABLESWAP)|g" \
+		-e "s|@DEFENABLEMSWAP@|$(DEFENABLEDEBUG)|g" \
 		$< > $@
 
 generate-config: $(CONFIG)

--- a/config.go
+++ b/config.go
@@ -83,6 +83,7 @@ type hypervisor struct {
 	DisableBlockDeviceUse bool   `toml:"disable_block_device_use"`
 	MemPrealloc           bool   `toml:"enable_mem_prealloc"`
 	Swap                  bool   `toml:"enable_swap"`
+	Debug                 bool   `toml:"enable_debug"`
 }
 
 type proxy struct {
@@ -211,6 +212,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DisableBlockDeviceUse: h.DisableBlockDeviceUse,
 		MemPrealloc:           h.MemPrealloc,
 		Mlock:                 !h.Swap,
+		Debug:                 h.Debug,
 	}, nil
 }
 
@@ -320,6 +322,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		DefaultMemSz:          defaultMemSize,
 		MemPrealloc:           defaultEnableMemPrealloc,
 		Mlock:                 !defaultEnableSwap,
+		Debug:                 defaultEnableDebug,
 	}
 
 	defaultAgentConfig := vc.HyperConfig{

--- a/config.go
+++ b/config.go
@@ -82,6 +82,7 @@ type hypervisor struct {
 	DefaultMemSz          uint32 `toml:"default_memory"`
 	DisableBlockDeviceUse bool   `toml:"disable_block_device_use"`
 	MemPrealloc           bool   `toml:"enable_mem_prealloc"`
+	Swap                  bool   `toml:"enable_swap"`
 }
 
 type proxy struct {
@@ -209,6 +210,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DefaultMemSz:          h.defaultMemSz(),
 		DisableBlockDeviceUse: h.DisableBlockDeviceUse,
 		MemPrealloc:           h.MemPrealloc,
+		Mlock:                 !h.Swap,
 	}, nil
 }
 
@@ -317,6 +319,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		DefaultVCPUs:          defaultVCPUCount,
 		DefaultMemSz:          defaultMemSize,
 		MemPrealloc:           defaultEnableMemPrealloc,
+		Mlock:                 !defaultEnableSwap,
 	}
 
 	defaultAgentConfig := vc.HyperConfig{

--- a/config.go
+++ b/config.go
@@ -81,6 +81,7 @@ type hypervisor struct {
 	DefaultVCPUs          int32  `toml:"default_vcpus"`
 	DefaultMemSz          uint32 `toml:"default_memory"`
 	DisableBlockDeviceUse bool   `toml:"disable_block_device_use"`
+	MemPrealloc           bool   `toml:"enable_mem_prealloc"`
 }
 
 type proxy struct {
@@ -207,6 +208,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DefaultVCPUs:          h.defaultVCPUs(),
 		DefaultMemSz:          h.defaultMemSz(),
 		DisableBlockDeviceUse: h.DisableBlockDeviceUse,
+		MemPrealloc:           h.MemPrealloc,
 	}, nil
 }
 
@@ -314,6 +316,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		HypervisorMachineType: defaultMachineType,
 		DefaultVCPUs:          defaultVCPUCount,
 		DefaultMemSz:          defaultMemSize,
+		MemPrealloc:           defaultEnableMemPrealloc,
 	}
 
 	defaultAgentConfig := vc.HyperConfig{

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -9,12 +9,14 @@ machine_type = "@MACHINETYPE@"
 # For example, use `kernel_params = "vsyscall=emulate"` if you are having
 # trouble running pre-2.15 glibc
 kernel_params = "@KERNELPARAMS@"
+
 # Default number of vCPUs per POD/VM:
 # unspecified or 0 --> will be set to @DEFVCPUS@
 # < 0              --> will be set to the actual number of physical cores
 # > 0 <= 255       --> will be set to the specified number
 # > 255            --> will be set to 255
 default_vcpus = -1
+
 # Default memory size in MiB for POD/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 #default_memory = @DEFMEMSZ@
@@ -28,10 +30,21 @@ disable_block_device_use = @DEFDISABLEBLOCK@
 # to be very predictable
 # Default false
 #enable_mem_prealloc = true
-#
+
 # Enable swap of vm memory. Default false.
 # The behaviour is undefined if mem_prealloc is also set to true
 #enable_swap = true
+
+# Debug changes the default hypervisor and kernel parameters to
+# enable debug output where available.
+# Default false
+# these logs can be obtained in the cc-proxy logs  when the 
+# proxy is set to run in debug mode
+# /usr/libexec/clear-containers/cc-proxy -log debug
+# or by stopping the cc-proxy service and running the cc-proxy 
+# explicitly using the same command line
+# 
+#enable_debug = true
 
 [proxy.cc]
 url = "@PROXYURL@"

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -21,7 +21,17 @@ default_vcpus = -1
 disable_block_device_use = @DEFDISABLEBLOCK@
 
 # Enable pre allocation of VM RAM, default false
+# Enabling this will result in lower container density
+# as all of the memory will be allocated and locked
+# This is useful when you want to reserve all the memory
+# upfront or in the cases where you want memory latencies
+# to be very predictable
+# Default false
 #enable_mem_prealloc = true
+#
+# Enable swap of vm memory. Default false.
+# The behaviour is undefined if mem_prealloc is also set to true
+#enable_swap = true
 
 [proxy.cc]
 url = "@PROXYURL@"

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -20,6 +20,9 @@ default_vcpus = -1
 #default_memory = @DEFMEMSZ@
 disable_block_device_use = @DEFDISABLEBLOCK@
 
+# Enable pre allocation of VM RAM, default false
+#enable_mem_prealloc = true
+
 [proxy.cc]
 url = "@PROXYURL@"
 


### PR DESCRIPTION
Depends on vendoring of QEMU https://github.com/01org/ciao/pull/1434

# Add support for fine grained control of memory management.

    ```enable_prealloc=true```  Will result in the upfront allocation  and locking down of all VM memory, resulting in lower VM density.

    ```enable_swap=true```   Will enable swap of VM memory, resulting in higher VM density with potentially higher latency

Enabling the two together results in undefined behavior.


    ```enable_debug=true```   Will enable hypervisor and container kernel logs

Fixes https://github.com/clearcontainers/runtime/issues/568