### PR TITLE
cc-env: Add architecture to output

### DIFF
--- a/cc-env.go
+++ b/cc-env.go
@@ -30,7 +30,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.7"
+const formatVersion = "1.0.8"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -113,6 +113,7 @@ type DistroInfo struct {
 // HostInfo stores host details
 type HostInfo struct {
 	Kernel             string
+	Architecture       string
 	Distro             DistroInfo
 	CPU                CPUInfo
 	VMContainerCapable bool
@@ -191,6 +192,7 @@ func getHostInfo() (HostInfo, error) {
 
 	ccHost := HostInfo{
 		Kernel:             hostKernelVersion,
+		Architecture:       arch,
 		Distro:             hostDistro,
 		CPU:                hostCPU,
 		VMContainerCapable: hostVMContainerCapable,

--- a/cc-env_test.go
+++ b/cc-env_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 
@@ -163,6 +164,7 @@ func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	}
 
 	const expectedKernelVersion = "99.1"
+	const expectedArch = goruntime.GOARCH
 
 	expectedDistro := DistroInfo{
 		Name:    "Foo",
@@ -176,6 +178,7 @@ func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 
 	expectedHostDetails := HostInfo{
 		Kernel:             expectedKernelVersion,
+		Architecture:       expectedArch,
 		Distro:             expectedDistro,
 		CPU:                expectedCPU,
 		VMContainerCapable: false,

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	goruntime "runtime"
 	"runtime/debug"
 	"strings"
 
@@ -31,6 +32,9 @@ import (
 
 // specConfig is the name of the file holding the containers configuration
 const specConfig = "config.json"
+
+// arch is the architecture for the running program
+const arch = goruntime.GOARCH
 
 var usage = fmt.Sprintf(`%s runtime
 


### PR DESCRIPTION
Add the host architecture to the output of the `cc-env` command.

Fixes #993.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>