### PR TITLE
vendor: virtcontainers 1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "da22c6ccce00e942d37212717d112105fa174588"
+  revision = "b87d5637e3562e54a642a81fb749200125bd099a"
 
 [[projects]]
   branch = "master"
@@ -38,10 +38,10 @@
   revision = "5bbff37294de9dfb33771dac6f53411c88abe62a"
 
 [[projects]]
-  branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/vcMock"]
-  revision = "355a162e595764ef99d3aa3355c9483267532a24"
+  revision = "6b4015e1c5c162ca34bc8109c1187824f10f864c"
+  version = "1.0.0"
 
 [[projects]]
   branch = "master"

--- a/delete_test.go
+++ b/delete_test.go
@@ -170,6 +170,8 @@ func TestDeletePod(t *testing.T) {
 	}
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
 		return []vc.PodStatus{
@@ -180,7 +182,7 @@ func TestDeletePod(t *testing.T) {
 						ID: pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodSandbox),
-							oci.ConfigPathKey:    configPath,
+							oci.ConfigJSONKey:    configJSON,
 						},
 						State: vc.State{
 							State: "ready",
@@ -195,7 +197,7 @@ func TestDeletePod(t *testing.T) {
 		testingImpl.ListPodFunc = nil
 	}()
 
-	err := delete(pod.ID(), false)
+	err = delete(pod.ID(), false)
 	assert.Error(err)
 	assert.True(vcMock.IsMockError(err))
 
@@ -231,6 +233,8 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 	}
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
 		return []vc.PodStatus{
@@ -241,7 +245,7 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 						ID: pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: "InvalidType",
-							oci.ConfigPathKey:    configPath,
+							oci.ConfigJSONKey:    configJSON,
 						},
 						State: vc.State{
 							State: "created",
@@ -257,7 +261,7 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 	}()
 
 	// Delete an invalid container type
-	err := delete(pod.ID(), false)
+	err = delete(pod.ID(), false)
 	assert.Error(err)
 	assert.False(vcMock.IsMockError(err))
 }
@@ -270,6 +274,8 @@ func TestDeletePodRunning(t *testing.T) {
 	}
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
 		return []vc.PodStatus{
@@ -280,7 +286,7 @@ func TestDeletePodRunning(t *testing.T) {
 						ID: pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodSandbox),
-							oci.ConfigPathKey:    configPath,
+							oci.ConfigJSONKey:    configJSON,
 						},
 						State: vc.State{
 							State: "running",
@@ -296,7 +302,7 @@ func TestDeletePodRunning(t *testing.T) {
 	}()
 
 	// Delete on a running pod should fail
-	err := delete(pod.ID(), false)
+	err = delete(pod.ID(), false)
 	assert.Error(err)
 	assert.False(vcMock.IsMockError(err))
 
@@ -340,6 +346,8 @@ func TestDeleteRunningContainer(t *testing.T) {
 	}
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
 		return []vc.PodStatus{
@@ -350,7 +358,7 @@ func TestDeleteRunningContainer(t *testing.T) {
 						ID: pod.MockContainers[0].ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    configPath,
+							oci.ConfigJSONKey:    configJSON,
 						},
 						State: vc.State{
 							State: "running",
@@ -366,7 +374,7 @@ func TestDeleteRunningContainer(t *testing.T) {
 	}()
 
 	// Delete on a running container should fail.
-	err := delete(pod.MockContainers[0].ID(), false)
+	err = delete(pod.MockContainers[0].ID(), false)
 	assert.Error(err)
 	assert.False(vcMock.IsMockError(err))
 
@@ -414,6 +422,8 @@ func TestDeleteContainer(t *testing.T) {
 	}
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
 		return []vc.PodStatus{
@@ -424,7 +434,7 @@ func TestDeleteContainer(t *testing.T) {
 						ID: pod.MockContainers[0].ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    configPath,
+							oci.ConfigJSONKey:    configJSON,
 						},
 						State: vc.State{
 							State: "ready",
@@ -439,7 +449,7 @@ func TestDeleteContainer(t *testing.T) {
 		testingImpl.ListPodFunc = nil
 	}()
 
-	err := delete(pod.MockContainers[0].ID(), false)
+	err = delete(pod.MockContainers[0].ID(), false)
 	assert.Error(err)
 	assert.True(vcMock.IsMockError(err))
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -90,10 +90,12 @@ func TestExecuteErrors(t *testing.T) {
 
 	// Container not running
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations = map[string]string{
 		oci.ContainerTypeKey: string(vc.PodSandbox),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
@@ -125,10 +127,12 @@ func TestExecuteErrorReadingProcessJson(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodSandbox),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{
@@ -167,10 +171,12 @@ func TestExecuteErrorOpeningConsole(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodSandbox),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{
@@ -227,10 +233,12 @@ func TestExecuteWithFlags(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodSandbox),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{
@@ -309,10 +317,12 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodSandbox),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{
@@ -381,10 +391,12 @@ func TestExecuteWithInvalidProcessJson(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodSandbox),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{
@@ -426,10 +438,12 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodContainer),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{
@@ -516,10 +530,12 @@ func TestExecuteWithInvalidEnvironment(t *testing.T) {
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
 	configPath := testConfigSetup(t)
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
 
 	annotations := map[string]string{
 		oci.ContainerTypeKey: string(vc.PodContainer),
-		oci.ConfigPathKey:    configPath,
+		oci.ConfigJSONKey:    configJSON,
 	}
 
 	state := vc.State{

--- a/main_test.go
+++ b/main_test.go
@@ -139,6 +139,21 @@ func runUnitTests(m *testing.M) {
 	os.Exit(ret)
 }
 
+// Read fail that should contain a CompatOCISpec and
+// return its JSON representation on success
+func readOCIConfigJSON(configFile string) (string, error) {
+	bundlePath := filepath.Dir(configFile)
+	ociSpec, err := oci.ParseConfigJSON(bundlePath)
+	if err != nil {
+		return "", nil
+	}
+	ociSpecJSON, err := json.Marshal(ociSpec)
+	if err != nil {
+		return "", err
+	}
+	return string(ociSpecJSON), err
+}
+
 // TestMain is the common main function used by ALL the test functions
 // for this package.
 func TestMain(m *testing.M) {

--- a/run_test.go
+++ b/run_test.go
@@ -156,14 +156,14 @@ func TestRunInvalidArgs(t *testing.T) {
 }
 
 type runContainerData struct {
-	pidFilePath    string
-	consolePath    string
-	bundlePath     string
-	configJSONPath string
-	pod            *vcMock.Pod
-	runtimeConfig  oci.RuntimeConfig
-	process        *os.Process
-	tmpDir         string
+	pidFilePath   string
+	consolePath   string
+	bundlePath    string
+	configJSON    string
+	pod           *vcMock.Pod
+	runtimeConfig oci.RuntimeConfig
+	process       *os.Process
+	tmpDir        string
 }
 
 func testRunContainerSetup(t *testing.T) runContainerData {
@@ -211,15 +211,18 @@ func testRunContainerSetup(t *testing.T) runContainerData {
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, consolePath, true)
 	assert.NoError(err)
 
+	configJSON, err := readOCIConfigJSON(configPath)
+	assert.NoError(err)
+
 	return runContainerData{
-		pidFilePath:    pidFilePath,
-		consolePath:    consolePath,
-		bundlePath:     bundlePath,
-		configJSONPath: configPath,
-		pod:            pod,
-		runtimeConfig:  runtimeConfig,
-		process:        cmd.Process,
-		tmpDir:         tmpdir,
+		pidFilePath:   pidFilePath,
+		consolePath:   consolePath,
+		bundlePath:    bundlePath,
+		configJSON:    configJSON,
+		pod:           pod,
+		runtimeConfig: runtimeConfig,
+		process:       cmd.Process,
+		tmpDir:        tmpdir,
 	}
 }
 
@@ -257,7 +260,7 @@ func TestRunContainerSuccessful(t *testing.T) {
 						ID: d.pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    d.configJSONPath,
+							oci.ConfigJSONKey:    d.configJSON,
 						},
 					},
 				},
@@ -333,7 +336,7 @@ func TestRunContainerDetachSuccessful(t *testing.T) {
 						ID: d.pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    d.configJSONPath,
+							oci.ConfigJSONKey:    d.configJSON,
 						},
 					},
 				},
@@ -406,7 +409,7 @@ func TestRunContainerDeleteFail(t *testing.T) {
 						ID: d.pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    d.configJSONPath,
+							oci.ConfigJSONKey:    d.configJSON,
 						},
 					},
 				},
@@ -482,7 +485,7 @@ func TestRunContainerWaitFail(t *testing.T) {
 						ID: d.pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    d.configJSONPath,
+							oci.ConfigJSONKey:    d.configJSON,
 						},
 					},
 				},
@@ -566,7 +569,7 @@ func TestRunContainerStartFail(t *testing.T) {
 						ID: d.pod.ID(),
 						Annotations: map[string]string{
 							oci.ContainerTypeKey: string(vc.PodContainer),
-							oci.ConfigPathKey:    d.configJSONPath,
+							oci.ConfigJSONKey:    d.configJSON,
 						},
 					},
 				},

--- a/vendor/github.com/01org/ciao/qemu/qemu_test.go
+++ b/vendor/github.com/01org/ciao/qemu/qemu_test.go
@@ -223,7 +223,7 @@ func TestAppendEmptyDevice(t *testing.T) {
 	testAppend(device, "", t)
 }
 
-var knobsString = "-no-user-config -nodefaults -nographic -daemonize"
+var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on"
 
 func TestAppendKnobsAllTrue(t *testing.T) {
 	knobs := Knobs{
@@ -231,6 +231,9 @@ func TestAppendKnobsAllTrue(t *testing.T) {
 		NoDefaults:   true,
 		NoGraphic:    true,
 		Daemonize:    true,
+		MemPrealloc:  true,
+		Realtime:     true,
+		Mlock:        true,
 	}
 
 	testAppend(knobs, knobsString, t)
@@ -241,6 +244,9 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 		NoUserConfig: false,
 		NoDefaults:   false,
 		NoGraphic:    false,
+		MemPrealloc:  false,
+		Realtime:     false,
+		Mlock:        false,
 	}
 
 	testAppend(knobs, "", t)

--- a/vendor/github.com/containers/virtcontainers/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/containers/virtcontainers/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+clear-containers-code-of-conduct@clearlinux.org. All complaints will be
+reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+
+[homepage]: https://www.contributor-covenant.org

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -5,31 +5,31 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "9453e376b8ad6d67fd0dafb3dffd0d515a1f9feb"
+  revision = "8c505ffb1e9b0397bee3a65569f517ca4821fe81"
 
 [[projects]]
   branch = "master"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
-  revision = "3d4380f53a34dcdc95f0c1db702615992b38d9a4"
+  revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
   branch = "master"
   name = "github.com/clearcontainers/proxy"
   packages = ["api","client"]
-  revision = "cf19e7935daaff8db546111c7a48cfdc2c1f09f6"
+  revision = "79ff321da6d34682fea11a47dff0e5ca72c20a01"
 
 [[projects]]
   branch = "master"
   name = "github.com/containernetworking/cni"
   packages = ["libcni","pkg/invoke","pkg/types","pkg/types/020","pkg/types/current","pkg/version"]
-  revision = "49d814cf37bfea351a1caedd0c66825c9d6fca52"
+  revision = "909fe7d10d98ab99b9990966796316249c83b263"
 
 [[projects]]
   branch = "master"
   name = "github.com/containernetworking/plugins"
   packages = ["pkg/ns"]
-  revision = "5bbff37294de9dfb33771dac6f53411c88abe62a"
+  revision = "e256564546e8d1ca8a36911f8445c11929043221"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/kubernetes-incubator/cri-o"
   packages = ["pkg/annotations"]
-  revision = "f3f8b67b76d53887b874633c6de13140dae99b76"
+  revision = "400713a58bedb88678e84b72d4620847c8d27fec"
 
 [[projects]]
   branch = "master"
@@ -53,13 +53,13 @@
   branch = "master"
   name = "github.com/opencontainers/runc"
   packages = ["libcontainer/configs"]
-  revision = "ff00fb108cc8764bdeb3fa1c538f572545673a9d"
+  revision = "593914b8bd5448a93f7c3e4902a03408b6d5c0ce"
 
 [[projects]]
   branch = "master"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
-  revision = "c3ed25aeee1d5a9bce94c68180224a366530af09"
+  revision = "689521f694a44ef01d4d39d17c638271655d58fd"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -68,40 +68,46 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
+  version = "v1.0.3"
+
+[[projects]]
   branch = "master"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "f6abca593680b2315d2075e0f5e2a9751e3f431a"
+  revision = "890a5c3458b43e6104ff5da8dfa139d013d77544"
 
 [[projects]]
   branch = "master"
   name = "github.com/urfave/cli"
   packages = ["."]
-  revision = "b892ba3809cd07fcf2b064e166b0c2e16e0147bd"
+  revision = "7fb9c86b14e6a702a4157ccb5a863f07d844a207"
 
 [[projects]]
   branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "4e28683688429fdf8413cc610d59fb1841986300"
+  revision = "933b978eae8c18daa1077a0eb7186b689cd9f82d"
 
 [[projects]]
   branch = "master"
   name = "github.com/vishvananda/netns"
   packages = ["."]
-  revision = "54f0e4339ce73702a0607f49922aaa1e749b418d"
+  revision = "86bef332bfc3b59b7624a600bd53009ce91a9829"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh"]
-  revision = "adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d"
+  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
+  revision = "faadfbdc035307d901e69eea569f5dda451a3ee3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733"
+  packages = ["unix","windows"]
+  revision = "062cd7e4e68206d8bab9b18396626e855c992658"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -1021,9 +1021,9 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = StartContainer(p.ID(), contID)
-	if c != nil || err == nil {
-		t.Fatal()
+	_, err = StartContainer(p.ID(), contID)
+	if err == nil {
+		t.Fatal("Function should have failed")
 	}
 }
 

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -454,12 +454,6 @@ func (h *hyper) startPod(pod Pod) error {
 		return err
 	}
 
-	for _, c := range pod.containers {
-		if err := h.startOneContainer(pod, *c); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -151,6 +151,17 @@ type HypervisorConfig struct {
 	// DefaultMem specifies default memory size in MiB for the VM.
 	// Pod configuration VMConfig.Memory overwrites this.
 	DefaultMemSz uint32
+
+	// MemPrealloc specifies if the memory should be pre-allocated
+	MemPrealloc bool
+
+	// Realtime Used to enable/disable realtime
+	Realtime bool
+
+	// Mlock is used to control memory locking when Realtime is enabled
+	// Realtime=true and Mlock=false, allows for swapping out of VM memory
+	// enabling higher density
+	Mlock bool
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -687,7 +687,7 @@ func (p *Pod) startCheckStates() error {
 	return nil
 }
 
-func (p *Pod) startSetStates() error {
+func (p *Pod) startSetState() error {
 	podState := State{
 		State: StateRunning,
 		// retain existing URL value
@@ -695,11 +695,6 @@ func (p *Pod) startSetStates() error {
 	}
 
 	err := p.setPodState(podState)
-	if err != nil {
-		return err
-	}
-
-	err = p.setContainersState(podState.State)
 	if err != nil {
 		return err
 	}
@@ -795,12 +790,15 @@ func (p *Pod) start() error {
 		return err
 	}
 
-	for _, c := range p.containers {
-		c.storeMounts()
+	// Pod is started
+	if err := p.startSetState(); err != nil {
+		return err
 	}
 
-	if err := p.startSetStates(); err != nil {
-		return err
+	for _, c := range p.containers {
+		if err := c.start(); err != nil {
+			return err
+		}
 	}
 
 	virtLog.Infof("Started Pod %s", p.ID())

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -559,6 +559,9 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		NoDefaults:   true,
 		NoGraphic:    true,
 		Daemonize:    true,
+		MemPrealloc:  q.config.MemPrealloc,
+		Realtime:     q.config.Realtime,
+		Mlock:        q.config.Mlock,
 	}
 
 	kernel := ciaoQemu.Kernel{


### PR DESCRIPTION
Update virtcontainers to 1.0 version.

  Added support for memory and cpu reservation
  Added stroage hotplug support
  Added code of conduct
  Added memory pre-allocation, realtime and memory locking support
  Fixed nested virtualization support
  Fixed log verbosity
  Fixed pod cleanup

- Fix issues deleting a container after a failing start
  e.g: docker run -ti busybox non-exithing binary
Fixes: #507

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>