### PR TITLE
vendor: Re-vendor virtcontainers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,12 +8,22 @@
 
 [[projects]]
   name = "github.com/clearcontainers/proxy"
-  packages = ["api","client"]
+  packages = [
+    "api",
+    "client"
+  ]
   revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
 
 [[projects]]
   name = "github.com/containernetworking/cni"
-  packages = ["libcni","pkg/invoke","pkg/types","pkg/types/020","pkg/types/current","pkg/version"]
+  packages = [
+    "libcni",
+    "pkg/invoke",
+    "pkg/types",
+    "pkg/types/020",
+    "pkg/types/current",
+    "pkg/version"
+  ]
   revision = "384d8c0b5288c25b9f1da901c66ea5155e6c567d"
 
 [[projects]]
@@ -23,8 +33,17 @@
 
 [[projects]]
   name = "github.com/containers/virtcontainers"
-  packages = [".","pkg/annotations","pkg/cni","pkg/ethtool","pkg/hyperstart","pkg/oci","pkg/uuid","pkg/vcMock"]
-  revision = "387abeb4466d86aef1171b054f64ee8c636aa05f"
+  packages = [
+    ".",
+    "pkg/annotations",
+    "pkg/cni",
+    "pkg/ethtool",
+    "pkg/hyperstart",
+    "pkg/oci",
+    "pkg/uuid",
+    "pkg/vcMock"
+  ]
+  revision = "3a6bd62b25e130dc142ba430cf3b45c975d1878e"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -44,13 +63,25 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types"
+  ]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
@@ -60,7 +91,10 @@
 
 [[projects]]
   name = "github.com/kata-containers/agent"
-  packages = ["protocols/client","protocols/grpc"]
+  packages = [
+    "protocols/client",
+    "protocols/grpc"
+  ]
   revision = "306ee20ff47628fe370012d7e3f9316480e43c2e"
 
 [[projects]]
@@ -96,7 +130,10 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = [".","hooks/syslog"]
+  packages = [
+    ".",
+    "hooks/syslog"
+  ]
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
@@ -111,7 +148,10 @@
 
 [[projects]]
   name = "github.com/vishvananda/netlink"
-  packages = [".","nl"]
+  packages = [
+    ".",
+    "nl"
+  ]
   revision = "c2a3de3b38bd00f07290c3c5e12b4dbc04ec8666"
 
 [[projects]]
@@ -126,18 +166,44 @@
 
 [[projects]]
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace"
+  ]
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "1d2aa6dbdea45adaaebb9905d0666e4537563829"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
@@ -148,12 +214,34 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "5a9f7b402fe85096d2e1d0383435ee1876e863d0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2d0f5ec123ad4d9ee3a784a7ae3c9962a1ac547079589968ec722ca922f472a2"
+  inputs-digest = "9fb7085c26eb892865b021b6f8b8b81f43e5669f9a9c71b9c21d68b349da468e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,4 +72,4 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "387abeb4466d86aef1171b054f64ee8c636aa05f"
+  revision = "3a6bd62b25e130dc142ba430cf3b45c975d1878e"

--- a/vendor/github.com/containers/virtcontainers/.gitignore
+++ b/vendor/github.com/containers/virtcontainers/.gitignore
@@ -4,4 +4,6 @@
 /hack/virtc/virtc
 /hook/mock/hook
 /shim/mock/shim
+/shim/mock/cc-shim/cc-shim
+/shim/mock/kata-shim/kata-shim
 profile.cov

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -834,7 +834,7 @@ func (c *Container) hotplugDrive() error {
 	}).Info("Block device detected")
 
 	// Add drive with id as container id
-	devID := makeBlockDevIDForHypervisor(c.id)
+	devID := makeNameID("drive", c.id)
 	drive := Drive{
 		File:   devicePath,
 		Format: "raw",
@@ -870,7 +870,7 @@ func (c *Container) removeDrive() (err error) {
 	if c.isDriveUsed() && c.state.HotpluggedDrive {
 		c.Logger().Info("unplugging block device")
 
-		devID := makeBlockDevIDForHypervisor(c.id)
+		devID := makeNameID("drive", c.id)
 		drive := Drive{
 			ID: devID,
 		}

--- a/vendor/github.com/containers/virtcontainers/device_test.go
+++ b/vendor/github.com/containers/virtcontainers/device_test.go
@@ -17,16 +17,90 @@
 package virtcontainers
 
 import (
+	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
 )
 
 const fileMode0640 = os.FileMode(0640)
+
+func TestVhostUserSocketPath(t *testing.T) {
+
+	// First test case: search for existing:
+	addresses := []netlink.Addr{
+		{
+			IPNet: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 2),
+				Mask: net.IPv4Mask(192, 168, 0, 2),
+			},
+		},
+		{
+			IPNet: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 1),
+				Mask: net.IPv4Mask(192, 168, 0, 1),
+			},
+		},
+	}
+
+	expectedPath := "/tmp/vhostuser_192.168.0.1"
+	expectedFileName := "vhu.sock"
+	expectedResult := fmt.Sprintf("%s/%s", expectedPath, expectedFileName)
+
+	err := os.Mkdir(expectedPath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Create(expectedResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	netinfo := NetworkInfo{
+		Addrs: addresses,
+	}
+
+	path, _ := vhostUserSocketPath(netinfo)
+
+	if path != expectedResult {
+		t.Fatalf("Got %+v\nExpecting %+v", path, expectedResult)
+	}
+
+	// Second test case: search doesn't include matching vsock:
+	addressesFalse := []netlink.Addr{
+		{
+			IPNet: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 4),
+				Mask: net.IPv4Mask(192, 168, 0, 4),
+			},
+		},
+	}
+	netinfoFail := NetworkInfo{
+		Addrs: addressesFalse,
+	}
+
+	path, _ = vhostUserSocketPath(netinfoFail)
+	if path != "" {
+		t.Fatalf("Got %+v\nExpecting %+v", path, "")
+	}
+
+	err = os.Remove(expectedResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Remove(expectedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
 
 func TestIsVFIO(t *testing.T) {
 	type testData struct {

--- a/vendor/github.com/containers/virtcontainers/hyperstart_agent.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart_agent.go
@@ -123,6 +123,14 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperstart.Process, error)
 		NoNewPrivileges:  cmd.NoNewPrivileges,
 	}
 
+	process.Capabilities = hyperstart.Capabilities{
+		Bounding:    cmd.Capabilities.Bounding,
+		Effective:   cmd.Capabilities.Effective,
+		Inheritable: cmd.Capabilities.Inheritable,
+		Permitted:   cmd.Capabilities.Permitted,
+		Ambient:     cmd.Capabilities.Ambient,
+	}
+
 	return process, nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -75,6 +75,9 @@ const (
 
 	// VFIODevice is VFIO device type
 	vfioDev
+
+	// vhostuserDev is a Vhost-user device type
+	vhostuserDev
 )
 
 // Set sets an hypervisor type based on the input string.
@@ -113,6 +116,16 @@ func newHypervisor(hType HypervisorType) (hypervisor, error) {
 	default:
 		return nil, fmt.Errorf("Unknown hypervisor type %s", hType)
 	}
+}
+
+//Generic function for creating a named-id for passing on the hypervisor commandline
+func makeNameID(namedType string, id string) string {
+	nameID := fmt.Sprintf("%s-%s", namedType, id)
+	if len(nameID) > maxDevIDSize {
+		nameID = string(nameID[:maxDevIDSize])
+	}
+
+	return nameID
 }
 
 // Param is a key/value representation for hypervisor and kernel parameters.

--- a/vendor/github.com/containers/virtcontainers/kata_agent.go
+++ b/vendor/github.com/containers/virtcontainers/kata_agent.go
@@ -437,7 +437,13 @@ func (k *kataAgent) startContainer(pod Pod, c Container) error {
 	}
 
 	_, err := k.client.StartContainer(context.Background(), req)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// The Kata shim wants to be signaled when the init container
+	// is created. Sending the signal for all containers is harmless.
+	return signalShim(c.process.Pid, syscall.SIGUSR1)
 }
 
 func (k *kataAgent) stopContainer(pod Pod, c Container) error {

--- a/vendor/github.com/containers/virtcontainers/kata_shim.go
+++ b/vendor/github.com/containers/virtcontainers/kata_shim.go
@@ -60,7 +60,7 @@ func (s *kataShim) start(pod Pod, params ShimParams) (int, error) {
 
 	args := []string{config.Path, "-agent", params.URL, "-container", params.Container, "-exec-id", params.Token}
 	if config.Debug {
-		args = append(args, "-d")
+		args = append(args, "-log", "debug")
 	}
 
 	return startShim(args, params)

--- a/vendor/github.com/containers/virtcontainers/mount.go
+++ b/vendor/github.com/containers/virtcontainers/mount.go
@@ -373,11 +373,13 @@ func bindUnmountContainerMounts(mounts []Mount) error {
 	for _, m := range mounts {
 		if !isSystemMount(m.Destination) && m.Type == "bind" {
 			err := syscall.Unmount(m.HostPath, 0)
-			mountLogger().WithFields(logrus.Fields{
-				"host-path": m.HostPath,
-				"error":     err,
-			}).Warn("Could not umount")
-			return err
+			if err != nil {
+				mountLogger().WithFields(logrus.Fields{
+					"host-path": m.HostPath,
+					"error":     err,
+				}).Warn("Could not umount")
+				return err
+			}
 		}
 	}
 	return nil

--- a/vendor/github.com/containers/virtcontainers/network_test.go
+++ b/vendor/github.com/containers/virtcontainers/network_test.go
@@ -193,6 +193,37 @@ func TestIncorrectEndpointTypeString(t *testing.T) {
 	testEndpointTypeString(t, &endpointType, "")
 }
 
+func TestCreateVhostUserEndpoint(t *testing.T) {
+	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x48}
+	ifcName := "vhost-deadbeef"
+	socket := "/tmp/vhu_192.168.0.1"
+
+	netinfo := NetworkInfo{
+		Iface: NetlinkIface{
+			LinkAttrs: netlink.LinkAttrs{
+				HardwareAddr: macAddr,
+				Name:         ifcName,
+			},
+		},
+	}
+
+	expected := &VhostUserEndpoint{
+		SocketPath:   socket,
+		HardAddr:     macAddr.String(),
+		IfaceName:    ifcName,
+		EndpointType: VhostUserEndpointType,
+	}
+
+	result, err := createVhostUserEndpoint(netinfo, socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatalf("\n\tGot %v\n\tExpecting %v", result, expected)
+	}
+}
+
 func TestCreateVirtualNetworkEndpoint(t *testing.T) {
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -151,6 +151,20 @@ type Rlimit struct {
 	Soft uint64 `json:"soft"`
 }
 
+// Capabilities specify the capabilities to keep when executing the process inside the container.
+type Capabilities struct {
+	// Bounding is the set of capabilities checked by the kernel.
+	Bounding []string `json:"bounding"`
+	// Effective is the set of capabilities checked by the kernel.
+	Effective []string `json:"effective"`
+	// Inheritable is the capabilities preserved across execve.
+	Inheritable []string `json:"inheritable"`
+	// Permitted is the limiting superset for effective capabilities.
+	Permitted []string `json:"permitted"`
+	// Ambient is the ambient set of capabilities that are kept.
+	Ambient []string `json:"ambient"`
+}
+
 // Process describes a process running on a container inside a pod.
 type Process struct {
 	User             string   `json:"user,omitempty"`
@@ -173,6 +187,8 @@ type Process struct {
 	Rlimits []Rlimit `json:"rlimits,omitempty"`
 	// NoNewPrivileges indicates that the process should not gain any additional privileges
 	NoNewPrivileges bool `json:"noNewPrivileges"`
+	// Capabilities specifies the sets of capabilities for the process(es) inside the container.
+	Capabilities Capabilities `json:"capabilities"`
 }
 
 // SystemMountsInfo describes additional information for system mounts that the agent

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -30,13 +30,13 @@ import (
 // controlSocket is the pod control socket.
 // It is an hypervisor resource, and for example qemu's control
 // socket is the QMP one.
-const controlSocket = "ctrl.sock"
+const controlSocket = "ctl"
 
 // monitorSocket is the pod monitoring socket.
 // It is an hypervisor resource, and is a qmp socket in the qemu case.
 // This is a socket that any monitoring entity will listen to in order
 // to understand if the VM is still alive or not.
-const monitorSocket = "monitor.sock"
+const monitorSocket = "mon"
 
 // vmStartTimeout represents the time in seconds a pod can wait before
 // to consider the VM starting operation failed.
@@ -258,6 +258,21 @@ type EnvVar struct {
 	Value string
 }
 
+// LinuxCapabilities specify the capabilities to keep when executing
+// the process inside the container.
+type LinuxCapabilities struct {
+	// Bounding is the set of capabilities checked by the kernel.
+	Bounding []string
+	// Effective is the set of capabilities checked by the kernel.
+	Effective []string
+	// Inheritable is the capabilities preserved across execve.
+	Inheritable []string
+	// Permitted is the limiting superset for effective capabilities.
+	Permitted []string
+	// Ambient is the ambient set of capabilities that are kept.
+	Ambient []string
+}
+
 // Cmd represents a command to execute in a running container.
 type Cmd struct {
 	Args    []string
@@ -294,6 +309,7 @@ type Cmd struct {
 	Console         string
 	Detach          bool
 	NoNewPrivileges bool
+	Capabilities    LinuxCapabilities
 }
 
 // Resources describes VM resources configuration.

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -121,10 +121,12 @@ func testQemuAppend(t *testing.T, structure interface{}, expected []govmmQemu.De
 		devices = q.appendBlockDevice(devices, s)
 	case VFIODevice:
 		devices = q.appendVFIODevice(devices, s)
+	case VhostUserNetDevice:
+		devices = q.appendVhostUserDevice(devices, &s)
 	}
 
 	if reflect.DeepEqual(devices, expected) == false {
-		t.Fatalf("Got %v\nExpecting %v", devices, expected)
+		t.Fatalf("\n\tGot %v\n\tExpecting %v", devices, expected)
 	}
 }
 
@@ -223,6 +225,31 @@ func TestQemuAppendVFIODevice(t *testing.T) {
 	}
 
 	testQemuAppend(t, vfDevice, expectedOut, -1, nestedVM)
+}
+
+func TestQemuAppendVhostUserDevice(t *testing.T) {
+	nestedVM := true
+	socketPath := "nonexistentpath.sock"
+	macAddress := "00:11:22:33:44:55:66"
+	id := "deadbeef"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.VhostUserDevice{
+			SocketPath:    socketPath,
+			CharDevID:     fmt.Sprintf("char-%s", id),
+			TypeDevID:     fmt.Sprintf("net-%s", id),
+			Address:       macAddress,
+			VhostUserType: VhostUserNet,
+		},
+	}
+
+	vhostUserDevice := VhostUserNetDevice{
+		MacAddress: macAddress,
+	}
+	vhostUserDevice.ID = id
+	vhostUserDevice.SocketPath = socketPath
+
+	testQemuAppend(t, vhostUserDevice, expectedOut, -1, nestedVM)
 }
 
 func TestQemuAppendFSDevices(t *testing.T) {


### PR DESCRIPTION
Update virtcontainers specifically for commit fb1eecd which fixes the
issue of lingering bind-mounts after a container has been killed.

shortlog of virtcontainers changes:

    fb1eecd mount: Fix unmount of dangling bind-mounts
    d7462c7 pkg/oci: Clarify resource calculation comment
    027aab8 qemu: adjust QMP naming to avoid non-unique truncation
    0c4064e capabilities: Pass capabilities to hyperstart.
    e20ba9d oci: Add support for capabilities
    6776dd9 shim: Correct kata debug flag
    b307c08 qemu: refactor/simplify addDevice function
    747d364 vhost-user: rewrite to use interfaces/embedded types
    cc67fb0 vhost-user: enabling for vhost-user network devices
    f5587cf device: make a more generic function for hypervisor args
    d6f0600 gitignore: Add new shim binary to gitignore list
    bf8359f gitignore: Add new shim binary to gitignore list
    c30fd9a ci: Install missing dep tool
    d1bb792 kata_agent: Signal the kata shim
    08c96c2 shim: Generalize stopShim

Fixes #924.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>