### PR TITLE
Make debug configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ $ cc-runtime cc-env
 
 ## Debugging
 
+### Global logfile
+
 To provide a persistent log of all container activity on the system, the runtime
 offers a global logging facility. By default, this feature is disabled
 but can be enabled with a simple change to the [configuration](#Configuration) file.
@@ -101,6 +103,14 @@ attempt to create it.
 
 It is the Administrator's responsibility to ensure there is sufficient
 space for the global log.
+
+### Enabling debug for various components
+
+The runtime, the shim (`cc-shim`), and the hypervisor all have separate debug
+options in the [configuration file](#Configuration).
+
+The proxy (`cc-proxy`) has a command-line option to enable debug output. See
+the [proxy documentation](https://github.com/clearcontainers/proxy#debugging) for further details.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 # runtime
 
+* [Introduction](#introduction)
+* [License](#license)
+* [Hardware requirements](#hardware-requirements)
+* [Quick start for users](#quick-start-for-users)
+* [Quick start for developers](#quick-start-for-developers)
+* [Community](#community)
+* [Configuration](#configuration)
+* [Debugging](#debugging)
+    * [Global logfile](#global-logfile)
+    * [Enabling debug for various components](#enabling-debug-for-various-components)
+* [Limitations](#limitations)
+* [Home Page](#home-page)
+
 ## Introduction
 
 `cc-runtime` is the next generation of Intel® Clear Containers runtime.

--- a/config.go
+++ b/config.go
@@ -98,7 +98,8 @@ type runtime struct {
 }
 
 type shim struct {
-	Path string `toml:"path"`
+	Path  string `toml:"path"`
+	Debug bool   `toml:"enable_debug"`
 }
 
 type agent struct {
@@ -191,6 +192,10 @@ func (s shim) path() (string, error) {
 	return resolvePath(p)
 }
 
+func (s shim) debug() bool {
+	return s.Debug
+}
+
 func (a agent) pauseRootPath() (string, error) {
 	p := a.PauseRootPath
 
@@ -267,7 +272,8 @@ func newCCShimConfig(s shim) (vc.CCShimConfig, error) {
 	}
 
 	return vc.CCShimConfig{
-		Path: path,
+		Path:  path,
+		Debug: s.debug(),
 	}, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -95,6 +95,7 @@ type proxy struct {
 
 type runtime struct {
 	GlobalLogPath string `toml:"global_log_path"`
+	Debug         bool   `toml:"enable_debug"`
 }
 
 type shim struct {
@@ -399,6 +400,12 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	}
 
 	logfilePath = tomlConf.Runtime.GlobalLogPath
+
+	if !tomlConf.Runtime.Debug {
+		// If debug is not required, switch back to the original
+		// default log priority, otherwise continue in debug mode.
+		ccLog.Logger.Level = originalLoggerLevel
+	}
 
 	if !ignoreLogging {
 		// The configuration file may have enabled global logging,

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -66,6 +66,10 @@ url = "@PROXYURL@"
 [shim.cc]
 path = "@SHIMPATH@"
 
+# If enabled, shim messages will be sent to the system log
+# (default: disabled)
+#enable_debug = true
+
 [agent.hyperstart]
 pause_root_path = "@PAUSEROOTPATH@"
 

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -73,6 +73,11 @@ path = "@SHIMPATH@"
 [agent.hyperstart]
 pause_root_path = "@PAUSEROOTPATH@"
 
+[runtime]
 ## Uncomment to enable the global logging to the default path.
-#[runtime]
 #global_log_path = "@GLOBALLOGPATH@"
+
+# If enabled, the runtime will log additional debug messages to the global
+# log, assuming that is also enabled.
+# (default: disabled)
+#enable_debug = true

--- a/config_test.go
+++ b/config_test.go
@@ -985,6 +985,10 @@ func TestShimDefaults(t *testing.T) {
 	p, err = s.path()
 	assert.NoError(err)
 	assert.Equal(p, testShimPath)
+
+	assert.False(s.debug())
+	s.Debug = true
+	assert.True(s.debug())
 }
 
 func TestAgentDefaults(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -150,10 +150,10 @@ func TestHandleGlobalLog(t *testing.T) {
 
 		// Add a log entry
 		str := "hello. foo bar baz!"
-		ccLog.Debug(str)
+		ccLog.Info(str)
 
 		// Check that the string was logged
-		err = grep(fmt.Sprintf("level=\"debug\".*%s", str), d.path)
+		err = grep(fmt.Sprintf("level=\"info\".*%s", str), d.path)
 		assert.NoError(err)
 
 		// Check expected perms
@@ -191,7 +191,7 @@ func TestHandleGlobalLogEnvVar(t *testing.T) {
 	}
 
 	str := "foo or moo?"
-	ccLog.Debug(str)
+	ccLog.Info(str)
 	tmpfileExists := fileExists(tmpfile)
 	tmpfile2Exists := fileExists(tmpfile2)
 
@@ -204,7 +204,7 @@ func TestHandleGlobalLogEnvVar(t *testing.T) {
 	}
 
 	// Check that the string was logged
-	err = grep(fmt.Sprintf("level=\"debug\".*%s", str), tmpfile2)
+	err = grep(fmt.Sprintf("level=\"info\".*%s", str), tmpfile2)
 	assert.NoError(t, err)
 }
 
@@ -223,15 +223,15 @@ func TestLoggerFire(t *testing.T) {
 	entry := &logrus.Entry{
 		Logger:  ccLog.Logger,
 		Time:    time.Now().UTC(),
-		Level:   logrus.DebugLevel,
+		Level:   logrus.InfoLevel,
 		Message: "foo",
 	}
 
-	err = ccLog.Logger.Hooks.Fire(logrus.DebugLevel, entry)
+	err = ccLog.Logger.Hooks.Fire(logrus.InfoLevel, entry)
 	assert.NoError(t, err)
 
-	assert.Equal(t, len(ccLog.Logger.Hooks[logrus.DebugLevel]), 1)
-	hook, ok := ccLog.Logger.Hooks[logrus.DebugLevel][0].(*GlobalLogHook)
+	assert.Equal(t, len(ccLog.Logger.Hooks[logrus.InfoLevel]), 1)
+	hook, ok := ccLog.Logger.Hooks[logrus.InfoLevel][0].(*GlobalLogHook)
 	assert.True(t, ok)
 
 	err = hook.file.Close()
@@ -240,6 +240,6 @@ func TestLoggerFire(t *testing.T) {
 	err = os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
-	err = ccLog.Logger.Hooks.Fire(logrus.DebugLevel, entry)
+	err = ccLog.Logger.Hooks.Fire(logrus.InfoLevel, entry)
 	assert.Error(t, err)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containers/virtcontainers/pkg/vcMock"
 	"github.com/dlespiau/covertool/pkg/cover"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -678,22 +677,13 @@ func TestMainBeforeSubCommandsInvalidLogFile(t *testing.T) {
 	app := cli.NewApp()
 
 	set := flag.NewFlagSet("", 0)
-	set.Bool("debug", true, "")
 	set.String("log", logFile, "")
 	set.Parse([]string{"create"})
-
-	logLevel := ccLog.Logger.Level
-	ccLog.Logger.Level = logrus.PanicLevel
-
-	defer func() {
-		ccLog.Logger.Level = logLevel
-	}()
 
 	ctx := cli.NewContext(app, set, nil)
 
 	err = beforeSubcommands(ctx)
 	assert.Error(err)
-	assert.Equal(ccLog.Logger.Level, logrus.DebugLevel)
 }
 
 func TestMainBeforeSubCommandsInvalidLogFormat(t *testing.T) {


### PR DESCRIPTION
Add config options to toggle debug for the shim and the runtime (we already have an option for the hypervisor and the proxy is handled separately).