### PR TITLE
versions: Update image and kernel

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 cc_agent_version=0fca1509afbaa18c5a0ddf213f2e377c7b87dcc7
 #Clear Containers image from https://download.clearlinux.org/releases/
-clear_vm_image_version=18770
+clear_vm_image_version=18860
 #Kernel configuration and patches from https://github.com/clearcontainers/linux
 clear_container_kernel=v4.9.58-79.container
 

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@ cc_agent_version=0fca1509afbaa18c5a0ddf213f2e377c7b87dcc7
 #Clear Containers image from https://download.clearlinux.org/releases/
 clear_vm_image_version=18860
 #Kernel configuration and patches from https://github.com/clearcontainers/linux
-clear_container_kernel=v4.9.58-79.container
+clear_container_kernel=v4.9.60-80.container
 
 # Supported Docker version (but see docker_swarm_version)
 docker_version=v17.09-ce


### PR DESCRIPTION
- Image 
Changes:

version: 18800
```
Changes in package clear-containers-agent (from
1fa147836736824c32a46889d6fb59402d4e58bd-14 to
9adc9d49378aa0a19b85d02c447b3eb1e2b87774-14):
     Jose Carlos Venegas Munoz - new agent version 9adc9d
     https://download.clearlinux.org/releases/18800/clear/RELEASENOTES
```

- Kernel
New version: https://github.com/clearcontainers/linux/releases/tag/v4.9.60-80.container
Fixes: #797

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>