### PR TITLE
build: Set systemd unit name based on project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,9 @@ const project = "$(PROJECT_NAME)"
 // prefix used to denote non-standard CLI commands and options.
 const projectPrefix = "$(PROJECT_TYPE)"
 
+// systemdUnitName is the systemd(1) target used to launch the agent.
+const systemdUnitName = "$(PROJECT_TAG).target"
+
 // commit is the git commit the runtime is compiled from.
 var commit = "$(COMMIT)"
 

--- a/create.go
+++ b/create.go
@@ -160,7 +160,7 @@ func getKernelParams(containerID string) []vc.Param {
 		},
 		{
 			Key:   "systemd.unit",
-			Value: "clear-containers.target",
+			Value: systemdUnitName,
 		},
 		{
 			Key:   "systemd.mask",


### PR DESCRIPTION
Set the name of the systemd(1) unit based on the project being built for.

The unit name is used to construct the kernel command line, and then
used by the guests systemd to launch the agent, but previously only the
clear containers agent was supported.

Fixes #955.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>