### PR TITLE
vendor: Re-vendor virtcontainers to include changes in govmm.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
     "pkg/uuid",
     "pkg/vcMock"
   ]
-  revision = "6621b5d57f99532d6b3a52208a79f63ceaa41308"
+  revision = "000e6860d188dfc7a5be972ec0c2c386a09acf6f"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -94,7 +94,7 @@
 [[projects]]
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "9250e77eda726cbc468985582ce6de932c868bec"
+  revision = "d60256118ff05e570408e24c159171cca903e362"
 
 [[projects]]
   name = "github.com/kata-containers/agent"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1c4ba5d7c1522fc0689ad9e0432da9deb2ed26a53923e9d3170d2192dc36224d"
+  inputs-digest = "cd4649104e7076a2c0cf3601b104d08afae043fd5d76a500253af65f96903c47"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "6621b5d57f99532d6b3a52208a79f63ceaa41308"
+  revision = "000e6860d188dfc7a5be972ec0c2c386a09acf6f"
 
 [prune]
   non-go = true

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -166,7 +166,16 @@ func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (
 		Detach:    cmd.Detach,
 	}
 
-	pid, err := shim.start(*pod, shimParams)
+	netNS, err := pod.storage.fetchPodNetwork(pod.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	var pid int
+	err = pod.network.run(netNS.NetNsPath, func() (shimErr error) {
+		pid, shimErr = shim.start(*pod, shimParams)
+		return
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Re-vendor virtcontainers to bring latest changes in govmm for machine
option.

13d23e2 vendor: Re-vendor govmm
a43389e (origin/kata_crio_overlay) kata_agent: Ignore resources from the specification
1479051 kata_agent: Empty namespaces paths
a28064c kata_agent: Fix 9pfs rootfs
97be8e1 (origin/update_dep_vendoring) vendor: Update Gopkg.toml for new prune syntax
a0ee7ef vendor: Remove constraints from packages not directly vendored
195d71f Run cc-shim in the network namespace of pod

Fixes #1012

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>