### PR TITLE
oci: Add conatiner ID to error message

### DIFF
--- a/oci.go
+++ b/oci.go
@@ -85,7 +85,7 @@ func getExistingContainerInfo(containerID string) (vc.ContainerStatus, string, e
 
 	// container ID MUST exist.
 	if cStatus.ID == "" {
-		return vc.ContainerStatus{}, "", fmt.Errorf("Container ID does not exist")
+		return vc.ContainerStatus{}, "", fmt.Errorf("Container ID (%v) does not exist", containerID)
 	}
 
 	return cStatus, podID, nil


### PR DESCRIPTION
Improve one of the errors returned by `getExistingContainerInfo()` when
it fails to obtain the container status by including the container ID
in the returned error.

Fixes #735.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>