### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,7 +35,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/vcMock"]
-  revision = "8cbd7a24a221f4462dab8e2f5308265a35bd68c1"
+  revision = "da3902a846d3539c061f3b755db7ed5eff9b772c"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/NEWS
+++ b/vendor/github.com/containers/virtcontainers/NEWS
@@ -1,3 +1,9 @@
+1.0.3:
+	Added initial device assignment framework
+	Added VFIO devices assignment initial support
+	Fixed pod locking
+	Fixed unconfigured interfaces handling
+
 1.0.2:
 	Added James Hunt as maintainer
 	Added huge pages support

--- a/vendor/github.com/containers/virtcontainers/cc_shim.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim.go
@@ -28,7 +28,8 @@ type ccShim struct{}
 // CCShimConfig is the structure providing specific configuration
 // for ccShim implementation.
 type CCShimConfig struct {
-	Path string
+	Path  string
+	Debug bool
 }
 
 var consoleFileMode = os.FileMode(0660)
@@ -58,7 +59,12 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		return -1, fmt.Errorf("URL cannot be empty")
 	}
 
-	cmd := exec.Command(config.Path, "-t", params.Token, "-u", params.URL)
+	args := []string{config.Path, "-t", params.Token, "-u", params.URL}
+	if config.Debug {
+		args = append(args, "-d")
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = os.Environ()
 
 	if !params.Detach {


### PR DESCRIPTION
Use the latest version of virtcontainers to allow shim debug to be
enabled.

Shortlog of virtcontainers vendoring since the last one:

    df5e866 shim: Add ability to enable debug output
    06a344c 1.0.3 release

Fixes #690.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>