### PR TITLE
fix write cgroup no space left

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -44,6 +45,7 @@ import (
 const (
 	testDisabledNeedRoot    = "Test disabled as requires root user"
 	testDisabledNeedNonRoot = "Test disabled as requires non-root user"
+	testDisabledNeedCgroup  = "Test disabled as cgroup system not support"
 	testDirMode             = os.FileMode(0750)
 	testFileMode            = os.FileMode(0640)
 	testExeFileMode         = os.FileMode(0750)
@@ -485,6 +487,34 @@ func writeOCIConfigFile(spec oci.CompatOCISpec, configPath string) error {
 	}
 
 	return ioutil.WriteFile(configPath, bytes, testFileMode)
+}
+
+func findCgroupRoot() string {
+	var cgroupRootPath string
+	f, err := os.Open("/proc/mounts")
+	if err != nil {
+		return cgroupRootPath
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := scanner.Text()
+		fields := strings.Split(text, " ")
+		index := strings.Index(text, " - ")
+		postSeparatorFields := strings.Fields(text[index+3:])
+		numPostFields := len(postSeparatorFields)
+
+		// This is an error as we can't detect if the mount is for "cgroup"
+		if numPostFields == 0 || fields[0] != "cgroup" || numPostFields < 3 {
+			continue
+		}
+
+		cgroupRootPath = filepath.Dir(fields[1])
+		break
+	}
+
+	return cgroupRootPath
 }
 
 func newSingleContainerPodStatusList(podID, containerID string, podState, containerState vc.State, annotations map[string]string) []vc.PodStatus {

--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -186,4 +187,22 @@ func runCommandFull(args []string, includeStderr bool) (string, error) {
 // runCommand returns the commands space-trimmed standard output on success
 func runCommand(args []string) (string, error) {
 	return runCommandFull(args, false)
+}
+
+// writeFile write data into specified file
+func writeFile(filePath string, data string, fileMode os.FileMode) error {
+	// Normally dir should not be empty, one case is that cgroup subsystem
+	// is not mounted, we will get empty dir, and we want it fail here.
+	if filePath == "" {
+		return fmt.Errorf("no such file for %s", filePath)
+	}
+	if err := ioutil.WriteFile(filePath, []byte(data), fileMode); err != nil {
+		return fmt.Errorf("failed to write %v to %v: %v", data, filePath, err)
+	}
+	return nil
+}
+
+// isEmptyString return if string is empty
+func isEmptyString(b []byte) bool {
+	return len(bytes.Trim(b, "\n")) == 0
 }


### PR DESCRIPTION
fix write /sys/fs/cgroup/cpu/docker/471fb846c4d02703eebe9d3bafdbba3a5975b6c6535492784036298705576457/tasks: no space left on device

because cpuset.mems in the container's cpuset cgroup directory is empty
Fix #642 

Signed-off-by: Ace-Tang <huamin.thm@alibaba-inc.com>