### PR TITLE
usage: Show project URL in help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,9 @@ const projectPrefix = "$(PROJECT_TYPE)"
 // systemdUnitName is the systemd(1) target used to launch the agent.
 const systemdUnitName = "$(PROJECT_TAG).target"
 
+// original URL for this project
+const projectURL = "$(CC_PROJECT_URL)"
+
 // commit is the git commit the runtime is compiled from.
 var commit = "$(COMMIT)"
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,11 @@ NOTES:
 
 - Commands starting "%s-" and options starting "--%s-" are `+project+` extensions.
 
-`, projectPrefix, projectPrefix)
+URL:
+
+  The canonical URL for this project is: %s
+
+`, projectPrefix, projectPrefix, projectURL)
 
 // ccLog is the logger used to record all messages
 var ccLog *logrus.Entry


### PR DESCRIPTION
Display the project URL in the `--help` output which is fixed,
regardless of which project the Clear Containers runtime is built for.

Fixes #961.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>