### PR TITLE
config: remove pause_root_path from configuration file

### DIFF
--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -70,9 +70,6 @@ path = "@SHIMPATH@"
 # (default: disabled)
 #enable_debug = true
 
-[agent.hyperstart]
-pause_root_path = "@PAUSEROOTPATH@"
-
 [runtime]
 ## Uncomment to enable the global logging to the default path.
 #global_log_path = "@GLOBALLOGPATH@"


### PR DESCRIPTION
runtime doesn't need ```pause_root_path``` variable any more,
because of the pause binary was removed by a previous commit

fixes #793

Signed-off-by: Julio Montes <julio.montes@intel.com>