### PR TITLE
Improve docker failure message harder

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -104,9 +104,10 @@ func init() {
 	fmt.Printf("INFO: test directory is %v\n", testDir)
 
 	fmt.Printf("INFO: ensuring docker is running\n")
-	_, err = runCommand([]string{"docker", "version"})
+	output, err := runCommandFull([]string{"docker", "version"}, true)
 	if err != nil {
-		panic(fmt.Sprintf("ERROR: docker daemon is not running: %v", err))
+		panic(fmt.Sprintf("ERROR: docker daemon is not installed, not running, or not accessible to current user: %v (error %v)",
+			output, err))
 	}
 
 	// Do this now to avoid hitting the test timeout value due to

--- a/utils.go
+++ b/utils.go
@@ -163,7 +163,8 @@ func resolvePath(path string) (string, error) {
 }
 
 // runCommandFull returns the commands space-trimmed standard output and
-// error on success
+// error on success. Note that if the command fails, the requested output will
+// still be returned, along with an error.
 func runCommandFull(args []string, includeStderr bool) (string, error) {
 	cmd := exec.Command(args[0], args[1:]...)
 	var err error
@@ -175,13 +176,9 @@ func runCommandFull(args []string, includeStderr bool) (string, error) {
 		bytes, err = cmd.Output()
 	}
 
-	if err != nil {
-		return "", err
-	}
-
 	trimmed := strings.TrimSpace(string(bytes))
 
-	return trimmed, nil
+	return trimmed, err
 }
 
 // runCommand returns the commands space-trimmed standard output on success


### PR DESCRIPTION
If docker cannot be connected to, display a more informative error
message along with the error output.

Fixes #776.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>