### PR TITLE
scripts: Ignore qemu startup message

### DIFF
--- a/data/collect-data.sh.in
+++ b/data/collect-data.sh.in
@@ -63,6 +63,11 @@ problem_pattern+="\<warning\>|"
 problem_pattern+="\<wrong\>"
 problem_pattern+=")"
 
+# List of patterns used to exclude messages that are not problems
+problem_exclude_pattern="("
+problem_exclude_pattern+="\<launching .* with:"
+problem_exclude_pattern+=")"
+
 usage()
 {
 	cat <<EOT
@@ -218,6 +223,7 @@ find_system_journal_problems()
 	local problems=$(journalctl -q -o cat -a "$selector" "$program" |\
 		grep "time=" |\
 		egrep -i "$problem_pattern" |\
+		egrep -iv "$problem_exclude_pattern" |\
 		tail -n ${PROBLEM_LIMIT})
 
 	if [ -n "$problems" ]; then


### PR DESCRIPTION
Don't consider the hypervisor startup log message as a "problem".

Fixes #969.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>