### PR TITLE
Document docker swarm version

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,5 +1,38 @@
 # Clear Containers known differences and limitations
 
+* [Pending items](#pending-items)
+    * [Networking](#networking)
+        * [Adding networks dynamically](#adding-networks-dynamically)
+    * [Resource management](#resource-management)
+        * [`docker run --cpus=`](#docker-run---cpus)
+        * [`docker run --kernel-memory=`](#docker-run---kernel-memory)
+        * [shm](#shm)
+        * [cgroup constraints](#cgroup-constraints)
+        * [Capabilities](#capabilities)
+        * [sysctl](#sysctl)
+        * [tmpfs](#tmpfs)
+    * [Other](#other)
+        * [checkpoint and restore](#checkpointandrestore)
+        * [`docker stats`](#docker-stats)
+    * [runtime commands](#runtime-commands)
+        * [`ps` command](#pscommand)
+        * [`events` command](#events-command)
+        * [`update` command](#update-command)
+  * [Architectural limitations](#architectural-limitations)
+      * [Networking](#networking)
+        * [Support for joining an existing VM network](#support-for-joining-an-existing-vmnetwork)
+        * [`docker --net=host`](#docker---nethost)
+        * [`docker run --link`](#docker-run---link)
+    * [Host resource sharing](#host-resource-sharing)
+        * [`docker --device`](#docker---device)
+        * [`docker -v /dev/...`](#docker--v-dev)
+        * [`docker run --privileged`](#docker-run---privileged)
+    * [Other](#other)
+        * [Annotations](#annotations)
+    * [runtime commands](#runtime-commands)
+        * [`init` command](#init-command)
+        * [`spec` command](#spec-command)
+
 As Intel® Clear Containers utilises Virtual Machines (VM) to enhance
 security and isolation of container workloads, the `cc-runtime` has a
 number of differences and limitations when compared with the standard

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -36,7 +36,7 @@
 As Intel® Clear Containers utilises Virtual Machines (VM) to enhance
 security and isolation of container workloads, the `cc-runtime` has a
 number of differences and limitations when compared with the standard
-Docker runtime, `runc`. Some of these limitations have potential
+Docker* runtime, `runc`. Some of these limitations have potential
 solutions, whereas others exist due to fundamental architectural
 differences generally related to the use of VMs.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,7 @@
 # Clear Containers known differences and limitations
 
 * [Pending items](#pending-items)
+    * [Docker swarm support](#docker-swarm-support)
     * [Networking](#networking)
         * [Adding networks dynamically](#adding-networks-dynamically)
     * [Resource management](#resource-management)
@@ -52,6 +53,21 @@ more detailed information.
 ## Pending items
 
 This section lists items that may technically be fixable:
+
+### Docker swarm support
+
+The newest version of Docker supported is specified by the `docker_version`
+variable in the
+[versions.txt](https://github.com/clearcontainers/runtime/blob/master/versions.txt)
+file.
+
+However, if you wish to use Docker's swarm facility, an older version of Docker is
+required. This is specified by the `docker_swarm_version` variable in the
+[versions.txt](https://github.com/clearcontainers/runtime/blob/master/versions.txt)
+file.
+
+See issue [\#771](https://github.com/clearcontainers/runtime/issues/771) for more
+information.
 
 ### Networking
 

--- a/versions.txt
+++ b/versions.txt
@@ -3,8 +3,10 @@ cc_agent_version=0fca1509afbaa18c5a0ddf213f2e377c7b87dcc7
 clear_vm_image_version=18770
 #Kernel configuration and patches from https://github.com/clearcontainers/linux
 clear_container_kernel=v4.9.58-79.container
-#Docker suported version: 
+
+# Supported Docker version
 docker_version=v17.09-ce
+
 #Supported OCI spec: https://github.com/opencontainers/runtime-spec/releases
 oci_spec_version=v1.0.0-rc5
 

--- a/versions.txt
+++ b/versions.txt
@@ -4,8 +4,11 @@ clear_vm_image_version=18770
 #Kernel configuration and patches from https://github.com/clearcontainers/linux
 clear_container_kernel=v4.9.58-79.container
 
-# Supported Docker version
+# Supported Docker version (but see docker_swarm_version)
 docker_version=v17.09-ce
+
+# Version of docker required to use Docker's swarm feature
+docker_swarm_version=1.12.1
 
 #Supported OCI spec: https://github.com/opencontainers/runtime-spec/releases
 oci_spec_version=v1.0.0-rc5


### PR DESCRIPTION
   docs: Document docker version for swarm
    
    Docker swarm support currently requires a back-level version of Docker
    so add details to the limitations doc.
    
    Fixes #781.