### PR TITLE
Configuration: Provide an option to disable nesting customizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ DEFDISABLEBLOCK := false
 DEFENABLEMEMPREALLOC := false
 DEFENABLESWAP := false
 DEFENABLEDEBUG := false
+DEFDISABLENESTINGCHECKS := false
 
 SED = sed
 
@@ -187,6 +188,7 @@ USER_VARS += DEFDISABLEBLOCK
 USER_VARS += DEFENABLEMEMPREALLOC
 USER_VARS += DEFENABLESWAP
 USER_VARS += DEFENABLEDEBUG
+USER_VARS += DEFDISABLENESTINGCHECKS
 
 
 V              = @
@@ -239,6 +241,7 @@ const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 const defaultEnableMemPrealloc bool = $(DEFENABLEMEMPREALLOC)
 const defaultEnableSwap bool = $(DEFENABLESWAP)
 const defaultEnableDebug bool = $(DEFENABLEDEBUG)
+const defaultDisableNestingChecks bool = $(DEFDISABLENESTINGCHECKS)
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(DESTCONFIG)"
@@ -304,6 +307,7 @@ $(GENERATED_FILES): %: %.in Makefile VERSION
 		-e "s|@DEFENABLEMEMPREALLOC@|$(DEFENABLEMEMPREALLOC)|g" \
 		-e "s|@DEFENABLEMSWAP@|$(DEFENABLESWAP)|g" \
 		-e "s|@DEFENABLEMSWAP@|$(DEFENABLEDEBUG)|g" \
+		-e "s|@DEFDISABLENESTINGCHECKS@|$(DEFDISABLENESTINGCHECKS)|g" \
 		$< > $@
 
 generate-config: $(CONFIG)

--- a/config.go
+++ b/config.go
@@ -85,6 +85,7 @@ type hypervisor struct {
 	MemPrealloc           bool   `toml:"enable_mem_prealloc"`
 	Swap                  bool   `toml:"enable_swap"`
 	Debug                 bool   `toml:"enable_debug"`
+	DisableNestingChecks  bool   `toml:"disable_nesting_checks"`
 }
 
 type proxy struct {
@@ -236,6 +237,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		MemPrealloc:           h.MemPrealloc,
 		Mlock:                 !h.Swap,
 		Debug:                 h.Debug,
+		DisableNestingChecks:  h.DisableNestingChecks,
 	}, nil
 }
 
@@ -347,6 +349,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		MemPrealloc:           defaultEnableMemPrealloc,
 		Mlock:                 !defaultEnableSwap,
 		Debug:                 defaultEnableDebug,
+		DisableNestingChecks:  defaultDisableNestingChecks,
 	}
 
 	defaultAgentConfig := vc.HyperConfig{

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -46,6 +46,12 @@ disable_block_device_use = @DEFDISABLEBLOCK@
 # 
 #enable_debug = true
 
+# Disable the customizations done in the runtime when it detects
+# that it is running on top a VMM. This will result in the runtime
+# behaving as it would when running on bare metal.
+# 
+#disable_nesting_checks = true
+
 [proxy.cc]
 url = "@PROXYURL@"
 


### PR DESCRIPTION
Provide an option to disable nesting customization. This is useful
when running on top of KVM, where disabling the customizations
performed when the runtime detects it is running on top of a VM
results in higher performance.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>