### PR TITLE
main: coredump on internal error

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	vc "github.com/containers/virtcontainers"
@@ -132,6 +133,11 @@ var runtimeVersion = makeVersionString
 var savedCLIAppHelpTemplate = cli.AppHelpTemplate
 var savedCLIVersionPrinter = cli.VersionPrinter
 var savedCLIErrWriter = cli.ErrWriter
+
+func init() {
+	// Force a coredump + full stacktrace on internal error
+	debug.SetTraceback("crash")
+}
 
 // beforeSubcommands is the function to perform preliminary checks
 // before command-line parsing occurs.


### PR DESCRIPTION
Override the default golang panic handling by printing a full traceback
(not just for the current goroutine) and coredumping to allow
crash-handling programs like apport to log the details.

Fixes #688.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>