### PR TITLE
cc-env: Remove unused error return value

### DIFF
--- a/cc-env.go
+++ b/cc-env.go
@@ -246,13 +246,13 @@ func getShimInfo(config oci.RuntimeConfig) (ShimInfo, error) {
 	return ccShim, nil
 }
 
-func getAgentInfo(config oci.RuntimeConfig) (AgentInfo, error) {
+func getAgentInfo(config oci.RuntimeConfig) AgentInfo {
 	ccAgent := AgentInfo{
 		Type:    string(config.AgentType),
 		Version: unknown,
 	}
 
-	return ccAgent, nil
+	return ccAgent
 }
 
 func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
@@ -290,10 +290,7 @@ func getEnvInfo(configFile, logfilePath string, config oci.RuntimeConfig) (env E
 		return EnvInfo{}, err
 	}
 
-	ccAgent, err := getAgentInfo(config)
-	if err != nil {
-		return EnvInfo{}, err
-	}
+	ccAgent := getAgentInfo(config)
 
 	hypervisor := getHypervisorInfo(config)
 

--- a/cc-env_test.go
+++ b/cc-env_test.go
@@ -737,28 +737,8 @@ func TestCCEnvGetAgentInfo(t *testing.T) {
 	expectedAgent, err := getExpectedAgentDetails(config)
 	assert.NoError(t, err)
 
-	ccAgent, err := getAgentInfo(config)
-	assert.NoError(t, err)
-
+	ccAgent := getAgentInfo(config)
 	assert.Equal(t, expectedAgent, ccAgent)
-}
-
-func TestCCEnvGetAgentInfoInvalidType(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
-	_, config, err := makeRuntimeConfig(tmpdir)
-	assert.NoError(t, err)
-
-	_, err = getExpectedAgentDetails(config)
-	assert.NoError(t, err)
-
-	config.AgentConfig = "foo"
-	_, err = getAgentInfo(config)
-	assert.NoError(t, err)
 }
 
 func testCCEnvShowSettings(t *testing.T, tmpdir string, tmpfile *os.File) error {


### PR DESCRIPTION
The `getAgentInfo()` can't fail (now), so remove the error return value.

Fixes #791.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>