### PR TITLE
logger: Fix logging of non-string types

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -141,8 +141,15 @@ func formatFields(fields map[string]interface{}) string {
 
 	var sorted []string
 
-	for _, k := range keys {
-		sorted = append(sorted, fmt.Sprintf("%s=%q", k, fields[k]))
+	for _, key := range keys {
+		v := fields[key]
+		value, ok := v.(string)
+
+		if !ok {
+			value = fmt.Sprint(v)
+		}
+
+		sorted = append(sorted, fmt.Sprintf("%s=%q", key, value))
 	}
 
 	return strings.Join(sorted, " ")

--- a/logger_test.go
+++ b/logger_test.go
@@ -243,3 +243,30 @@ func TestLoggerFire(t *testing.T) {
 	err = ccLog.Logger.Hooks.Fire(logrus.InfoLevel, entry)
 	assert.Error(t, err)
 }
+
+func TestLoggerFormatFields(t *testing.T) {
+	assert := assert.New(t)
+
+	fields := logrus.Fields{
+		"zzz-last-field":  "The End.",
+		"int":             999,
+		"string":          "foo bar",
+		"float":           3.14159,
+		"bool-true":       true,
+		"aaa-first-field": "winner!",
+		"bool-false":      false,
+	}
+
+	expected := ""
+	expected += "aaa-first-field=\"winner!\""
+	expected += " bool-false=\"false\""
+	expected += " bool-true=\"true\""
+	expected += " float=\"3.14159\""
+	expected += " int=\"999\""
+	expected += " string=\"foo bar\""
+	expected += " zzz-last-field=\"The End.\""
+
+	result := formatFields(fields)
+
+	assert.Equal(expected, result)
+}


### PR DESCRIPTION
The logger was not correctly converting the values to log into strings
prior to quoting leading to garbled log entries for non-string log
fields.

Added new unit test to ensure correct behaviour.

Fixes #786.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>