### PR TITLE
tests: fix format error in TestIsCgroupMounted

### DIFF
--- a/oci_test.go
+++ b/oci_test.go
@@ -532,7 +532,7 @@ func TestIsCgroupMounted(t *testing.T) {
 
 	memoryCgroupPath := "/sys/fs/cgroup/memory"
 	if _, err := os.Stat(memoryCgroupPath); os.IsNotExist(err) {
-		t.Skip("memory cgroup does not exist: %s", memoryCgroupPath)
+		t.Skipf("memory cgroup does not exist: %s", memoryCgroupPath)
 	}
 
 	assert.True(isCgroupMounted(memoryCgroupPath), "%s is a cgroup", memoryCgroupPath)


### PR DESCRIPTION
should use t.Skipf() instead of Skip(), or will cause
format error

Fixes #717.

Ace-Tang <aceapril@126.com>

Thank for tell me if the patch is properly