### PR TITLE
versions.txt: Update kernel and image versions

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,8 @@
 cc_agent_version=0fca1509afbaa18c5a0ddf213f2e377c7b87dcc7
 #Clear Containers image from https://download.clearlinux.org/releases/
-clear_vm_image_version=16910 
+clear_vm_image_version=17270
 #Kernel configuration and patches from https://github.com/clearcontainers/linux
-clear_container_kernel=v4.9.35-76.container
+clear_container_kernel=v4.9.47-77.container
 #Docker suported version: 
 docker_version=v17.06-ce
 #Supported OCI spec: https://github.com/opencontainers/runtime-spec/releases


### PR DESCRIPTION
We are using kernel 4.9.47-77 and clear-containers-image 17270 in the
current build of clear-containers.

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>