### PR TITLE
config: Add option to change internetworking model 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,7 @@
   packages = [
     ".",
     "pkg/annotations",
+    "pkg/annotations/dockershim",
     "pkg/cni",
     "pkg/ethtool",
     "pkg/hyperstart",
@@ -49,7 +50,7 @@
     "pkg/uuid",
     "pkg/vcMock"
   ]
-  revision = "c112a9f2b187153c1c7dc742618db77802c40bcf"
+  revision = "f8d2c11dcfd5c04e529e5900a195ee055734d5df"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -248,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "540dedfa90a1b3d2180c14d8692f95021d474e7a3c3fe715d23a1c9acb3220b3"
+  inputs-digest = "83cd7507e92185659814c3490d7bba016df2add7cfcd901727a7d75eb6b17717"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "c112a9f2b187153c1c7dc742618db77802c40bcf"
+  revision = "f8d2c11dcfd5c04e529e5900a195ee055734d5df"
 
 [prune]
   non-go = true

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,8 @@ DEFVCPUS := 1
 DEFMEMSZ := 2048
 #Default number of bridges
 DEFBRIDGES := 1
+#Default network model
+DEFNETWORKMODEL := macvtap
 
 DEFDISABLEBLOCK := false
 DEFENABLEMEMPREALLOC := false
@@ -287,6 +289,7 @@ USER_VARS += SYSCONFDIR
 USER_VARS += DEFVCPUS
 USER_VARS += DEFMEMSZ
 USER_VARS += DEFBRIDGES
+USER_VARS += DEFNETWORKMODEL
 USER_VARS += DEFDISABLEBLOCK
 USER_VARS += DEFENABLEMEMPREALLOC
 USER_VARS += DEFENABLEHUGEPAGES
@@ -389,6 +392,7 @@ const defaultRuntimeRun = "$(PKGRUNDIR)"
 const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB
 const defaultBridgesCount uint32 = $(DEFBRIDGES)
+const defaultInterNetworkingModel = "$(DEFNETWORKMODEL)"
 const defaultDisableBlockDeviceUse bool = $(DEFDISABLEBLOCK)
 const defaultEnableMemPrealloc bool = $(DEFENABLEMEMPREALLOC)
 const defaultEnableHugePages bool = $(DEFENABLEHUGEPAGES)
@@ -475,6 +479,7 @@ $(GENERATED_FILES): %: %.in Makefile VERSION
 		-e "s|@DEFVCPUS@|$(DEFVCPUS)|g" \
 		-e "s|@DEFMEMSZ@|$(DEFMEMSZ)|g" \
 		-e "s|@DEFBRIDGES@|$(DEFBRIDGES)|g" \
+		-e "s|@DEFNETWORKMODEL@|$(DEFNETWORKMODEL)|g" \
 		-e "s|@DEFDISABLEBLOCK@|$(DEFDISABLEBLOCK)|g" \
 		-e "s|@DEFENABLEMEMPREALLOC@|$(DEFENABLEMEMPREALLOC)|g" \
 		-e "s|@DEFENABLEHUGEPAGES@|$(DEFENABLEHUGEPAGES)|g" \

--- a/config.go
+++ b/config.go
@@ -98,7 +98,8 @@ type proxy struct {
 }
 
 type runtime struct {
-	Debug bool `toml:"enable_debug"`
+	Debug             bool   `toml:"enable_debug"`
+	InterNetworkModel string `toml:"internetworking_model"`
 }
 
 type shim struct {
@@ -388,6 +389,11 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		DisableNestingChecks:  defaultDisableNestingChecks,
 	}
 
+	err = config.InterNetworkModel.SetModel(defaultInterNetworkingModel)
+	if err != nil {
+		return "", config, err
+	}
+
 	defaultAgentConfig := vc.HyperConfig{}
 
 	config = oci.RuntimeConfig{
@@ -426,6 +432,12 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		// If debug is not required, switch back to the original
 		// default log priority, otherwise continue in debug mode.
 		ccLog.Logger.Level = originalLoggerLevel
+	}
+	if tomlConf.Runtime.InterNetworkModel != "" {
+		err = config.InterNetworkModel.SetModel(tomlConf.Runtime.InterNetworkModel)
+		if err != nil {
+			return "", config, err
+		}
 	}
 
 	if !ignoreLogging {

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -114,3 +114,17 @@ path = "@SHIMPATH@"
 # system log
 # (default: disabled)
 #enable_debug = true
+#
+# Internetworking model
+# Determines how the VM should be connected to the
+# the container network interface
+# Options:
+#
+#   - bridged
+#     Uses a linux bridge to interconnect the container interface to
+#     the VM. Works for most cases except macvlan and ipvlan.
+#
+#   - macvtap
+#     Used when the Container network interface can be bridged using
+#     macvtap.
+internetworking_model="@DEFNETWORKMODEL@"

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -160,7 +160,7 @@ type agent interface {
 	createContainer(pod *Pod, c *Container) (*Process, error)
 
 	// startContainer will tell the agent to start a container related to a Pod.
-	startContainer(pod Pod, c Container) error
+	startContainer(pod Pod, c *Container) error
 
 	// stopContainer will tell the agent to stop a container related to a Pod.
 	stopContainer(pod Pod, c Container) error

--- a/vendor/github.com/containers/virtcontainers/cni.go
+++ b/vendor/github.com/containers/virtcontainers/cni.go
@@ -111,8 +111,8 @@ func (n *cni) invokePluginsDelete(pod Pod, networkNS NetworkNamespace) error {
 	return nil
 }
 
-func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace, netInfo *NetworkInfo) error {
-	endpoints, err := createEndpointsFromScan(networkNS.NetNsPath)
+func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace, netInfo *NetworkInfo, config NetworkConfig) error {
+	endpoints, err := createEndpointsFromScan(networkNS.NetNsPath, config)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (n *cni) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated 
 		return NetworkNamespace{}, err
 	}
 
-	if err := n.updateEndpointsFromScan(&networkNS, netInfo); err != nil {
+	if err := n.updateEndpointsFromScan(&networkNS, netInfo, config); err != nil {
 		return NetworkNamespace{}, err
 	}
 

--- a/vendor/github.com/containers/virtcontainers/cnm.go
+++ b/vendor/github.com/containers/virtcontainers/cnm.go
@@ -41,7 +41,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 
 // add adds all needed interfaces inside the network namespace for the CNM network.
 func (n *cnm) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
-	endpoints, err := createEndpointsFromScan(netNsPath)
+	endpoints, err := createEndpointsFromScan(netNsPath, config)
 	if err != nil {
 		return NetworkNamespace{}, err
 	}

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -17,6 +17,7 @@
 package virtcontainers
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -234,30 +235,6 @@ func (c *Container) fetchDevices() ([]Device, error) {
 	return c.pod.storage.fetchContainerDevices(c.podID, c.id)
 }
 
-// fetchContainer fetches a container config from a pod ID and returns a Container.
-func fetchContainer(pod *Pod, containerID string) (*Container, error) {
-	if pod == nil {
-		return nil, errNeedPod
-	}
-
-	if containerID == "" {
-		return nil, errNeedContainerID
-	}
-
-	fs := filesystem{}
-	config, err := fs.fetchContainerConfig(pod.id, containerID)
-	if err != nil {
-		return nil, err
-	}
-
-	container, err := createContainer(pod, config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create container with config %v in pod %v: %v", config, pod.id, err)
-	}
-
-	return container, nil
-}
-
 // storeContainer stores a container config.
 func (c *Container) storeContainer() error {
 	fs := filesystem{}
@@ -298,6 +275,77 @@ func (c *Container) createContainersDirs() error {
 	if err != nil {
 		c.pod.storage.deleteContainerResources(c.podID, c.id, nil)
 		return err
+	}
+
+	return nil
+}
+
+// mountSharedDirMounts handles bind-mounts by bindmounting to the host shared
+// directory which is mounted through 9pfs in the VM.
+// It also updates the container mount list with the HostPath info, and store
+// container mounts to the storage. This way, we will have the HostPath info
+// available when we will need to unmount those mounts.
+func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) ([]Mount, error) {
+	var sharedDirMounts []Mount
+	for idx, m := range c.mounts {
+		if isSystemMount(m.Destination) || m.Type != "bind" {
+			continue
+		}
+
+		randBytes, err := generateRandomBytes(8)
+		if err != nil {
+			return nil, err
+		}
+
+		// These mounts are created in the shared dir
+		filename := fmt.Sprintf("%s-%s-%s", c.id, hex.EncodeToString(randBytes), filepath.Base(m.Destination))
+		mountDest := filepath.Join(hostSharedDir, c.pod.id, filename)
+
+		if err := bindMount(m.Source, mountDest, false); err != nil {
+			return nil, err
+		}
+
+		// Save HostPath mount value into the mount list of the container.
+		c.mounts[idx].HostPath = mountDest
+
+		// Check if mount is readonly, let the agent handle the readonly mount
+		// within the VM.
+		readonly := false
+		for _, flag := range m.Options {
+			if flag == "ro" {
+				readonly = true
+			}
+		}
+
+		sharedDirMount := Mount{
+			Source:      filepath.Join(guestSharedDir, filename),
+			Destination: m.Destination,
+			Type:        m.Type,
+			Options:     m.Options,
+			ReadOnly:    readonly,
+		}
+
+		sharedDirMounts = append(sharedDirMounts, sharedDirMount)
+	}
+
+	if err := c.storeMounts(); err != nil {
+		return nil, err
+	}
+
+	return sharedDirMounts, nil
+}
+
+func (c *Container) unmountHostMounts() error {
+	for _, m := range c.mounts {
+		if m.HostPath != "" {
+			if err := syscall.Unmount(m.HostPath, 0); err != nil {
+				c.Logger().WithFields(logrus.Fields{
+					"host-path": m.HostPath,
+					"error":     err,
+				}).Warn("Could not umount")
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -356,7 +404,8 @@ func newContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	return c, nil
 }
 
-// createContainer creates and start a container inside a Pod.
+// createContainer creates and start a container inside a Pod. It has to be
+// called only when a new container, not known by the pod, has to be created.
 func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	if pod == nil {
 		return nil, errNeedPod
@@ -371,17 +420,29 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 		return nil, err
 	}
 
-	state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
-	if err == nil && state.State != "" {
-		c.state.State = state.State
-		return c, nil
+	agentCaps := c.pod.agent.capabilities()
+	hypervisorCaps := c.pod.hypervisor.capabilities()
+
+	if agentCaps.isBlockDeviceSupported() && hypervisorCaps.isBlockDeviceHotplugSupported() {
+		if err := c.hotplugDrive(); err != nil {
+			return nil, err
+		}
 	}
 
-	// If we reached that point, this means that no state file has been
-	// found and that we are in the first creation of this container.
-	// We don't want the following code to be executed outside of this
-	// specific case.
-	process, err := c.pod.agent.createContainer(c.pod, c)
+	// Attach devices
+	if err := c.attachDevices(); err != nil {
+		return nil, err
+	}
+
+	// Deduce additional system mount info that should be handled by the agent
+	// inside the VM
+	c.getSystemMountInfo()
+
+	if err := c.storeDevices(); err != nil {
+		return nil, err
+	}
+
+	process, err := pod.agent.createContainer(c.pod, c)
 	if err != nil {
 		return nil, err
 	}
@@ -479,25 +540,7 @@ func (c *Container) start() error {
 		}
 	}
 
-	agentCaps := c.pod.agent.capabilities()
-	hypervisorCaps := c.pod.hypervisor.capabilities()
-
-	if agentCaps.isBlockDeviceSupported() && hypervisorCaps.isBlockDeviceHotplugSupported() {
-		if err := c.hotplugDrive(); err != nil {
-			return err
-		}
-	}
-
-	// Attach devices
-	if err := c.attachDevices(); err != nil {
-		return err
-	}
-
-	// Deduce additional system mount info that should be handled by the agent
-	// inside the VM
-	c.getSystemMountInfo()
-
-	if err := c.pod.agent.startContainer(*(c.pod), *c); err != nil {
+	if err := c.pod.agent.startContainer(*(c.pod), c); err != nil {
 		c.Logger().WithError(err).Error("Failed to start container")
 
 		if err := c.stop(); err != nil {
@@ -505,8 +548,6 @@ func (c *Container) start() error {
 		}
 		return err
 	}
-	c.storeMounts()
-	c.storeDevices()
 
 	err = c.setContainerState(StateRunning)
 	if err != nil {
@@ -517,25 +558,23 @@ func (c *Container) start() error {
 }
 
 func (c *Container) stop() error {
-	state, err := c.fetchState("stop")
-	if err != nil {
-		return err
-	}
-
 	// In case the container status has been updated implicitly because
 	// the container process has terminated, it might be possible that
 	// someone try to stop the container, and we don't want to issue an
 	// error in that case. This should be a no-op.
-	if state.State == StateStopped {
+	//
+	// This has to be handled before the transition validation since this
+	// is an exception.
+	if c.state.State == StateStopped {
 		c.Logger().Info("Container already stopped")
 		return nil
 	}
 
-	if state.State != StateRunning {
-		return fmt.Errorf("Container not running, impossible to stop")
+	if c.pod.state.State != StateReady && c.pod.state.State != StateRunning {
+		return fmt.Errorf("Pod not ready or running, impossible to stop the container")
 	}
 
-	if err := state.validTransition(StateRunning, StateStopped); err != nil {
+	if err := c.state.validTransition(c.state.State, StateStopped); err != nil {
 		return err
 	}
 
@@ -552,13 +591,20 @@ func (c *Container) stop() error {
 
 	}()
 
-	if err := c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGKILL, true); err != nil {
+	ctrRunning, err := isShimRunning(c.process.Pid)
+	if err != nil {
 		return err
 	}
 
-	// Wait for the end of container
-	if err := waitForShim(c.process.Pid); err != nil {
-		return err
+	if ctrRunning {
+		if err := c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGKILL, true); err != nil {
+			return err
+		}
+
+		// Wait for the end of container
+		if err := waitForShim(c.process.Pid); err != nil {
+			return err
+		}
 	}
 
 	if err := c.pod.agent.stopContainer(*(c.pod), *c); err != nil {
@@ -599,50 +645,15 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 }
 
 func (c *Container) kill(signal syscall.Signal, all bool) error {
-	podState, err := c.pod.storage.fetchPodState(c.pod.id)
-	if err != nil {
-		return err
-	}
-
-	if podState.State != StateReady && podState.State != StateRunning {
+	if c.pod.state.State != StateReady && c.pod.state.State != StateRunning {
 		return fmt.Errorf("Pod not ready or running, impossible to signal the container")
 	}
 
-	state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
-	if err != nil {
-		return err
+	if c.state.State != StateReady && c.state.State != StateRunning {
+		return fmt.Errorf("Container not ready or running, impossible to signal the container")
 	}
 
-	// In case our container is "ready", there is no point in trying to
-	// send any signal because nothing has been started. However, this is
-	// a valid case that we handle by doing nothing or by killing the shim
-	// and updating the container state, according to the signal.
-	if state.State == StateReady {
-		if signal != syscall.SIGTERM && signal != syscall.SIGKILL {
-			c.Logger().WithField("signal", signal).Info("Not sending signal as container already ready")
-			return nil
-		}
-
-		// Calling into stopShim() will send a SIGKILL to the shim.
-		// This signal will be forwarded to the proxy or directly the
-		// agent and will be handled accordingly.
-		if err := stopShim(c.process.Pid); err != nil {
-			return err
-		}
-
-		return c.setContainerState(StateStopped)
-	}
-
-	if state.State != StateRunning {
-		return fmt.Errorf("Container not running, impossible to signal the container")
-	}
-
-	err = c.pod.agent.killContainer(*(c.pod), *c, signal, all)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.pod.agent.killContainer(*(c.pod), *c, signal, all)
 }
 
 func (c *Container) processList(options ProcessListOptions) (ProcessList, error) {

--- a/vendor/github.com/containers/virtcontainers/device.go
+++ b/vendor/github.com/containers/virtcontainers/device.go
@@ -352,15 +352,6 @@ func newBlockDevice(devInfo DeviceInfo) *BlockDevice {
 }
 
 func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
-	// If VM has not been launched yet, return immediately.
-	// This is because we always want to hotplug block devices.
-	// Eventually attachDevices will be called only after VM is launched,
-	// and this check can be taken out.
-	// See https://github.com/containers/virtcontainers/issues/444
-	if c.state.State == "" {
-		return nil
-	}
-
 	randBytes, err := generateRandomBytes(8)
 	if err != nil {
 		return err

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -61,7 +61,7 @@ func (n *noopAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.
-func (n *noopAgent) startContainer(pod Pod, c Container) error {
+func (n *noopAgent) startContainer(pod Pod, c *Container) error {
 	return nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/pkg/annotations/dockershim/annotations.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/annotations/dockershim/annotations.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package dockershim
+
+const (
+	// Copied from k8s.io/pkg/kubelet/dockershim/docker_service.go,
+	// used to identify whether a docker container is a sandbox or
+	// a regular container, will be removed after defining those as
+	// public fields in dockershim.
+
+	// ContainerTypeLabelKey is the container type (podsandbox or container) annotation
+	ContainerTypeLabelKey = "io.kubernetes.docker.type"
+
+	// ContainerTypeLabelSandbox represents a pod sandbox container
+	ContainerTypeLabelSandbox = "podsandbox"
+
+	// ContainerTypeLabelContainer represents a container running within a pod
+	ContainerTypeLabelContainer = "container"
+
+	// SandboxIDLabelKey is the sandbox ID annotation
+	SandboxIDLabelKey = "io.kubernetes.sandbox.id"
+)

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -709,6 +709,27 @@ func fetchPod(podID string) (pod *Pod, err error) {
 	return pod, nil
 }
 
+// findContainer returns a container from the containers list held by the
+// pod structure, based on a container ID.
+func (p *Pod) findContainer(containerID string) (*Container, error) {
+	if p == nil {
+		return nil, errNeedPod
+	}
+
+	if containerID == "" {
+		return nil, errNeedContainerID
+	}
+
+	for _, c := range p.containers {
+		if containerID == c.id {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Could not find the container %q from the pod %q containers list",
+		containerID, p.id)
+}
+
 // delete deletes an already created pod.
 // The VM in which the pod is running will be shut down.
 func (p *Pod) delete() error {

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -107,7 +107,7 @@ var supportedQemuMachines = []govmmQemu.Machine{
 }
 
 const (
-	defaultSockets uint32 = 1
+	defaultCores   uint32 = 1
 	defaultThreads uint32 = 1
 )
 
@@ -354,9 +354,9 @@ func (q *qemu) appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQe
 
 func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType {
 	switch model {
-	case ModelBridged:
+	case NetXConnectBridgedModel:
 		return govmmQemu.MACVTAP //TODO: We should rename MACVTAP to .NET_FD
-	case ModelMacVtap:
+	case NetXConnectMacVtapModel:
 		return govmmQemu.MACVTAP
 	//case ModelEnlightened:
 	// Here the Network plugin will create a VM native interface
@@ -581,10 +581,11 @@ func (q *qemu) setCPUResources(podConfig PodConfig) govmmQemu.SMP {
 		vcpus = uint32(podConfig.VMConfig.VCPUs)
 	}
 
+	// Network IO shows better performance with 1 CPU 1 Socket
 	smp := govmmQemu.SMP{
 		CPUs:    vcpus,
-		Cores:   vcpus,
-		Sockets: defaultSockets,
+		Sockets: vcpus,
+		Cores:   defaultCores,
 		Threads: defaultThreads,
 	}
 

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -140,11 +140,7 @@ func signalShim(pid int, sig syscall.Signal) error {
 			"shim-signal": sig,
 		}).Info("Signalling shim")
 
-	if err := syscall.Kill(pid, sig); err != nil {
-		return err
-	}
-
-	return nil
+	return syscall.Kill(pid, sig)
 }
 
 func stopShim(pid int) error {


### PR DESCRIPTION
This PR add configuation option to allow change how VM will be connected to container network. 

Allowed options are : `default`,  `bridged` and `macvtap`
 
default will use the default defined by virt contaienrs.

This PR also updates virtcontainers: 


- It allows to define the InternetworkingModel from runtime.
- Allow to stop a container in state created
- CPU topology supports until 240 CPUs
- New dockershim annotations are supported.


  f19bd7a oci: Allow to get InternetworkingModel from config
    573dcf0 network: Add NetInterworkingModel methods
    6d19f56 network: Endpoint type dictate how the connection needs to be made
    037a81a network: define internetworking model at endpoint creation
    089119a network: remove unsed function createNetworkEndpoints
    254ad2a Merge pull request #591 from devimc/network/io
    5a1f1bb Merge pull request #607 from miaoyq/dockershim-support
    e6c6f84 Add support for dockershim pod annotations
    3ecda86 Merge pull request #593 from containers/fix_mount
    e01404c container: Allow to send a signal to a created container
    e5ad775 container: Allow to stop a container in state created
    00a9091 qemu: change CPU topology to support until 240 CPUs
    7dc7483 mount: Explicitely modify and store container mount list
    9acfae9 container: Move devices and mounts creation to createContainer()
    9a81686 Merge pull request #592 from containers/fix_container_semantic
     484cc19 api: Add new container pointer to pod structure
    d07aeb2 container: Replace fetchContainer() with findContainer()
    4f82905 Merge pull request #573 from jodh-intel/safe-clean-rule
    80038f3 build: Only clean files if they exist
    a4377a7 build: Fix clean and uninstall

