### PR TITLE
build: Only install git hooks in a git clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,17 @@ QUIET_GENERATE = $(Q:@=@echo    '     GENERATE '$@;)
 QUIET_INST     = $(Q:@=@echo    '     INSTALL '$@;)
 QUIET_TEST     = $(Q:@=@echo    '     TEST    '$@;)
 
-default: $(TARGET) $(CONFIG) install-git-hooks
+# return non-empty string if file exists
+define FILE_EXISTS
+$(realpath $1)
+endef
+
+# only install git hooks if working in a git clone
+ifneq (,$(call FILE_EXISTS,.git))
+	HANDLE_GIT_HOOKS = install-git-hooks
+endif
+
+default: $(TARGET) $(CONFIG) $(HANDLE_GIT_HOOKS)
 .DEFAULT: default
 
 build: default


### PR DESCRIPTION
Check to see if the build is being run from a git clone (with a `.git/`
directory) before installing the git hooks.

Fixes #949.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>