### PR TITLE
tests: Only pull docker test image if not available locally

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -104,9 +104,16 @@ func init() {
 	// Do this now to avoid hitting the test timeout value due to
 	// slow network response.
 	fmt.Printf("INFO: ensuring required docker image (%v) is available\n", testDockerImage)
-	_, err = runCommand([]string{"docker", "pull", testDockerImage})
-	if err != nil {
-		panic(err)
+
+	// Only hit the network if the image doesn't exist locally
+	_, err = runCommand([]string{"docker", "image", "inspect", testDockerImage})
+	if err == nil {
+		fmt.Printf("INFO: docker image %v already exists locally\n", testDockerImage)
+	} else {
+		_, err = runCommand([]string{"docker", "pull", testDockerImage})
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	testBundleDir = filepath.Join(testDir, testBundle)


### PR DESCRIPTION
Change the unit-test setup code to only download the "busybox" docker
image if it doesn't already exist locally. Since the unit-tests are run
twice (once as a non-privileged user and once as `root`), this can speed
up the overall unit-test runtime significantly.

Fixes #653.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>