### PR TITLE
main: Set the OCI vc package logger

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	vc "github.com/containers/virtcontainers"
+	"github.com/containers/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -193,6 +194,9 @@ func beforeSubcommands(context *cli.Context) error {
 
 	// Set virtcontainers logger.
 	vci.SetLogger(ccLog)
+
+	// Set the OCI package logger.
+	oci.SetLogger(ccLog)
 
 	ignoreLogging := false
 	if context.NArg() == 1 && context.Args()[0] == "cc-env" {


### PR DESCRIPTION
In order to merge the virtcontainers OCI package logs with
the rest of the cc-runtime ones.

Fixes #934

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>