### PR TITLE
versions: image: Update base os to version 20640

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 cc_agent_version=b1d92e2aa14d915680e8fe770745a511857ac7ff
 
 # Clear Containers image from https://download.clearlinux.org/releases/
-clear_vm_image_version=19350
+clear_vm_image_version=20640
 
 # Clear Containers Kernel version
 # Kernel configuration and patches from

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,5 @@
 # Clear Containers agent commit
-cc_agent_version=b1d92e2aa14d915680e8fe770745a511857ac7ff
+cc_agent_version=867639223bbcd15672626bcd7f58cde2530c0cc5
 
 # Clear Containers image from https://download.clearlinux.org/releases/
 clear_vm_image_version=20640


### PR DESCRIPTION
Update agent to version 867639223bbcd15672626bcd7f58cde2530c0cc5

Changes :

f4fe1d8 network: Revert delete conflicting route
88eb422 CI: Don't require an issue for release PRs
bbd24dc agent: Add support to online vCPUs
ae71318 agent: Fix sync issues with exit code and stdout of a process
16eb82e capabilities: Add support for Linux capabilities
41802c2 agent: add libudev as dependency
ad7c8a5 privileges: Add NoNewPrivileges in the api
4c2b752 devices: Bind mount devices only when /dev is expected to be
d38fb19 dev: Listen to udev events and bind mount these to container's
bd925f1 agent: Make the agent the subreaper of all processes
cf05dda vendor: Update libcontainer vendoring
4dac904 dev: Mount /dev from tmpfs before mount namespace is created
3e12a1b debug: Send errors on the control channel
aa14193 vendor: Update vendoring for virtcontainers
d939c51 network: Use RouteAdd instead of RouteReplace.
9275cec network: Make the error returned on failure to delete a route verbose.
2ec2446 dev: Bind mount /dev/vfio inside container mount namespace
e30849c network: Delete conflicting route

Changes in package coreutils (from 8.28-41 to 8.29-42):
Arjan van de Ven - coreutils: Autospec creation for update from
version 8.28 to version 8.29
https://download.clearlinux.org/releases/19960/clear/RELEASENOTES

Changes in package systemd (from 234-158 to 234-159):
Auke Kok - Allow timesyncd to restart after a
software update.
https://download.clearlinux.org/releases/20480/clear/RELEASENOTES

Changes in package coreutils (from 8.29-42 to 8.29-43):
Victor Rodriguez - coreutils:
    Fix forCVE-2017-18018 CVE-2017-18018-1
Patrick McCarty - Add giturl
https://download.clearlinux.org/releases/20490/clear/RELEASENOTES

Changes in package systemd (from 234-159 to 234-160):
Simental Magana, Marcos - Fix rejected send message by D-Bus from
logind
https://download.clearlinux.org/releases/20620/clear/RELEASENOTES

Fixes #979

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>