### PR TITLE
logger: Display timezone as offset

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -156,7 +157,7 @@ func (hook *GlobalLogHook) Fire(entry *logrus.Entry) error {
 	fields := formatFields(entry.Data)
 
 	str := fmt.Sprintf("time=%q pid=%d name=%q level=%q",
-		entry.Time,
+		entry.Time.Format(time.RFC3339Nano),
 		os.Getpid(),
 		name,
 		entry.Level)


### PR DESCRIPTION
Change format of time included in log entries to display the timezone
as an offset.

Example of old format:

    time="2017-09-28 13:22:58.965483966 +0100 BST"

Example of new format:

    time="2017-09-29T13:22:58.965483966+01:00"

Fixes #650.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>