### PR TITLE
config: Support a stateless system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ endif
 
 LIBEXECDIR := $(PREFIX)/libexec
 SHAREDIR := $(PREFIX)/share
+DEFAULTSDIR := $(SHAREDIR)/defaults
 
 PKGDATADIR := $(SHAREDIR)/$(CCDIR)
 PKGLIBDIR := $(LOCALSTATEDIR)/lib/$(CCDIR)
@@ -123,8 +124,15 @@ CONFIG_IN = $(CONFIG).in
 
 DESTTARGET := $(abspath $(DESTBINDIR)/$(TARGET))
 
-DESTCONFDIR := $(DESTDIR)/$(SYSCONFDIR)/$(CCDIR)
+DESTCONFDIR := $(DESTDIR)/$(DEFAULTSDIR)/$(CCDIR)
+DESTSYSCONFDIR := $(DESTDIR)/$(SYSCONFDIR)/$(CCDIR)
+
+# Main configuration file location for stateless systems
 DESTCONFIG := $(abspath $(DESTCONFDIR)/$(CONFIG_FILE))
+
+# Secondary configuration file location. Note that this takes precedence
+# over DESTCONFIG.
+DESTSYSCONFIG := $(abspath $(DESTSYSCONFDIR)/$(CONFIG_FILE))
 
 DESTSHAREDIR := $(DESTDIR)/$(SHAREDIR)
 
@@ -139,6 +147,7 @@ USER_VARS += BINDIR
 USER_VARS += CC_SYSTEM_BUILD
 USER_VARS += DESTCONFIG
 USER_VARS += DESTDIR
+USER_VARS += DESTSYSCONFIG
 USER_VARS += DESTTARGET
 USER_VARS += GLOBALLOGPATH
 USER_VARS += IMAGEPATH
@@ -215,7 +224,13 @@ const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
 const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 
+// Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(DESTCONFIG)"
+
+// Alternate config file that takes precedence over
+// defaultRuntimeConfiguration.
+var defaultSysConfRuntimeConfiguration = "$(DESTSYSCONFIG)"
+
 var defaultProxyPath = "$(PROXYPATH)"
 endef
 
@@ -339,14 +354,15 @@ show-footer:
 show-summary: show-header
 	@printf "• Summary:\n"
 	@printf "\n"
-	@printf "\tClear Containers system build     : $(cc_system_build)\n"
+	@printf "\tClear Containers system build         : $(cc_system_build)\n"
 	@printf "\n"
-	@printf "\tbinary install path (DESTTARGET)  : %s\n" $(DESTTARGET)
-	@printf "\tconfig install path (DESTCONFIG)  : %s\n" $(DESTCONFIG)
-	@printf "\thypervisor path (QEMUPATH)        : %s\n" $(QEMUPATH)
-	@printf "\tassets path (PKGDATADIR)          : %s\n" $(PKGDATADIR)
-	@printf "\tproxy+shim path (PKGLIBEXECDIR)   : %s\n" $(PKGLIBEXECDIR)
-	@printf "\tpause bundle path (PAUSEROOTPATH) : %s\n" $(PAUSEROOTPATH)
+	@printf "\tbinary install path (DESTTARGET)      : %s\n" $(DESTTARGET)
+	@printf "\tconfig install path (DESTCONFIG)      : %s\n" $(DESTCONFIG)
+	@printf "\talternate config path (DESTSYSCONFIG) : %s\n" $(DESTSYSCONFIG)
+	@printf "\thypervisor path (QEMUPATH)            : %s\n" $(QEMUPATH)
+	@printf "\tassets path (PKGDATADIR)              : %s\n" $(PKGDATADIR)
+	@printf "\tproxy+shim path (PKGLIBEXECDIR)       : %s\n" $(PKGLIBEXECDIR)
+	@printf "\tpause bundle path (PAUSEROOTPATH)     : %s\n" $(PAUSEROOTPATH)
 	@printf "\n"
 
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,20 @@ See [the contributing document](CONTRIBUTING.md).
 
 ## Configuration
 
-The runtime uses a single configuration file called `configuration.toml` which is normally located at `/etc/clear-containers/configuration.toml`.
+The runtime uses a single configuration file called `configuration.toml`.
+Since the runtime supports a [stateless system](https://clearlinux.org/features/stateless),
+it checks for this configuration file in multiple locations. The default
+location is `/usr/share/defaults/clear-containers/configuration.toml` for a
+standard system. However, if `/etc/clear-containers/configuration.toml`
+exists, this will take priority.
 
-To see details of your systems runtime environment (including the location of the configuration file), run:
+To see which paths the runtime will check for a configuration source, run:
+
+```bash
+$ cc-runtime --cc-show-default-config-paths
+```
+
+To see details of your systems runtime environment (including the location of the configuration file being used), run:
 
 ```bash
 $ cc-runtime cc-env

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -236,9 +236,9 @@ library.
 ### Configuration
 
 The runtime uses a TOML format configuration file called `configuration.toml`. By
-default this file is installed in the `/etc/clear-containers` directory and
-contains various settings such as the paths to the hypervisor, the guest
-kernel and the mini-OS image.
+default this file is installed in the `/usr/share/defaults/clear-containers`
+directory and contains various settings such as the paths to the hypervisor,
+the guest kernel and the mini-OS image.
 
 Most users will not need to modify the configuration file.
 

--- a/docs/developers-clear-containers-install.md
+++ b/docs/developers-clear-containers-install.md
@@ -123,7 +123,7 @@ See [the upgrading document](upgrading.md) for further details.
    $ # (note that this is only an example using default paths).
    $ sudo sed -i.bak -e 's!^\(image = ".*"\)!# \1 \
    image = "/usr/share/clear-containers/container.img"!g' \
-   /etc/clear-containers/configuration.toml
+   /usr/share/defaults/clear-containers/configuration.toml
    
 For more details on the runtime's build system, run:
 

--- a/installation/centos-setup.sh
+++ b/installation/centos-setup.sh
@@ -128,7 +128,7 @@ sudo yum -y install cc-runtime cc-proxy cc-shim linux-container clear-containers
 # rather than the OBS default values.
 sudo -E prefix_dir="${prefix_dir}" sed -i -e \
     "s,^path = \"/usr/bin/qemu-system-x86_64\",path = \"${prefix_dir}/bin/qemu-system-x86_64\",g" \
-    /etc/clear-containers/configuration.toml
+    /usr/share/defaults/clear-containers/configuration.toml
 
 # Configure CC by default
 service_dir="/etc/systemd/system/docker.service.d"

--- a/main.go
+++ b/main.go
@@ -91,6 +91,10 @@ var runtimeFlags = []cli.Flag{
 		Value: defaultRootDirectory,
 		Usage: "root directory for storage of container state (this should be located in tmpfs)",
 	},
+	cli.BoolFlag{
+		Name:  "cc-show-default-config-paths",
+		Usage: "show config file paths that will be checked for (in order)",
+	},
 }
 
 // runtimeCommands is the list of supported command-line (sub-)
@@ -132,6 +136,16 @@ var savedCLIErrWriter = cli.ErrWriter
 // beforeSubcommands is the function to perform preliminary checks
 // before command-line parsing occurs.
 func beforeSubcommands(context *cli.Context) error {
+	if context.GlobalBool("cc-show-default-config-paths") {
+		files := getDefaultConfigFilePaths()
+
+		for _, file := range files {
+			fmt.Fprintf(defaultOutputFile, "%s\n", file)
+		}
+
+		exit(0)
+	}
+
 	if userWantsUsage(context) || (context.NArg() == 1 && (context.Args()[0] == "cc-check")) {
 		// No setup required if the user just
 		// wants to see the usage statement or are

--- a/utils.go
+++ b/utils.go
@@ -150,6 +150,11 @@ func resolvePath(path string) (string, error) {
 
 	resolved, err := filepath.EvalSymlinks(absolute)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Make the error clearer than the default
+			return "", fmt.Errorf("file %v does not exist", absolute)
+		}
+
 		return "", err
 	}
 


### PR DESCRIPTION
Modify the runtime to look in multiple locations for its configuration.

Previously, with a CC system build, the build system would generate (and
the runtime would read) the file below:

    /etc/clear-containers/configuration.toml

This file was represented by the DESTCONFIG build variable.

However, now a CC system build will generate the following path instead:

    /usr/share/defaults/clear-containers/configuration.toml

But the runtime will look in both locations in the following order
(with build variables in brackets):

    /etc/clear-containers/configuration.toml (DESTSYSCONFIG)
    /usr/share/defaults/clear-containers/configuration.toml (DESTCONFIG)

(Note that the original configuration file now has a new build variable
name: DESTSYSCONFIG).

The first file the runtime finds will be used. Since previously the
configuration file below "/etc" was used and now the build will generate
the file below "/usr/share/defaults" instead, the advice is to delete
the "/etc/clear-containers" directory to ensure that the runtime uses
the latest pristine built configuration file by default.

Since the runtime requires a configuration file to run most commands,
but since the runtime is now looking in multiple locations for this
configuration, this change also introduces a new
"--cc-show-default-config-paths" global option. This option simply
displays the list of paths the runtime will consider as a configuration
source and then exits. This option does not require a configuration file
and may be useful to establish where the runtime is obtaining its
configuration from.

Fixes #551.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>