### PR TITLE
build: Fix config file warning message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}
 
 CONFIG_FILE = configuration.toml
 CONFIG = config/$(CONFIG_FILE)
+CONFIG_IN = $(CONFIG).in
 
 DESTTARGET := $(abspath $(DESTBINDIR)/$(TARGET))
 


### PR DESCRIPTION
Commit ffe6ccfc9047245c0d6193738b00973f2ee5460c inadvertently removed the
`CONFIG_IN` variable used by the build to generate part of the warning
message in the auto-generated config file.

Re-added to fix it.

Fixes #635.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>