### PR TITLE
build: Allow for kata project build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 /cc-runtime
+/kata-runtime
 /coverage.html
 /config-generated.go
 /data/cc-collect-data.sh
+/data/cc-collect-data.sh.in
+/data/kata-collect-data.sh
+/data/kata-collect-data.sh.in
+/data/completions/bash/cc-runtime
+/data/completions/bash/cc-runtime.in
+/data/completions/bash/kata-runtime
+/data/completions/bash/kata-runtime.in
 /config/configuration.toml

--- a/cc-check.go
+++ b/cc-check.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -324,7 +324,7 @@ func kvmIsUsable() error {
 }
 
 var ccCheckCLICommand = cli.Command{
-	Name:  "cc-check",
+	Name:  checkCmd,
 	Usage: "tests if system can run " + project,
 	Action: func(context *cli.Context) error {
 		err := hostIsClearContainersCapable(procCPUInfo)

--- a/cc-env.go
+++ b/cc-env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Semantic version for the output of the "cc-env" command.
+// Semantic version for the output of the command.
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
@@ -119,7 +119,7 @@ type HostInfo struct {
 }
 
 // EnvInfo collects all information that will be displayed by the
-// "cc-env" command.
+// env command.
 //
 // XXX: Any changes must be coupled with a change to formatVersion.
 type EnvInfo struct {
@@ -346,7 +346,7 @@ func handleSettings(file *os.File, metadata map[string]interface{}) error {
 }
 
 var ccEnvCLICommand = cli.Command{
-	Name:  "cc-env",
+	Name:  envCmd,
 	Usage: "display settings",
 	Action: func(context *cli.Context) error {
 		return handleSettings(defaultOutputFile, context.App.Metadata)

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -1,4 +1,9 @@
-# XXX: Warning: this file is auto-generated from file "@CONFIG_IN@".
+# XXX: Warning: this file is auto-generated.
+# XXX:
+# XXX: Source file: "@CONFIG_IN@"
+# XXX: Project:
+# XXX:   Name: @PROJECT_NAME@
+# XXX:   Type: @PROJECT_TYPE@
 
 [hypervisor.qemu]
 path = "@QEMUPATH@"
@@ -82,21 +87,21 @@ disable_block_device_use = @DEFDISABLEBLOCK@
 # 
 #disable_nesting_checks = true
 
-[proxy.cc]
+[proxy.@PROJECT_TYPE@]
 path = "@PROXYPATH@"
 
 # If enabled, proxy messages will be sent to the system log
 # (default: disabled)
 #enable_debug = true
 
-[shim.cc]
+[shim.@PROJECT_TYPE@]
 path = "@SHIMPATH@"
 
 # If enabled, shim messages will be sent to the system log
 # (default: disabled)
 #enable_debug = true
 
-[agent.cc]
+[agent.@PROJECT_TYPE@]
 # There is no field for this section. The goal is only to be able to
 # specify which type of agent the user wants to use.
 

--- a/data/collect-data.sh.in
+++ b/data/collect-data.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2017-2018 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 script_name=${0##*/}
-runtime_name="cc-runtime"
+runtime_name="@RUNTIME_NAME@"
 runtime=$(command -v "$runtime_name" 2>/dev/null)
-issue_url="https://github.com/clearcontainers/runtime/issues/new"
+issue_url="@PROJECT_URL@/issues/new"
 script_version="@VERSION@ (commit @COMMIT@)"
 
 # Maximum number of errors to show for a single system component
@@ -68,10 +68,10 @@ usage()
 	cat <<EOT
 Usage: $script_name
 
-Summary: Collect data about an Intel® Clear Containers installation.
+Summary: Collect data about an installation of @PROJECT_NAME@.
 
 Description: Run this script as root to obtain a markdown-formatted summary
-  of the Clear Containers installation environment. The output of this script
+  of the environment of the @PROJECT_NAME@ installation. The output of this script
   can be pasted directly into a github issue at the address below:
 
       $issue_url

--- a/data/completions/bash/runtime.in
+++ b/data/completions/bash/runtime.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2017-2018 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,22 +19,22 @@
 # Description: Bash tab completion script.
 #---------------------------------------------------------------------
 
-_ccruntime='cc-runtime'
+_runtime='@RUNTIME_NAME@'
 
 # Return a list of sub-commands
-_cc_get_subcmds()
+_@PROJECT_TYPE@_get_subcmds()
 {
-    "$_ccruntime" --generate-bash-completion
+    "$_runtime" --generate-bash-completion
 }
 
 # Return a list of options for the specified sub-command
 #
 # Limitation: Note that this only supports long-options.
-_cc_get_subcmd_options()
+_@PROJECT_TYPE@_get_subcmd_options()
 {
     local subcmd="$1"
 
-    "$_ccruntime" "$subcmd" --help |\
+    "$_runtime" "$subcmd" --help |\
         egrep -- "^ *--[^ ]*[ ][^ ]*" |\
         awk '{print $1}' |\
         tr -d \, |\
@@ -42,15 +42,15 @@ _cc_get_subcmd_options()
 }
 
 # Return a list of global options
-_cc_get_global_options()
+_@PROJECT_TYPE@_get_global_options()
 {
-    _cc_get_subcmd_options ""
+    _@PROJECT_TYPE@_get_subcmd_options ""
 }
 
 # Return name of subcmd already seen, or ""
-_cc_subcmd_seen()
+_@PROJECT_TYPE@_subcmd_seen()
 {
-    local subcmds=$(_cc_get_subcmds)
+    local subcmds=$(_@PROJECT_TYPE@_get_subcmds)
     local cmd
 
     for cmd in $subcmds; do
@@ -65,14 +65,14 @@ _cc_subcmd_seen()
 
 # Return 0 if the specified sub-command requires the name of an
 # *existing* container, else 1.
-_cc_subcmd_needs_existing_container()
+_@PROJECT_TYPE@_subcmd_needs_existing_container()
 {
     local subcmd="$1"
     local cmd
 
     for cmd in \
-	    'cc-check' \
-	    'cc-env' \
+	    '@PROJECT_TYPE@-check' \
+	    '@PROJECT_TYPE@-env' \
 	    'create' \
 	    'help' \
 	    'list' \
@@ -84,17 +84,17 @@ _cc_subcmd_needs_existing_container()
 }
 
 # Returns a list of container names
-_cc_get_containers()
+_@PROJECT_TYPE@_get_containers()
 {
     # Commands that manipulate containers need root privileges.
     # If the user isn't running as root, don't attempt to obtain a list
     # as it will result in an error.
     [ $(id -u) -eq 0 ] || return
 
-    "$_ccruntime" list --quiet
+    "$_runtime" list --quiet
 }
 
-_cc_bash_autocomplete() {
+_@PROJECT_TYPE@_bash_autocomplete() {
     COMPREPLY=()
 
     local opts opt
@@ -109,34 +109,34 @@ _cc_bash_autocomplete() {
         [ "$cur" = "$opt" ] && return 0
     done
 
-    local subcmd_seen=$(_cc_subcmd_seen)
+    local subcmd_seen=$(_@PROJECT_TYPE@_subcmd_seen)
 
     if [ -n "$subcmd_seen" ]; then
-	    _cc_subcmd_needs_existing_container "$subcmd_seen"
+	    _@PROJECT_TYPE@_subcmd_needs_existing_container "$subcmd_seen"
 	    local container_cmd=$?
     
             if [ -n "$cur" ]; then
                     # Complete with local options and maybe container names
-                    opts=$(_cc_get_subcmd_options "$subcmd_seen")
-                    [ $container_cmd -eq 0 ] && opts="$opts $(_cc_get_containers)"
+                    opts=$(_@PROJECT_TYPE@_get_subcmd_options "$subcmd_seen")
+                    [ $container_cmd -eq 0 ] && opts="$opts $(_@PROJECT_TYPE@_get_containers)"
             elif [[ "${cur}" == -* ]]; then
                     # Complete with local options
-                    opts=$(_cc_get_subcmd_options "$subcmd_seen")
+                    opts=$(_@PROJECT_TYPE@_get_subcmd_options "$subcmd_seen")
             else
                     # Potentially complete with container names
-                    [ $container_cmd -eq 0 ] && opts="$(_cc_get_containers)"
+                    [ $container_cmd -eq 0 ] && opts="$(_@PROJECT_TYPE@_get_containers)"
             fi
     else
             if [ -n "$cur" ]; then
                     # Complete with global options and subcmds
-                    opts="$opts $(_cc_get_global_options)"
-                    opts="$opts $(_cc_get_subcmds)"
+                    opts="$opts $(_@PROJECT_TYPE@_get_global_options)"
+                    opts="$opts $(_@PROJECT_TYPE@_get_subcmds)"
             elif [[ "${cur}" == -* ]]; then
                     # Complete with global options
-                    opts=$(_cc_get_global_options)
+                    opts=$(_@PROJECT_TYPE@_get_global_options)
             else
                     # Complete with subcmds
-                    opts=$(_cc_get_subcmds)
+                    opts=$(_@PROJECT_TYPE@_get_subcmds)
             fi
     fi
 
@@ -145,4 +145,4 @@ _cc_bash_autocomplete() {
     return 0
 }
 
-complete -F _cc_bash_autocomplete "$_ccruntime"
+complete -F _@PROJECT_TYPE@_bash_autocomplete "$_runtime"


### PR DESCRIPTION
Rework the build system to allow the runtime to be built for either
of the following:

- Clear Containers (`cc-runtime` binary and configuration)
- Kata Containers (`kata-runtime` binary and configuration)

The existing build rules are retained but there are now two new rules:

```
$ make build-kata-system
$ sudo make install-kata-system
```

Two new variables have also been added:

- `KATA_SYSTEM_BUILD`: set to any value to build/install for Kata.
- `SYSTEM_BUILD_TYPE`: build for either Clear Containers (set to `cc`) or
Kata (set to `kata`).

See `make help` for further details.

Note that configuration files are installed to a project-specific
directory, allowing for systems to be installed for both Kata and Clear
Containers.

Finally, the bash completion and collection scripts have been updated
to work for either project.

Fixes #919, #921.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
