### PR TITLE
config: Set agent type

### DIFF
--- a/config.go
+++ b/config.go
@@ -335,9 +335,13 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 	for k := range tomlConf.Agent {
 		switch k {
 		case hyperstartAgentTableType:
+			config.AgentType = hyperstartAgentTableType
 			config.AgentConfig = vc.HyperConfig{}
+
 		case kataAgentTableType:
+			config.AgentType = kataAgentTableType
 			config.AgentConfig = vc.KataAgentConfig{}
+
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -984,3 +984,27 @@ func TestDefaultMachineAccelerators(t *testing.T) {
 	h.MachineAccelerators = ",, abc ,,, 123 ,,"
 	assert.Equal(machineAccelerators, h.machineAccelerators())
 }
+
+func TestUpdateRuntimeConfiguration(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.NotEqual(defaultAgent, vc.KataContainersAgent)
+
+	config := oci.RuntimeConfig{}
+
+	tomlConf := tomlConfig{
+		Agent: map[string]agent{
+			// force a non-default value
+			kataAgentTableType: {},
+		},
+	}
+
+	assert.NotEqual(config.AgentType, vc.AgentType(kataAgentTableType))
+	assert.NotEqual(config.AgentConfig, vc.KataAgentConfig{})
+
+	err := updateRuntimeConfig("", tomlConf, &config)
+	assert.NoError(err)
+
+	assert.Equal(config.AgentType, vc.AgentType(kataAgentTableType))
+	assert.Equal(config.AgentConfig, vc.KataAgentConfig{})
+}


### PR DESCRIPTION
`updateRuntimeConfig()` was not setting the agent type, so if the
runtime was configured for kata containers, it would try
to use a hyperstart agent.

Fixes #911.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>