### PR TITLE
config: Allow user-specified kernel params to take priority

### DIFF
--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -1,4 +1,4 @@
-# XXX: Warning: this file is auto-generated.
+# XXX: WARNING: this file is auto-generated.
 # XXX:
 # XXX: Source file: "@CONFIG_IN@"
 # XXX: Project:
@@ -10,9 +10,17 @@ path = "@QEMUPATH@"
 kernel = "@KERNELPATH@"
 image = "@IMAGEPATH@"
 machine_type = "@MACHINETYPE@"
+
 # Optional space-separated list of options to pass to the guest kernel.
 # For example, use `kernel_params = "vsyscall=emulate"` if you are having
-# trouble running pre-2.15 glibc
+# trouble running pre-2.15 glibc.
+#
+# WARNING: - any parameter specified here will take priority over the default
+# parameter value of the same name used to start the virtual machine.
+# Do not set values here unless you understand the impact of doing so as you
+# may stop the virtual machine from booting.
+# To see the list of default parameters, enable hypervisor debug, create a
+# container and look for 'default-kernel-parameters' log entries.
 kernel_params = "@KERNELPARAMS@"
 
 # Path to the firmware.


### PR DESCRIPTION
Any `kernel_params=` values specified in the config file should take
priority over any in-built defaults (for better or for worse).

Fixes #963.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>