### PR TITLE
refactor: simplify code to return the fastpath first

### DIFF
--- a/cc-check.go
+++ b/cc-check.go
@@ -108,13 +108,7 @@ func findAnchoredString(haystack, needle string) bool {
 	// Ensure the search string is anchored
 	pattern := regexp.MustCompile(`\b` + needle + `\b`)
 
-	matched := pattern.MatchString(haystack)
-
-	if matched {
-		return true
-	}
-
-	return false
+	return pattern.MatchString(haystack)
 }
 
 func getCPUFlags(cpuinfo string) string {
@@ -140,11 +134,7 @@ func haveKernelModule(module string) bool {
 	// Now, check if the module is unloaded, but available
 	cmd := exec.Command(modInfoCmd, module)
 	err := cmd.Run()
-	if err == nil {
-		return true
-	}
-
-	return false
+	return err == nil
 }
 
 func checkCPU(tag, cpuinfo string, attribs map[string]string) error {
@@ -154,11 +144,10 @@ func checkCPU(tag, cpuinfo string, attribs map[string]string) error {
 
 	for attrib, desc := range attribs {
 		found := findAnchoredString(cpuinfo, attrib)
-		if found {
-			ccLog.Infof("Found CPU %v %q (%s)", tag, desc, attrib)
-		} else {
+		if !found {
 			return fmt.Errorf("CPU does not have required %v: %q (%s)", tag, desc, attrib)
 		}
+		ccLog.Infof("Found CPU %v %q (%s)", tag, desc, attrib)
 	}
 
 	return nil
@@ -193,9 +182,7 @@ func checkKernelModules(modules map[string]kernelModule) error {
 
 			value = strings.TrimRight(value, "\n\r")
 
-			if value == expected {
-				ccLog.Infof("Kernel module %q parameter %q has correct value", details.desc, param)
-			} else {
+			if value != expected {
 				msg := fmt.Sprintf("kernel module %q parameter %q has value %q (expected %q)", details.desc, param, value, expected)
 
 				// this option is not required when
@@ -207,6 +194,8 @@ func checkKernelModules(modules map[string]kernelModule) error {
 
 				return errors.New(msg)
 			}
+
+			ccLog.Infof("Kernel module %q parameter %q has correct value", details.desc, param)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -402,13 +402,11 @@ func getDefaultConfigFile() (string, error) {
 
 	for _, file := range getDefaultConfigFilePaths() {
 		resolved, err := resolvePath(file)
-		if err != nil {
-			s := fmt.Sprintf("config file %q unresolvable: %v", file, err)
-			errs = append(errs, s)
-			continue
+		if err == nil {
+			return resolved, nil
 		}
-
-		return resolved, nil
+		s := fmt.Sprintf("config file %q unresolvable: %v", file, err)
+		errs = append(errs, s)
 	}
 
 	return "", errors.New(strings.Join(errs, ", "))

--- a/exec.go
+++ b/exec.go
@@ -242,21 +242,21 @@ func execute(context *cli.Context) error {
 		return err
 	}
 
-	if !params.detach {
-		p, err := os.FindProcess(process.Pid)
-		if err != nil {
-			return err
-		}
-
-		ps, err := p.Wait()
-		if err != nil {
-			return fmt.Errorf("Process state %s, container info %+v: %v",
-				ps.String(), status, err)
-		}
-
-		// Exit code has to be forwarded in this case.
-		return cli.NewExitError("", ps.Sys().(syscall.WaitStatus).ExitStatus())
+	if params.detach {
+		return nil
 	}
 
-	return nil
+	p, err := os.FindProcess(process.Pid)
+	if err != nil {
+		return err
+	}
+
+	ps, err := p.Wait()
+	if err != nil {
+		return fmt.Errorf("Process state %s, container info %+v: %v",
+			ps.String(), status, err)
+	}
+
+	// Exit code has to be forwarded in this case.
+	return cli.NewExitError("", ps.Sys().(syscall.WaitStatus).ExitStatus())
 }

--- a/run.go
+++ b/run.go
@@ -95,30 +95,30 @@ func run(containerID, bundle, console, consoleSocket, pidFile string, detach boo
 		return err
 	}
 
-	if !detach {
-		containers := pod.GetAllContainers()
-		if len(containers) == 0 {
-			return fmt.Errorf("There are no containers running in the pod: %s", pod.ID())
-		}
-
-		p, err := os.FindProcess(containers[0].GetPid())
-		if err != nil {
-			return err
-		}
-
-		ps, err := p.Wait()
-		if err != nil {
-			return fmt.Errorf("Process state %s: %s", ps.String(), err)
-		}
-
-		// delete container's resources
-		if err := delete(pod.ID(), true); err != nil {
-			return err
-		}
-
-		//runtime should forward container exit code to the system
-		return cli.NewExitError("", ps.Sys().(syscall.WaitStatus).ExitStatus())
+	if detach {
+		return nil
 	}
 
-	return nil
+	containers := pod.GetAllContainers()
+	if len(containers) == 0 {
+		return fmt.Errorf("There are no containers running in the pod: %s", pod.ID())
+	}
+
+	p, err := os.FindProcess(containers[0].GetPid())
+	if err != nil {
+		return err
+	}
+
+	ps, err := p.Wait()
+	if err != nil {
+		return fmt.Errorf("Process state %s: %s", ps.String(), err)
+	}
+
+	// delete container's resources
+	if err := delete(pod.ID(), true); err != nil {
+		return err
+	}
+
+	//runtime should forward container exit code to the system
+	return cli.NewExitError("", ps.Sys().(syscall.WaitStatus).ExitStatus())
 }


### PR DESCRIPTION
Hi, my friends, 

Today I spend some time in learning this project clearcontainers/runtime, and will try to use this in the own company's virtualization environment. 

What is amazing project this is! I found that you guys organized and maintained the project so well.

I would be excited if I could be involved in this project. While when I am learning the project, I found that maybe there is some place where we could improve a bit.

What I did:
1. simplify some codes;
2. use `return fast` to eliminate some `else` block, since I think this will make codes ident less to be more readable.

fixes https://github.com/clearcontainers/runtime/issues/623

Although these are all tiny changes, feel free to tell me if I could make more improvement.

 