### PR TITLE
check: Fix golint errors.

### DIFF
--- a/cc-check.go
+++ b/cc-check.go
@@ -234,11 +234,7 @@ func hostIsClearContainersCapable(cpuinfoFile string) error {
 		return err
 	}
 
-	if err = checkKernelModules(requiredKernelModules); err != nil {
-		return err
-	}
-
-	return nil
+	return checkKernelModules(requiredKernelModules)
 }
 
 var ccCheckCLICommand = cli.Command{

--- a/create.go
+++ b/create.go
@@ -140,11 +140,7 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 	// Creation of PID file has to be the last thing done in the create
 	// because containerd considers the create complete after this file
 	// is created.
-	if err := createPIDFile(pidFilePath, process.Pid); err != nil {
-		return err
-	}
-
-	return nil
+	return createPIDFile(pidFilePath, process.Pid)
 }
 
 func getKernelParams(containerID string) []vc.Param {

--- a/kill.go
+++ b/kill.go
@@ -116,11 +116,7 @@ func kill(containerID, signal string, all bool) error {
 		return fmt.Errorf("Container %s not ready or running, cannot send a signal", containerID)
 	}
 
-	if err := vci.KillContainer(podID, containerID, signum, all); err != nil {
-		return err
-	}
-
-	return nil
+	return vci.KillContainer(podID, containerID, signum, all)
 }
 
 func processSignal(signal string) (syscall.Signal, error) {

--- a/list.go
+++ b/list.go
@@ -178,10 +178,8 @@ func (f *formatTabular) Write(state []fullContainerState, showAll bool, file *os
 			fmt.Fprintf(w, "\n")
 		}
 	}
-	if err := w.Flush(); err != nil {
-		return err
-	}
-	return nil
+
+	return w.Flush()
 }
 
 func (f *formatJSON) Write(state []fullContainerState, showAll bool, file *os.File) error {


### PR DESCRIPTION
golint is now causing builds to fail due to the need to simplify
certain functions that return errors.

Fixes #573.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>