### PR TITLE
CI: do not call .ci/setup.sh with sudo

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -18,11 +18,6 @@
 
 set -e
 
-# Make sure root does not own any folder of the GOPATH
-# Otherwise this would prevent the following scripts to
-# succeed when performing "go get"
-sudo chown -R ${USER}:${USER} ${GOPATH}
-
 # Run unit testing
 make check
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -40,4 +40,4 @@ checkcommits \
 
 # Setup environment and build components.
 cd "${test_repo_dir}"
-sudo -E PATH=$PATH bash -c ".ci/setup.sh"
+.ci/setup.sh


### PR DESCRIPTION
There is no need to setup the CC environment with the
root user.

Also after running the setup, we needed to change the ownership
of the $GOPATH directory back from root. With this change we
will not need to do this anymore.

Fixes #930.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>