### PR TITLE
versions: downgrade clear containers image

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 cc_agent_version=a074983f12ce3c50b8655659bcd81a6c81e4126c-18
 
 # Clear Containers image from https://download.clearlinux.org/releases/
-clear_vm_image_version=19790
+clear_vm_image_version=19350
 
 # Clear Containers Kernel version
 # Kernel configuration and patches from


### PR DESCRIPTION
Image 19790 still has issues for setting up networking inside
a kubernetes pod.
See https://github.com/clearcontainers/agent/issues/182
This commit downgrades the version of the image to 19350, which
is the latest that is known to work flawlessly.

Fixes #889

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>