### PR TITLE
hotplug: add default_bridges to configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ PROXYPATH := $(PKGLIBEXECDIR)/$(PROXYCMD)
 DEFVCPUS := 1
 # Default memory size in MiB
 DEFMEMSZ := 2048
+#Default number of bridges
+DEFBRIDGES := 1
 
 DEFDISABLEBLOCK := false
 DEFENABLEMEMPREALLOC := false
@@ -176,6 +178,7 @@ USER_VARS += SHIMPATH
 USER_VARS += SYSCONFDIR
 USER_VARS += DEFVCPUS
 USER_VARS += DEFMEMSZ
+USER_VARS += DEFBRIDGES
 USER_VARS += DEFDISABLEBLOCK
 USER_VARS += DEFENABLEMEMPREALLOC
 USER_VARS += DEFENABLEHUGEPAGES
@@ -229,6 +232,7 @@ const defaultRuntimeRun = "$(PKGRUNDIR)"
 
 const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
+const defaultBridgesCount uint32 = $(DEFBRIDGES)
 const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 const defaultEnableMemPrealloc bool = $(DEFENABLEMEMPREALLOC)
 const defaultEnableHugePages bool = $(DEFENABLEHUGEPAGES)
@@ -299,6 +303,7 @@ $(GENERATED_FILES): %: %.in Makefile VERSION
 		-e "s|@SHIMPATH@|$(SHIMPATH)|g" \
 		-e "s|@DEFVCPUS@|$(DEFVCPUS)|g" \
 		-e "s|@DEFMEMSZ@|$(DEFMEMSZ)|g" \
+		-e "s|@DEFBRIDGES@|$(DEFBRIDGES)|g" \
 		-e "s|@DEFDISABLEBLOCK@|$(DEFDISABLEBLOCK)|g" \
 		-e "s|@DEFENABLEMEMPREALLOC@|$(DEFENABLEMEMPREALLOC)|g" \
 		-e "s|@DEFENABLEHUGEPAGES@|$(DEFENABLEHUGEPAGES)|g" \

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -26,6 +26,19 @@ machine_accelerators="@MACHINEACCELERATORS@"
 # > 255            --> will be set to 255
 default_vcpus = -1
 
+
+# Bridges can be used to hot plug devices.
+# Limitations:
+# * Currently only pci bridges are supported
+# * Until 30 devices per bridge can be hot plugged.
+# * Until 5 PCI bridges can be cold plugged per VM.
+#   This limitation could be a bug in qemu or in the kernel
+# Default number of bridges per POD/VM:
+# unspecified or 0   --> will be set to @DEFBRIDGES@
+# > 1 <= 5           --> will be set to the specified number
+# > 5                --> will be set to 5
+default_bridges = @DEFBRIDGES@
+
 # Default memory size in MiB for POD/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 #default_memory = @DEFMEMSZ@

--- a/config_test.go
+++ b/config_test.go
@@ -133,7 +133,8 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		DefaultVCPUs:          defaultVCPUCount,
 		DefaultMemSz:          defaultMemSize,
 		DisableBlockDeviceUse: disableBlockDevice,
-		Mlock: !defaultEnableSwap,
+		DefaultBridges:        defaultBridgesCount,
+		Mlock:                 !defaultEnableSwap,
 	}
 
 	agentConfig := vc.HyperConfig{}
@@ -506,7 +507,8 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		DefaultVCPUs:          defaultVCPUCount,
 		DefaultMemSz:          defaultMemSize,
 		DisableBlockDeviceUse: defaultDisableBlockDeviceUse,
-		Mlock: !defaultEnableSwap,
+		DefaultBridges:        defaultBridgesCount,
+		Mlock:                 !defaultEnableSwap,
 	}
 
 	expectedAgentConfig := vc.HyperConfig{}
@@ -902,6 +904,23 @@ func TestGetDefaultConfigFile(t *testing.T) {
 
 	_, err = getDefaultConfigFile()
 	assert.Error(err)
+}
+
+func TestDefaultBridges(t *testing.T) {
+	assert := assert.New(t)
+
+	h := hypervisor{DefaultBridges: 0}
+
+	bridges := h.defaultBridges()
+	assert.Equal(defaultBridgesCount, bridges)
+
+	h.DefaultBridges = maxPCIBridges + 1
+	bridges = h.defaultBridges()
+	assert.Equal(maxPCIBridges, bridges)
+
+	h.DefaultBridges = maxPCIBridges
+	bridges = h.defaultBridges()
+	assert.Equal(maxPCIBridges, bridges)
 }
 
 func TestDefaultFirmware(t *testing.T) {


### PR DESCRIPTION
default_bridges allows user specify how many PCI bridges
must be included in the VM, this allow to hot plug until
~150 devices

fixes #831

Signed-off-by: Julio Montes <julio.montes@intel.com>