### PR TITLE
cc-check: Only display KVM message if KVM checks run

### DIFF
--- a/cc-check.go
+++ b/cc-check.go
@@ -341,9 +341,9 @@ var ccCheckCLICommand = cli.Command{
 			if err != nil {
 				return err
 			}
-		}
 
-		ccLog.Info(successMessageCreate)
+			ccLog.Info(successMessageCreate)
+		}
 
 		return nil
 	},


### PR DESCRIPTION
The "cc-check" command should only display the KVM success message
if the KVM checks are actually run (if invoked as `root`).

Fixes #850.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>