### PR TITLE
oci: Follow the OCI spec for cgroup paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ generate-config: $(CONFIG)
 
 check: check-go-static check-go-test
 
-check-go-test:
+check-go-test: $(GENERATED_FILES)
 	$(QUIET_TEST).ci/go-test.sh
 
 check-go-static:

--- a/oci.go
+++ b/oci.go
@@ -228,13 +228,9 @@ func processCgroupsPathForResource(ociSpec oci.CompatOCISpec, resource string, i
 	}
 
 	if !cgroupMountFound {
-		if isPod {
-			return "", fmt.Errorf("cgroupsPath %q is absolute, cgroup mount MUST exist",
-				ociSpec.Linux.CgroupsPath)
-		}
-
-		// In case of container (CRI-O), if the mount point is not
-		// provided, we assume this is a relative path.
+		// According to the OCI spec, an absolute path should be
+		// interpreted as relative to the system cgroup mount point
+		// when there is no cgroup mount point.
 		return filepath.Join(cgroupsDirPath, resource, ociSpec.Linux.CgroupsPath), nil
 	}
 

--- a/oci_test.go
+++ b/oci_test.go
@@ -344,9 +344,9 @@ func TestProcessCgroupsPathRelativePathSuccessful(t *testing.T) {
 	}
 }
 
-func TestProcessCgroupsPathAbsoluteNoCgroupMountFailure(t *testing.T) {
-	assert := assert.New(t)
+func TestProcessCgroupsPathAbsoluteNoCgroupMountSuccessful(t *testing.T) {
 	absoluteCgroupsPath := "/absolute/cgroups/path"
+	cgroupsDirPath = "/foo/runtime/base"
 
 	ociSpec := oci.CompatOCISpec{}
 
@@ -357,9 +357,9 @@ func TestProcessCgroupsPathAbsoluteNoCgroupMountFailure(t *testing.T) {
 	for _, d := range cgroupTestData {
 		ociSpec.Linux.Resources = d.linuxSpec
 
-		_, err := processCgroupsPath(ociSpec, true)
-		assert.Error(err, "This test should fail because no cgroup mount provided (%+v)", d)
-		assert.False(vcMock.IsMockError(err))
+		p := filepath.Join(cgroupsDirPath, d.resource, absoluteCgroupsPath)
+
+		testProcessCgroupsPath(t, ociSpec, []string{p})
 	}
 }
 


### PR DESCRIPTION
Getting an absolute path while not having a cgroup mount
from the OCI spec is a valid case. In that case the path
should be interpreted as a relative one to the system
cgroup mount point.

Fixes #552

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>