### PR TITLE
list: Don't fail if rootfs doesn't exist

### DIFF
--- a/list.go
+++ b/list.go
@@ -323,12 +323,14 @@ func getContainers(context *cli.Context) ([]fullContainerState, error) {
 			ociState := oci.StatusToOCIState(container)
 			staleAssets := getStaleAssets(currentHypervisorDetails, latestHypervisorDetails)
 
-			uid, err := getDirOwner(container.RootFs)
-			if err != nil {
-				return nil, err
-			}
+			var owner string
 
-			owner := fmt.Sprintf("#%v", uid)
+			uid, err := getDirOwner(container.RootFs)
+			if err == nil {
+				owner = fmt.Sprintf("#%v", uid)
+			} else {
+				owner = "?"
+			}
 
 			s = append(s, fullContainerState{
 				containerState: containerState{


### PR DESCRIPTION
If it is not possible to determine the owner of the rootfs, do not fail
the entire `list` operation, just mark the container owner field with a
question mark.

Fixes #906.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>