### PR TITLE
tests: Increase unit test timeout

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -4,7 +4,14 @@ script_dir=$(cd `dirname $0`; pwd)
 root_dir=`dirname $script_dir`
 
 test_packages="."
-go_test_flags="-v -race -timeout 5s"
+
+# Set default test run timeout value.
+#
+# CC_GO_TEST_TIMEOUT can be set to any value accepted by
+# "go test -timeout X"
+timeout_value=${CC_GO_TEST_TIMEOUT:-10s}
+
+go_test_flags="-v -race -timeout $timeout_value"
 cov_file="profile.cov"
 tmp_cov_file="profile_tmp.cov"
 


### PR DESCRIPTION
Increase unit-test timeout to 10 seconds as 5 seconds is often
not enough in a Jenkins environment.

Allow the timeout to be configured by setting the variable
"CC_GO_TEST_TIMEOUT" to any valid value supported by
"go test -timeout X".

Fixes #617.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>