### PR TITLE
docs: remove references to Clear Containers proxy service

### DIFF
--- a/docs/fedora-installation-guide.md
+++ b/docs/fedora-installation-guide.md
@@ -40,14 +40,12 @@ ExecStart=/usr/bin/dockerd -D --add-runtime cc-runtime=/usr/bin/cc-runtime --def
 EOF
 ```
 
-4. Restart the Docker and Clear Containers systemd services with the following commands:
+4. Restart the Docker systemd service with the following commands:
 
 ```
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable docker.service
 $ sudo systemctl restart docker
-$ sudo systemctl enable cc-proxy.socket
-$ sudo systemctl start cc-proxy.socket
 ```
 
 5. Run Clear Containers 3.0.

--- a/docs/ubuntu-installation-guide.md
+++ b/docs/ubuntu-installation-guide.md
@@ -41,7 +41,7 @@ ExecStart=/usr/bin/dockerd -D --add-runtime cc-runtime=/usr/bin/cc-runtime --def
 EOF
 ```
 
-4. Restart the Docker and Clear Containers systemd services with the following commands:
+4. Restart the Docker systemd service with the following commands:
 
 ```
 $ sudo systemctl daemon-reload

--- a/installation/centos-setup.sh
+++ b/installation/centos-setup.sh
@@ -155,5 +155,3 @@ EOF
 
 sudo systemctl daemon-reload
 sudo systemctl restart docker
-sudo systemctl enable cc-proxy.socket
-sudo systemctl start cc-proxy.socket

--- a/installation/sles-setup.sh
+++ b/installation/sles-setup.sh
@@ -150,5 +150,3 @@ EOF
 
 sudo systemctl daemon-reload
 sudo systemctl restart docker
-sudo systemctl enable cc-proxy.socket
-sudo systemctl start cc-proxy.socket


### PR DESCRIPTION
We no longer run cc-proxy as a daemon on the host.  Update install
directions to no longer reference a Clear Containers service restart and
removed directions for starting a cc-proxy service.

Fixes: #957

Signed-off-by: Eric Ernst <eric.ernst@intel.com>