### PR TITLE
vendor: update ciao and virtcontainers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,7 +35,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/vcMock"]
-  revision = "da3902a846d3539c061f3b755db7ed5eff9b772c"
+  revision = "8776aa26767ad804738b7032951aa82e07c8286b"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "49b0fd97c72517dfb2450aa6a08ff4b9bb7bff42"
+  revision = "cbd9f90db8c1ae5d4f938361146c716a305064ec"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/01org/ciao/qemu/qemu.go
+++ b/vendor/github.com/01org/ciao/qemu/qemu.go
@@ -837,6 +837,9 @@ type Config struct {
 	// Knobs is a set of qemu boolean settings.
 	Knobs Knobs
 
+	// Bios is the -bios parameter
+	Bios string
+
 	// fds is a list of open file descriptors to be passed to the spawned qemu process
 	fds []*os.File
 
@@ -1082,6 +1085,13 @@ func (config *Config) appendKnobs() {
 	}
 }
 
+func (config *Config) appendBios() {
+	if config.Bios != "" {
+		config.qemuParams = append(config.qemuParams, "-bios")
+		config.qemuParams = append(config.qemuParams, config.Bios)
+	}
+}
+
 // LaunchQemu can be used to launch a new qemu instance.
 //
 // The Config parameter contains a set of qemu parameters and settings.
@@ -1105,6 +1115,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendVGA()
 	config.appendKnobs()
 	config.appendKernel()
+	config.appendBios()
 
 	return LaunchCustomQemu(config.Ctx, config.Path, config.qemuParams, config.fds, logger)
 }

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "221e8b626c089e06ba37e095fac372b779077e5d"
+  revision = "44068003db570d97b20b7de0ed0686a9eee0cc0f"
 
 [[projects]]
   name = "github.com/clearcontainers/proxy"

--- a/vendor/github.com/containers/virtcontainers/device_test.go
+++ b/vendor/github.com/containers/virtcontainers/device_test.go
@@ -92,7 +92,7 @@ func testCreateDevice(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func testNewDevice(t *testing.T) {
+func testNewDevices(t *testing.T) {
 	savedSysDevPrefix := sysDevPrefix
 
 	major := int64(252)
@@ -116,10 +116,20 @@ func testNewDevice(t *testing.T) {
 	err = ioutil.WriteFile(ueventPath, content, 0644)
 	assert.Nil(t, err)
 
-	device, err := NewDevice(path, "c", major, minor, nil, 2, 2)
+	deviceInfo := DeviceInfo{
+		ContainerPath: path,
+		Major:         major,
+		Minor:         minor,
+		UID:           2,
+		GID:           2,
+		DevType:       "c",
+	}
+
+	devices, err := newDevices([]DeviceInfo{deviceInfo})
 	assert.Nil(t, err)
 
-	vfioDev, ok := device.(*VFIODevice)
+	assert.Equal(t, len(devices), 1)
+	vfioDev, ok := devices[0].(*VFIODevice)
 	assert.True(t, ok)
 	assert.Equal(t, vfioDev.DeviceInfo.HostPath, path)
 	assert.Equal(t, vfioDev.DeviceInfo.ContainerPath, path)

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -127,6 +127,12 @@ type HypervisorConfig struct {
 	// ImagePath is the guest image host path.
 	ImagePath string
 
+	// FirmwarePath is the bios host path
+	FirmwarePath string
+
+	// MachineAccelerators are machine specific accelerators
+	MachineAccelerators string
+
 	// HypervisorPath is the hypervisor executable host path.
 	HypervisorPath string
 

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils_test.go
@@ -132,7 +132,6 @@ func TestMinimalPodConfig(t *testing.T) {
 
 	devInfo := vc.DeviceInfo{
 		ContainerPath: "/dev/vfio/17",
-		HostPath:      "/dev/vfio/17",
 		Major:         242,
 		Minor:         0,
 		DevType:       "c",
@@ -140,12 +139,8 @@ func TestMinimalPodConfig(t *testing.T) {
 		GID:           0,
 	}
 
-	vfioDevice := vc.VFIODevice{}
-	vfioDevice.DeviceInfo = devInfo
-	vfioDevice.DeviceType = vc.DeviceVFIO
-
-	expectedDevices := []vc.Device{
-		&vfioDevice,
+	expectedDeviceInfo := []vc.DeviceInfo{
+		devInfo,
 	}
 
 	expectedContainerConfig := vc.ContainerConfig{
@@ -158,8 +153,8 @@ func TestMinimalPodConfig(t *testing.T) {
 			BundlePathKey:    tempBundlePath,
 			ContainerTypeKey: string(vc.PodSandbox),
 		},
-		Mounts:  expectedMounts,
-		Devices: expectedDevices,
+		Mounts:      expectedMounts,
+		DeviceInfos: expectedDeviceInfo,
 	}
 
 	expectedNetworkConfig := vc.NetworkConfig{
@@ -675,7 +670,7 @@ func TestDeviceTypeFailure(t *testing.T) {
 		},
 	}
 
-	_, err := containerDevices(ociSpec)
+	_, err := containerDeviceInfos(ociSpec)
 	assert.NotNil(t, err, "This test should fail as device type [%s] is invalid ", invalidDeviceType)
 }
 
@@ -700,7 +695,7 @@ func TestDevicePathEmpty(t *testing.T) {
 		},
 	}
 
-	_, err := containerDevices(ociSpec)
+	_, err := containerDeviceInfos(ociSpec)
 	assert.NotNil(t, err, "This test should fail as path cannot be empty for device")
 }
 

--- a/vendor/github.com/containers/virtcontainers/pod_test.go
+++ b/vendor/github.com/containers/virtcontainers/pod_test.go
@@ -1267,25 +1267,21 @@ func TestPodAttachDevicesVFIO(t *testing.T) {
 	}
 	vfioDevice := newVFIODevice(deviceInfo)
 
-	containers := []ContainerConfig{
-		{
-			ID: "100",
-			Devices: []Device{
-				vfioDevice,
-			},
+	c := &Container{
+		id: "100",
+		devices: []Device{
+			vfioDevice,
 		},
 	}
 
-	hConfig := newHypervisorConfig(nil, nil)
-	pod, err := testCreatePod(t, testPodID, MockHypervisor, hConfig, NoopAgentType, NoopNetworkModel, NetworkConfig{}, containers, nil)
-	if err != nil {
-		t.Fatal(err)
+	containers := []*Container{c}
+
+	pod := Pod{
+		containers: containers,
+		hypervisor: &mockHypervisor{},
 	}
 
-	c := pod.GetContainer("100")
-	if c == nil {
-		t.Fatal()
-	}
+	containers[0].pod = &pod
 
 	err = pod.attachDevices()
 	assert.Nil(t, err, "Error while attaching devices %s", err)


### PR DESCRIPTION
update ciao and virtcontainers

fixes #704 

virtcontainer short log:
    c286dbb device: Call addDevice after dereferencing pointer receiver.
    caefa12 devices: Refactor device handling
    95f3ae9 filesystem: Split function to reduce cyclomatic complexity
    4640741 filesystem: Custom marshal and unmarshal device interface objects
    e0fef66 qemu: add default machine accelerators
    cdc77cc qemu: remove newer machine accelerators
    c1291fb qemu: support for custom machine accelerators
    93014e4 qemu: support custom bios
    e1fa974 vendor: update ciao

ciao short log:
    96bd26b openstack/block: Remove unused API for getting limits
    fb02316 singlevm: Fix storage tests
    dd17576 openstack/compute: Remove flavor API
    5f764ed ciao-cli: Use workload API for listing workloads
    fd08780 ciao-controller: Add API entrypoints for listing workloads
    1a26ce2 openstack/compute: Make workload filtering use "workload"
    d5cfa99 openstack/compute: put workload ID in details struct
    979ab37 bat: Change references to FlavorID to WorkloadID
    e89a6f7 openstack/compute: Rename Flavor to WorkloadID in create request
    44223dc openstack/compute, bat: standardise on NodeID
    c2ab924 openstack/compute: rename OsExtendedVolumesVolumesAttached
    3d165fb openstack/compute: Simplify the way we store use IP/MAC addresses
    4a30edc openstack/compute: Remove unused fields from ServerDetails struct
    ad579e7 openstack/compute: Remove mostly unused Image field
    c5eea77 opentstack/compute: Remove unused fields from Addresses struct
    c73deac bios: add support for custom bios
    19f008d ciao-deploy: Keep going if any unjoin step fails
    9998583 configuration: Remove "compute_fqdn" from configuration
    0b88648 ciao-controller: Use certificate common name as canonical name
    b760589 storage_bat: Test that detaching from active instance fails
    a524e08 singlevm: Do not access $GOPATH directly
    1c4a091 singlevm: Move singlevm to use ciao-deploy setup
    3d858df ciao-deploy: When an SSH command fails report stdout/stderr
    9716e2d testutil: Remove unused code