### PR TITLE
kill: Fix CRI-O race condition

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
     "pkg/uuid",
     "pkg/vcMock"
   ]
-  revision = "f8d2c11dcfd5c04e529e5900a195ee055734d5df"
+  revision = "6621b5d57f99532d6b3a52208a79f63ceaa41308"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "83cd7507e92185659814c3490d7bba016df2add7cfcd901727a7d75eb6b17717"
+  inputs-digest = "1c4ba5d7c1522fc0689ad9e0432da9deb2ed26a53923e9d3170d2192dc36224d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "f8d2c11dcfd5c04e529e5900a195ee055734d5df"
+  revision = "6621b5d57f99532d6b3a52208a79f63ceaa41308"
 
 [prune]
   non-go = true

--- a/delete_test.go
+++ b/delete_test.go
@@ -383,10 +383,7 @@ func TestDeleteRunningContainer(t *testing.T) {
 	assert.Error(err)
 	assert.True(vcMock.IsMockError(err))
 
-	testingImpl.StopContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
-		return &vcMock.Container{}, nil
-	}
-
+	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
 	defer func() {
 		testingImpl.StopContainerFunc = nil
 	}()
@@ -453,10 +450,7 @@ func TestDeleteContainer(t *testing.T) {
 	assert.Error(err)
 	assert.True(vcMock.IsMockError(err))
 
-	testingImpl.StopContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
-		return &vcMock.Container{}, nil
-	}
-
+	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
 	defer func() {
 		testingImpl.StopContainerFunc = nil
 	}()

--- a/kill.go
+++ b/kill.go
@@ -116,7 +116,16 @@ func kill(containerID, signal string, all bool) error {
 		return fmt.Errorf("Container %s not ready or running, cannot send a signal", containerID)
 	}
 
-	return vci.KillContainer(podID, containerID, signum, all)
+	if err := vci.KillContainer(podID, containerID, signum, all); err != nil {
+		return err
+	}
+
+	if signum != syscall.SIGKILL && signum != syscall.SIGTERM {
+		return nil
+	}
+
+	_, err = vci.StopContainer(podID, containerID)
+	return err
 }
 
 func processSignal(signal string) (syscall.Signal, error) {

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -41,7 +41,7 @@ const (
 	KataShimType ShimType = "kataShim"
 )
 
-var waitForShimTimeout = 5.0
+var waitForShimTimeout = 10.0
 var consoleFileMode = os.FileMode(0660)
 
 // ShimParams is the structure providing specific parameters needed


### PR DESCRIPTION
CRI-O assumes that anything related to the container should be able
to be unmounted after the container process returned after a kill.
In our case, we have a strong dependency on what should be done before
CRI-O can actually unmount storage because it is plugged into the VM.

This means we have to translate a kill as a stop when needed. The
condition for that is to detect when someone calling into kill would
actually expect to see the container completely stopped. This case
happens for SIGKILL and SIGTERM, and those are the conditions for
our runtime to consider stopping the container after it has been
signalled.

Fixes #1002

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>