### PR TITLE
vendor: Update virtcontainers vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,7 +35,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/vcMock"]
-  revision = "8776aa26767ad804738b7032951aa82e07c8286b"
+  revision = "f5f7a9ffef726a16fe2fd801f0592f86c81fa6fa"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/cc_shim.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim.go
@@ -59,7 +59,11 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		return -1, fmt.Errorf("URL cannot be empty")
 	}
 
-	args := []string{config.Path, "-t", params.Token, "-u", params.URL}
+	if params.Container == "" {
+		return -1, fmt.Errorf("Container cannot be empty")
+	}
+
+	args := []string{config.Path, "-c", params.Container, "-t", params.Token, "-u", params.URL}
 	if config.Debug {
 		args = append(args, "-d")
 	}

--- a/vendor/github.com/containers/virtcontainers/cc_shim_test.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim_test.go
@@ -31,6 +31,9 @@ import (
 	. "github.com/containers/virtcontainers/pkg/mock"
 )
 
+// These tests don't care about the format of the container ID
+const testContainer = "testContainer"
+
 var testShimPath = "/usr/bin/virtcontainers/bin/test/shim"
 var testProxyURL = "foo:///foo/clear-containers/proxy.sock"
 var testWrongConsolePath = "/foo/wrong-console"
@@ -130,6 +133,24 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 	testCCShimStart(t, pod, params, true)
 }
 
+func TestCCShimStartParamsContainerEmptyFailure(t *testing.T) {
+	pod := Pod{
+		config: &PodConfig{
+			ShimType: CCShimType,
+			ShimConfig: CCShimConfig{
+				Path: getMockCCShimBinPath(),
+			},
+		},
+	}
+
+	params := ShimParams{
+		Token: "testToken",
+		URL:   "unix://is/awesome",
+	}
+
+	testCCShimStart(t, pod, params, true)
+}
+
 func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -175,9 +196,10 @@ func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.Fi
 	}
 
 	params := ShimParams{
-		Token:  "testToken",
-		URL:    testProxyURL,
-		Detach: detach,
+		Container: testContainer,
+		Token:     "testToken",
+		URL:       testProxyURL,
+		Detach:    detach,
 	}
 
 	return rStdout, wStdout, saveStdout, pod, params, nil
@@ -335,9 +357,10 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 	}
 
 	params := ShimParams{
-		Token:   "testToken",
-		URL:     testProxyURL,
-		Console: console,
+		Container: testContainer,
+		Token:     "testToken",
+		URL:       testProxyURL,
+		Console:   console,
 	}
 
 	testCCShimStart(t, pod, params, false)

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -702,10 +702,11 @@ func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, err
 	}
 
 	shimParams := ShimParams{
-		Token:   token,
-		URL:     url,
-		Console: cmd.Console,
-		Detach:  cmd.Detach,
+		Container: c.id,
+		Token:     token,
+		URL:       url,
+		Console:   cmd.Console,
+		Detach:    cmd.Detach,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -759,10 +759,11 @@ func (p *Pod) startShims() error {
 
 	for idx := range p.containers {
 		shimParams := ShimParams{
-			Token:   proxyInfos[idx].Token,
-			URL:     url,
-			Console: p.containers[idx].config.Cmd.Console,
-			Detach:  p.containers[idx].config.Cmd.Detach,
+			Container: p.containers[idx].id,
+			Token:     proxyInfos[idx].Token,
+			URL:       url,
+			Console:   p.containers[idx].config.Cmd.Console,
+			Detach:    p.containers[idx].config.Cmd.Detach,
 		}
 
 		pid, err := p.shim.start(*p, shimParams)

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -41,10 +41,11 @@ var waitForShimTimeout = 5.0
 // ShimParams is the structure providing specific parameters needed
 // for the execution of the shim binary.
 type ShimParams struct {
-	Token   string
-	URL     string
-	Console string
-	Detach  bool
+	Container string
+	Token     string
+	URL       string
+	Console   string
+	Detach    bool
 }
 
 // Set sets a shim type based on the input string.

--- a/vendor/github.com/stretchr/testify/.travis.gofmt.sh
+++ b/vendor/github.com/stretchr/testify/.travis.gofmt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -n "$(gofmt -l .)" ]; then
+  echo "Go code is not formatted:"
+  gofmt -d .
+  exit 1
+fi

--- a/vendor/github.com/stretchr/testify/.travis.gogenerate.sh
+++ b/vendor/github.com/stretchr/testify/.travis.gogenerate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_GO_VERSION" =~ ^1\.[45](\..*)?$ ]]; then
+  exit 0
+fi
+
+go get github.com/ernesto-jimenez/gogen/imports
+go generate ./...
+if [ -n "$(git diff)" ]; then
+  echo "Go generate had not been run"
+  git diff
+  exit 1
+fi

--- a/vendor/github.com/stretchr/testify/.travis.govet.sh
+++ b/vendor/github.com/stretchr/testify/.travis.govet.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd "$(dirname $0)"
+DIRS=". assert require mock _codegen"
+set -e
+for subdir in $DIRS; do
+  pushd $subdir
+  go vet
+  popd
+done


### PR DESCRIPTION
Use the latest version of virtcontainers to allow shim to be passed the
container ID.

Shortlog of virtcontainers changes since the last re-vendor:

    971215d ci: Fix call to virtcontainers-setup.sh
    1b5888f shim: Pass container ID using CLI option
    7148059 docs: Describe how vfio devices can be passed

Fixes #721.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>