### PR TITLE
build: Don't install git hooks when running under a CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,14 @@ ifneq (,$(call DIR_EXISTS,.git))
 	HANDLE_GIT_HOOKS = install-git-hooks
 endif
 
+# Don't install hooks when running under the CI as they will stop the
+# tests from running.
+#
+# See: https://github.com/clearcontainers/runtime/issues/984
+ifneq (,$(CI))
+	HANDLE_GIT_HOOKS =
+endif
+
 default: $(TARGET) $(CONFIG) $(HANDLE_GIT_HOOKS)
 .DEFAULT: default
 


### PR DESCRIPTION
Don't use git hooks when running under the CI as it will remove the
crucial `config-generated.go` file, which will cause `go test` to fail.

Fixes #984.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>