### PR TITLE
Lint fixes

### DIFF
--- a/.ci/go-static-checks.sh
+++ b/.ci/go-static-checks.sh
@@ -69,6 +69,9 @@ install_package github.com/fzipp/gocyclo
 install_package github.com/client9/misspell/cmd/misspell
 install_package github.com/golang/lint/golint
 install_package github.com/gordonklaus/ineffassign
+install_package github.com/opennota/check/cmd/structcheck
+install_package honnef.co/go/tools/cmd/unused
+install_package honnef.co/go/tools/cmd/staticcheck
 
 echo Doing go static checks on packages: $go_packages
 
@@ -100,5 +103,11 @@ for p in $go_packages; do golint -set_exit_status $p; done
 
 echo "Running ineffassign..."
 go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
+
+for tool in structcheck unused staticcheck
+do
+	echo "Running ${tool}..."
+	eval "$tool" "$go_packages"
+done
 
 echo "All Good!"

--- a/config.go
+++ b/config.go
@@ -65,11 +65,6 @@ const (
 	maxPCIBridges uint32 = 5
 )
 
-var (
-	errUnknownHypervisor = errors.New("unknown hypervisor")
-	errUnknownAgent      = errors.New("unknown agent")
-)
-
 type tomlConfig struct {
 	Hypervisor map[string]hypervisor
 	Proxy      map[string]proxy

--- a/console.go
+++ b/console.go
@@ -27,8 +27,6 @@ import (
 
 var ptmxPath = "/dev/ptmx"
 
-var ptsPtmxPath = "/dev/pts/ptmx"
-
 // Console represents a pseudo TTY.
 type Console struct {
 	io.ReadWriteCloser

--- a/main_test.go
+++ b/main_test.go
@@ -53,12 +53,6 @@ const (
 	testPodID       = "99999999-9999-9999-99999999999999999"
 	testContainerID = "1"
 	testBundle      = "bundle"
-	testKernel      = "kernel"
-	testImage       = "image"
-	testHypervisor  = "hypervisor"
-
-	MockHypervisor vc.HypervisorType = "mock"
-	NoopAgentType  vc.AgentType      = "noop"
 )
 
 var (
@@ -138,16 +132,6 @@ func init() {
 	}
 }
 
-var testPodAnnotations = map[string]string{
-	"pod.foo":   "pod.bar",
-	"pod.hello": "pod.world",
-}
-
-var testContainerAnnotations = map[string]string{
-	"container.foo":   "container.bar",
-	"container.hello": "container.world",
-}
-
 // resetCLIGlobals undoes the effects of setCLIGlobals(), restoring the original values
 func resetCLIGlobals() {
 	cli.AppHelpTemplate = savedCLIAppHelpTemplate
@@ -222,64 +206,6 @@ func grep(pattern, file string) error {
 	}
 
 	return nil
-}
-
-// newTestCmd creates a new virtcontainers Cmd to run a shell
-func newTestCmd() vc.Cmd {
-	envs := []vc.EnvVar{
-		{
-			Var:   "PATH",
-			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
-		},
-	}
-
-	cmd := vc.Cmd{
-		Args:    strings.Split("/bin/sh", " "),
-		Envs:    envs,
-		WorkDir: "/",
-	}
-
-	return cmd
-}
-
-// newTestContainerConfig returns a new ContainerConfig
-func newTestContainerConfig(dir string) vc.ContainerConfig {
-	return vc.ContainerConfig{
-		ID:          testContainerID,
-		RootFs:      filepath.Join(dir, testBundle),
-		Cmd:         newTestCmd(),
-		Annotations: testContainerAnnotations,
-	}
-}
-
-// newTestPodConfigNoop creates a new virtcontainers PodConfig
-// (of the most basic type). If create is true, create the required
-// resources.
-//
-// Note: no parameter validation in case caller wishes to create an invalid
-// object.
-func newTestPodConfigNoop(dir string, create bool) (vc.PodConfig, error) {
-	// Sets the hypervisor configuration.
-	hypervisorConfig, err := newTestHypervisorConfig(dir, create)
-	if err != nil {
-		return vc.PodConfig{}, err
-	}
-
-	container := newTestContainerConfig(dir)
-
-	podConfig := vc.PodConfig{
-		ID:               testPodID,
-		HypervisorType:   MockHypervisor,
-		HypervisorConfig: hypervisorConfig,
-
-		AgentType: NoopAgentType,
-
-		Containers: []vc.ContainerConfig{container},
-
-		Annotations: testPodAnnotations,
-	}
-
-	return podConfig, nil
 }
 
 // newTestHypervisorConfig creaets a new virtcontainers

--- a/oci.go
+++ b/oci.go
@@ -37,7 +37,6 @@ const (
 	cgroupsProcsFile = "cgroup.procs"
 	cgroupsDirMode   = os.FileMode(0750)
 	cgroupsFileMode  = os.FileMode(0640)
-	cgroupsMountType = "cgroup"
 
 	// Filesystem type corresponding to CGROUP_SUPER_MAGIC as listed
 	// here: http://man7.org/linux/man-pages/man2/statfs.2.html

--- a/start_test.go
+++ b/start_test.go
@@ -239,13 +239,12 @@ func TestStartCLIFunctionSuccess(t *testing.T) {
 		testingImpl.StartContainerFunc = nil
 	}()
 
-	flagSet := &flag.FlagSet{}
 	app := cli.NewApp()
 
 	fn, ok := startCLICommand.Action.(func(context *cli.Context) error)
 	assert.True(ok)
 
-	flagSet = flag.NewFlagSet("test", 0)
+	flagSet := flag.NewFlagSet("test", 0)
 	flagSet.Parse([]string{testContainerID})
 	ctx := cli.NewContext(app, flagSet, nil)
 	assert.NotNil(ctx)


### PR DESCRIPTION
Fix lint errors and add the following golang linters to the static checks tool to avoid
such problems recurring:

- `staticcheck`
- `structcheck`
- `unused`

Fixes #988.
