### PR TITLE
Vendoring: Switch to fixed revision vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,7 +7,6 @@
   revision = "b2a8a2ecea1318ae28a0861191ec385532491b5a"
 
 [[projects]]
-  branch = "master"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
   revision = "a368813c5e648fee92e5f6c30e3944ff9d5e8895"
@@ -39,7 +38,6 @@
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
 
 [[projects]]
-  branch = "master"
   name = "github.com/dlespiau/covertool"
   packages = ["pkg/cover"]
   revision = "b82616d290e628437bc08b858b5ecb3d7fe9ea53"
@@ -60,7 +58,6 @@
   revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/opencontainers/runc"
   packages = ["libcontainer/utils"]
   revision = "a0159fddcd197a57790b6dd5654802b7dc8f80be"
@@ -82,13 +79,11 @@
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
-  branch = "master"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "890a5c3458b43e6104ff5da8dfa139d013d77544"
 
 [[projects]]
-  branch = "master"
   name = "github.com/urfave/cli"
   packages = ["."]
   revision = "9e5b04886c4bfee2ceba1465b8121057355c4e53"
@@ -116,6 +111,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d420f5b96ebe118ff1650e702cd485bebe83967b1053d7ae4a999966ba765ac9"
+  inputs-digest = "f3e3b6721567780d5ec707bdc50f3a56e4c25135c12796c867c5c0e20bd3c821"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,59 +64,53 @@
 ## what source location any dependent projects specify.
 # source = "https://github.com/myfork/package.git"
 
-
-
 [[constraint]]
-  branch = "master"
   name = "github.com/01org/ciao"
+  revision = "b2a8a2ecea1318ae28a0861191ec385532491b5a"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/Azure/go-ansiterm"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/BurntSushi/toml"
+  revision = "a368813c5e648fee92e5f6c30e3944ff9d5e8895"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/clearcontainers/proxy"
+  revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/containernetworking/cni"
+  revision = "ff7c3e02e3c212f63a642ad64a5ed22ee54450bd"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/containernetworking/plugins"
+  revision = "e256564546e8d1ca8a36911f8445c11929043221"
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
   revision = "c3c42b5690ce384a26dcb8ac59e922a20dd0ac7a"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/davecgh/go-spew"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/dlespiau/covertool"
+  revision = "b82616d290e628437bc08b858b5ecb3d7fe9ea53"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/docker/docker"
+  name = "github.com/go-ini/ini"
+  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/kubernetes-incubator/cri-o"
+  revision = "3394b3b2d6af0e41d185bb695c6378be5dd4d61d"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/mitchellh/mapstructure"
+  revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/opencontainers/runc"
+  revision = "a0159fddcd197a57790b6dd5654802b7dc8f80be"
 
 [[constraint]]
   name = "github.com/opencontainers/runtime-spec"
@@ -124,27 +118,27 @@
 
 [[constraint]]
   name = "github.com/pmezard/go-difflib"
-  version = "1.0.0"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/sirupsen/logrus"
+  revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/stretchr/testify"
+  revision = "890a5c3458b43e6104ff5da8dfa139d013d77544"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/urfave/cli"
+  revision = "9e5b04886c4bfee2ceba1465b8121057355c4e53"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/vishvananda/netlink"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/vishvananda/netns"
+  revision = "86bef332bfc3b59b7624a600bd53009ce91a9829"
 
 [[constraint]]
   name = "golang.org/x/crypto"


### PR DESCRIPTION
virtcontainers has already switched to vendoring specific revisions of dependencies.
Switch the runtime to also adopt the same.

This allows an user to do perform

rm -rf vendor
dep ensure

without having to worry about unwanted changes being picked up.

The downside is that the revendoring becomes manual. It also requires that runtime dependency
revisions match that the exact revision used by virtcontainers (which may be a good thing).

Fixes #779

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>