### PR TITLE
build: Add basic architecture framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,19 @@ for file in /etc/os-release /usr/lib/os-release; do \
     fi \
 done)
 
+GOARCH=$(shell go env GOARCH)
+HOST_ARCH=$(shell arch)
+
+ifeq ($(ARCH),)
+	ARCH = $(GOARCH)
+endif
+
+ARCH_DIR = arch
+ARCH_FILE = $(ARCH_DIR)/$(ARCH)-options.mk
+
+# Load architecture-dependent settings
+include $(ARCH_FILE)
+
 #------------------------------
 # project-specifics
 
@@ -164,19 +177,8 @@ PKGLIBEXECDIR := $(LIBEXECDIR)/$(PROJECT_DIR)
 KERNELPATH := $(PKGDATADIR)/vmlinuz.container
 IMAGEPATH := $(PKGDATADIR)/$(IMAGENAME)
 FIRMWAREPATH :=
-MACHINEACCELERATORS :=
-
-KERNELPARAMS :=
-
-# The CentOS/RHEL hypervisor binary is not called qemu-lite
-ifeq (,$(filter-out centos rhel,$(distro)))
-QEMUCMD := qemu-system-x86_64
-else
-QEMUCMD := qemu-lite-system-x86_64
-endif
 
 QEMUPATH := $(QEMUBINDIR)/$(QEMUCMD)
-MACHINETYPE := pc
 
 SHIMCMD := $(BIN_PREFIX)-shim
 SHIMPATH := $(PKGLIBEXECDIR)/$(SHIMCMD)
@@ -240,6 +242,7 @@ SCRIPTS_DIR := $(BINDIR)
 GENERATED_FILES += $(COLLECT_SCRIPT)
 
 # list of variables the user may wish to override
+USER_VARS += ARCH
 USER_VARS += BASH_COMPLETIONSDIR
 USER_VARS += BINDIR
 USER_VARS += CC_SYSTEM_BUILD
@@ -525,6 +528,11 @@ show-footer:
 	@printf "• Project home: $(PROJECT_URL)\n\n"
 
 show-summary: show-header
+	@printf "• architecture:\n"
+	@printf "\tHost: $(HOST_ARCH)\n"
+	@printf "\tgolang: $(GOARCH)\n"
+	@printf "\tBuild: $(ARCH)\n"
+	@printf "\n"
 	@printf "• golang:\n"
 	@printf "\t"
 	@go version

--- a/arch/amd64-options.mk
+++ b/arch/amd64-options.mk
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Intel x86-64 settings
+
+MACHINETYPE := pc
+KERNELPARAMS :=
+MACHINEACCELERATORS :=
+
+# The CentOS/RHEL hypervisor binary is not called qemu-lite
+ifeq (,$(filter-out centos rhel,$(distro)))
+    QEMUCMD := qemu-system-x86_64
+else
+    QEMUCMD := qemu-lite-system-x86_64
+endif
+


### PR DESCRIPTION
Support building on different architectures. Currently, only `amd64`
(`x86-64`) is supported. To add support for a new architecture, create:

```
arch/$(GOARCH)-options.mk
```

To build for a different architecture to the hosts, specify the `ARCH`
variable. For example:

```
$ make ARCH=... generate-config
```

Fixes #928.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>