### PR TITLE
Networking: Revendor netlink and virtcontainers to support macvtap

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,7 +30,7 @@
 [[projects]]
   name = "github.com/containers/virtcontainers"
   packages = [".","pkg/cni","pkg/hyperstart","pkg/oci","pkg/uuid","pkg/vcMock"]
-  revision = "e8b0c3a6c9fd7691e37a6aa73ed6af4c42f42ad1"
+  revision = "c3c42b5690ce384a26dcb8ac59e922a20dd0ac7a"
 
 [[projects]]
   branch = "master"
@@ -96,7 +96,7 @@
 [[projects]]
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[projects]]
   name = "github.com/vishvananda/netns"
@@ -116,6 +116,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3c1e5894ba73555107971ec0b7f8e27019e5f1f8669f8e25ae6fd8f3b345c110"
+  inputs-digest = "d420f5b96ebe118ff1650e702cd485bebe83967b1053d7ae4a999966ba765ac9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,7 +92,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "e8b0c3a6c9fd7691e37a6aa73ed6af4c42f42ad1"
+  revision = "c3c42b5690ce384a26dcb8ac59e922a20dd0ac7a"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -76,7 +76,7 @@
 [[projects]]
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[projects]]
   name = "github.com/vishvananda/netns"
@@ -96,6 +96,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "52bc4229f63ca78c2086df724034421cf56f51e281edb843f319fb0644af36d3"
+  inputs-digest = "82781172d7b56c5605cb416f72f21b8cd71ae5f49ef87cfe940e8f7b3d0f3c21"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/containers/virtcontainers/Gopkg.toml
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.toml
@@ -114,7 +114,7 @@
 
 [[constraint]]
   name = "github.com/vishvananda/netlink"
-  revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[constraint]]
   name = "github.com/vishvananda/netns"

--- a/vendor/github.com/containers/virtcontainers/README.md
+++ b/vendor/github.com/containers/virtcontainers/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/containers/virtcontainers.svg?branch=master)](https://travis-ci.org/containers/virtcontainers)
-[![Build Status](https://semaphoreci.com/api/v1/clearcontainers/virtcontainers/branches/master/shields_badge.svg)](https://semaphoreci.com/clearcontainers/virtcontainers)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-16-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-16-04-master)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-17-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-17-04-master)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-fedora-26-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-fedora-26-master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containers/virtcontainers)](https://goreportcard.com/report/github.com/containers/virtcontainers)
 [![Coverage Status](https://coveralls.io/repos/github/containers/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/containers/virtcontainers?branch=master)
 [![GoDoc](https://godoc.org/github.com/containers/virtcontainers?status.svg)](https://godoc.org/github.com/containers/virtcontainers)

--- a/vendor/github.com/containers/virtcontainers/api.go
+++ b/vendor/github.com/containers/virtcontainers/api.go
@@ -103,7 +103,7 @@ func DeletePod(podID string) (VCPod, error) {
 		return nil, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func StartPod(podID string) (VCPod, error) {
 		return nil, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func StopPod(podID string) (VCPod, error) {
 		return nil, errNeedPod
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func RunPod(podConfig PodConfig) (VCPod, error) {
 		return nil, err
 	}
 
-	lockFile, err := lockPod(p.id)
+	lockFile, err := rwLockPod(p.id)
 	if err != nil {
 		return nil, err
 	}
@@ -331,16 +331,26 @@ func StatusPod(podID string) (PodStatus, error) {
 		return PodStatus{}, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rLockPod(podID)
 	if err != nil {
 		return PodStatus{}, err
 	}
-	defer unlockPod(lockFile)
 
 	pod, err := fetchPod(podID)
 	if err != nil {
+		unlockPod(lockFile)
 		return PodStatus{}, err
 	}
+
+	// We need to potentially wait for a separate container.stop() routine
+	// that needs to be terminated before we return from this function.
+	// Deferring the synchronization here is very important since we want
+	// to avoid a deadlock. Indeed, the goroutine started by statusContainer
+	// will need to lock an exclusive lock, meaning that all other locks have
+	// to be released to let this happen. This call ensures this will be the
+	// last operation executed by this function.
+	defer pod.wg.Wait()
+	defer unlockPod(lockFile)
 
 	var contStatusList []ContainerStatus
 	for _, container := range pod.containers {
@@ -372,7 +382,7 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (VCPod, VCCo
 		return nil, nil, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -417,7 +427,7 @@ func DeleteContainer(podID, containerID string) (VCContainer, error) {
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +476,7 @@ func StartContainer(podID, containerID string) (VCContainer, error) {
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +514,7 @@ func StopContainer(podID, containerID string) (VCContainer, error) {
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +552,7 @@ func EnterContainer(podID, containerID string, cmd Cmd) (VCPod, VCContainer, *Pr
 		return nil, nil, nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rLockPod(podID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -579,20 +589,32 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 		return ContainerStatus{}, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rLockPod(podID)
 	if err != nil {
 		return ContainerStatus{}, err
 	}
-	defer unlockPod(lockFile)
 
 	pod, err := fetchPod(podID)
 	if err != nil {
+		unlockPod(lockFile)
 		return ContainerStatus{}, err
 	}
+
+	// We need to potentially wait for a separate container.stop() routine
+	// that needs to be terminated before we return from this function.
+	// Deferring the synchronization here is very important since we want
+	// to avoid a deadlock. Indeed, the goroutine started by statusContainer
+	// will need to lock an exclusive lock, meaning that all other locks have
+	// to be released to let this happen. This call ensures this will be the
+	// last operation executed by this function.
+	defer pod.wg.Wait()
+	defer unlockPod(lockFile)
 
 	return statusContainer(pod, containerID)
 }
 
+// This function is going to spawn a goroutine and it needs to be waited for
+// by the caller.
 func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 	for _, container := range pod.containers {
 		if container.id == containerID {
@@ -602,15 +624,26 @@ func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 			if (container.state.State == StateRunning ||
 				container.state.State == StatePaused) &&
 				container.process.Pid > 0 {
+
 				running, err := isShimRunning(container.process.Pid)
 				if err != nil {
 					return ContainerStatus{}, err
 				}
 
 				if !running {
-					if err := container.stop(); err != nil {
-						return ContainerStatus{}, err
-					}
+					pod.wg.Add(1)
+					go func() {
+						defer pod.wg.Done()
+						lockFile, err := rwLockPod(pod.id)
+						if err != nil {
+							return
+						}
+						defer unlockPod(lockFile)
+
+						if err := container.stop(); err != nil {
+							return
+						}
+					}()
 				}
 			}
 
@@ -641,7 +674,7 @@ func KillContainer(podID, containerID string, signal syscall.Signal, all bool) e
 		return errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return err
 	}
@@ -690,7 +723,7 @@ func ProcessListContainer(podID, containerID string, options ProcessListOptions)
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rLockPod(podID)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -664,7 +664,7 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 			{
 				ID: containerID,
 				State: State{
-					State: StateStopped,
+					State: StateRunning,
 					URL:   "",
 				},
 				PID:         1000,
@@ -1462,6 +1462,8 @@ func TestStatusContainerStateReady(t *testing.T) {
 		Annotations: containerAnnotations,
 	}
 
+	defer p2.wg.Wait()
+
 	status, err := statusContainer(p2, contID)
 	if err != nil {
 		t.Fatal(err)
@@ -1526,13 +1528,15 @@ func TestStatusContainerStateRunning(t *testing.T) {
 	expectedStatus := ContainerStatus{
 		ID: contID,
 		State: State{
-			State: StateStopped,
+			State: StateRunning,
 			URL:   "",
 		},
 		PID:         1000,
 		RootFs:      filepath.Join(testDir, testBundle),
 		Annotations: containerAnnotations,
 	}
+
+	defer p2.wg.Wait()
 
 	status, err := statusContainer(p2, contID)
 	if err != nil {

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -857,7 +857,7 @@ func (c *Container) removeDrive() (err error) {
 
 func (c *Container) attachDevices() error {
 	for _, device := range c.devices {
-		if err := device.attach(c.pod.hypervisor); err != nil {
+		if err := device.attach(c.pod.hypervisor, c); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -132,6 +132,7 @@ type FsmapDescriptor struct {
 	Path         string `json:"path"`
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
+	AbsolutePath bool   `json:"absolutePath"`
 }
 
 // EnvironmentVar holds an environment variable and its value.

--- a/vendor/github.com/containers/virtcontainers/proxy.go
+++ b/vendor/github.com/containers/virtcontainers/proxy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 )
 
 // ProxyType describes a proxy type.
@@ -32,6 +33,10 @@ const (
 	// NoopProxyType is the noopProxy.
 	NoopProxyType ProxyType = "noopProxy"
 )
+
+func proxyLogger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "proxy")
+}
 
 // Set sets a proxy type based on the input string.
 func (pType *ProxyType) Set(value string) error {

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -310,11 +310,28 @@ func (q *qemu) appendSocket(devices []ciaoQemu.Device, socket Socket) []ciaoQemu
 	return devices
 }
 
+func networkModelToQemuType(model NetInterworkingModel) ciaoQemu.NetDeviceType {
+	switch model {
+	case ModelBridged:
+		return ciaoQemu.TAP
+	case ModelMacVtap:
+		return ciaoQemu.MACVTAP
+	//case ModelEnlightened:
+	// Here the Network plugin will create a VM native interface
+	// which could be MacVtap, IpVtap, SRIOV, veth-tap, vhost-user
+	// In these cases we will determine the interface type here
+	// and pass in the native interface through
+	default:
+		//TAP should work for most other cases
+		return ciaoQemu.TAP
+	}
+}
+
 func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) []ciaoQemu.Device {
 	for idx, endpoint := range endpoints {
 		devices = append(devices,
 			ciaoQemu.NetDevice{
-				Type:          ciaoQemu.TAP,
+				Type:          networkModelToQemuType(endpoint.NetPair.NetInterworkingModel),
 				Driver:        ciaoQemu.VirtioNetPCI,
 				ID:            fmt.Sprintf("network-%d", idx),
 				IFName:        endpoint.NetPair.TAPIface.Name,
@@ -323,6 +340,7 @@ func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) [
 				Script:        "no",
 				VHost:         true,
 				DisableModern: q.nestedRun,
+				FDs:           endpoint.NetPair.VMFds,
 			},
 		)
 	}

--- a/vendor/github.com/containers/virtcontainers/utils.go
+++ b/vendor/github.com/containers/virtcontainers/utils.go
@@ -19,6 +19,7 @@ package virtcontainers
 import (
 	"crypto/rand"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -63,4 +64,17 @@ func reverseString(s string) string {
 	}
 
 	return string(r)
+}
+
+func cleanupFds(fds []*os.File, numFds int) {
+
+	maxFds := len(fds)
+
+	if numFds < maxFds {
+		maxFds = numFds
+	}
+
+	for i := 0; i < maxFds; i++ {
+		_ = fds[i].Close()
+	}
 }

--- a/vendor/github.com/vishvananda/netlink/handle_test.go
+++ b/vendor/github.com/vishvananda/netlink/handle_test.go
@@ -132,6 +132,31 @@ func TestHandleTimeout(t *testing.T) {
 	}
 }
 
+func TestHandleReceiveBuffer(t *testing.T) {
+	h, err := NewHandle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Delete()
+	if err := h.SetSocketReceiveBufferSize(65536, false); err != nil {
+		t.Fatal(err)
+	}
+	sizes, err := h.GetSocketReceiveBufferSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sizes) != len(h.sockets) {
+		t.Fatalf("Unexpected number of socket buffer sizes: %d (expected %d)",
+			len(sizes), len(h.sockets))
+	}
+	for _, s := range sizes {
+		if s < 65536 || s > 2*65536 {
+			t.Fatalf("Unexpected socket receive buffer size: %d (expected around %d)",
+				s, 65536)
+		}
+	}
+}
+
 func verifySockTimeVal(t *testing.T, fd int, tv syscall.Timeval) {
 	var (
 		tr syscall.Timeval

--- a/vendor/github.com/vishvananda/netlink/link.go
+++ b/vendor/github.com/vishvananda/netlink/link.go
@@ -37,6 +37,7 @@ type LinkAttrs struct {
 	EncapType    string
 	Protinfo     *Protinfo
 	OperState    LinkOperState
+	NetNsID      int
 }
 
 // LinkOperState represents the values of the IFLA_OPERSTATE link

--- a/vendor/github.com/vishvananda/netlink/link_linux.go
+++ b/vendor/github.com/vishvananda/netlink/link_linux.go
@@ -851,6 +851,10 @@ func (h *Handle) linkModify(link Link, flags int) error {
 		msg.Change |= syscall.IFF_MULTICAST
 		msg.Flags |= syscall.IFF_MULTICAST
 	}
+	if base.Index != 0 {
+		msg.Index = int32(base.Index)
+	}
+
 	req.AddData(msg)
 
 	if base.ParentIndex != 0 {
@@ -1268,6 +1272,8 @@ func LinkDeserialize(hdr *syscall.NlMsghdr, m []byte) (Link, error) {
 			}
 		case syscall.IFLA_OPERSTATE:
 			base.OperState = LinkOperState(uint8(attr.Value[0]))
+		case nl.IFLA_LINK_NETNSID:
+			base.NetNsID = int(native.Uint32(attr.Value[0:4]))
 		}
 	}
 

--- a/vendor/github.com/vishvananda/netlink/link_test.go
+++ b/vendor/github.com/vishvananda/netlink/link_test.go
@@ -38,6 +38,12 @@ func testLinkAddDel(t *testing.T, link Link) {
 
 	rBase := result.Attrs()
 
+	if base.Index != 0 {
+		if base.Index != rBase.Index {
+			t.Fatalf("index is %d, should be %d", rBase.Index, base.Index)
+		}
+	}
+
 	if vlan, ok := link.(*Vlan); ok {
 		other, ok := result.(*Vlan)
 		if !ok {
@@ -258,6 +264,13 @@ func compareVxlan(t *testing.T, expected, actual *Vxlan) {
 			t.Fatal("Vxlan.PortHigh doesn't match")
 		}
 	}
+}
+
+func TestLinkAddDelWithIndex(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Dummy{LinkAttrs{Index: 1000, Name: "foo"}})
 }
 
 func TestLinkAddDelDummy(t *testing.T) {

--- a/vendor/github.com/vishvananda/netlink/nl/nl_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/nl_linux.go
@@ -621,6 +621,20 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, error) {
 	return syscall.ParseNetlinkMessage(rb)
 }
 
+// SetSendTimeout allows to set a send timeout on the socket
+func (s *NetlinkSocket) SetSendTimeout(timeout *syscall.Timeval) error {
+	// Set a send timeout of SOCKET_SEND_TIMEOUT, this will allow the Send to periodically unblock and avoid that a routine
+	// remains stuck on a send on a closed fd
+	return syscall.SetsockoptTimeval(int(s.fd), syscall.SOL_SOCKET, syscall.SO_SNDTIMEO, timeout)
+}
+
+// SetReceiveTimeout allows to set a receive timeout on the socket
+func (s *NetlinkSocket) SetReceiveTimeout(timeout *syscall.Timeval) error {
+	// Set a read timeout of SOCKET_READ_TIMEOUT, this will allow the Read to periodically unblock and avoid that a routine
+	// remains stuck on a recvmsg on a closed fd
+	return syscall.SetsockoptTimeval(int(s.fd), syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, timeout)
+}
+
 func (s *NetlinkSocket) GetPid() (uint32, error) {
 	fd := int(atomic.LoadInt32(&s.fd))
 	lsa, err := syscall.Getsockname(fd)


### PR DESCRIPTION
Revendor netlink and virtcontainers to switch the default network connection method to use macvtap.

Fixes #708
Fixes #709

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>