### PR TITLE
doc: Update README for "cc-check"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ The runtime has a built-in command to determine if your host system is capable o
 $ cc-runtime cc-check
 ```
 
+Note:
+
+If you run the command above as the `root` user, further checks will be
+performed (e.g. check if another incompatible hypervisor is running):
+
+```bash
+$ sudo cc-runtime cc-check
+```
+
 ## Quick start for users
 
 See the [installation guides](docs/) available for various operating systems.


### PR DESCRIPTION
PR #849 added new features to cc-check but neglected to update the
README to explain that those extra tests are only run when running the
command as the `root` user.

Fixes #853.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>