### PR TITLE
logger: Fix nanosecond timestamps

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"log/syslog"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -58,8 +59,10 @@ func newSystemLogHook(network, raddr string) (*sysLogHook, error) {
 	}
 
 	return &sysLogHook{
-		formatter: new(logrus.TextFormatter),
-		shook:     hook,
+		formatter: &logrus.TextFormatter{
+			TimestampFormat: time.RFC3339Nano,
+		},
+		shook: hook,
 	}, nil
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -17,7 +17,10 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -58,4 +61,101 @@ func TestHandleSystemLog(t *testing.T) {
 			assert.NoError(err, fmt.Sprintf("%+v", d))
 		}
 	}
+}
+
+func TestNewSystemLogHook(t *testing.T) {
+	assert := assert.New(t)
+
+	hook, err := newSystemLogHook("", "")
+	assert.NoError(err)
+
+	msg := "wibble"
+	level := logrus.DebugLevel
+
+	logger := logrus.New()
+
+	// ensure all output is displayed
+	logger.Level = logrus.DebugLevel
+
+	// throw away all stdout so that the Format() call
+	// below returns the data in structured form.
+	logger.Out = ioutil.Discard
+
+	entry := &logrus.Entry{
+		Logger: logger,
+
+		// UTC for time.Parse()
+		Time: time.Now().UTC(),
+
+		Message: msg,
+		Level:   level,
+	}
+
+	// call the formatting function directly and see if the output
+	// matches what we expect.
+	bytes, err := hook.formatter.Format(entry)
+	assert.NoError(err)
+
+	output := string(bytes)
+	output = strings.TrimSpace(output)
+	output = strings.Replace(output, `"`, "", -1)
+
+	fields := strings.Fields(output)
+
+	msgFound := ""
+	timeFound := ""
+	levelFound := ""
+
+	// look for the expected fields
+	for _, field := range fields {
+
+		// split each structured field into name and value fields
+		f := strings.Split(field, "=")
+		assert.True(len(f) >= 2)
+
+		switch f[0] {
+		case "level":
+			levelFound = f[1]
+		case "msg":
+			msgFound = f[1]
+		case "time":
+			timeFound = f[1]
+		}
+	}
+
+	assert.Equal(levelFound, level.String())
+	assert.Equal(msgFound, msg)
+	assert.NotEqual(timeFound, "")
+
+	// Tell time.Parse() how to handle the timestamps by putting it into
+	// the standard golang time format equivalent to:
+	//
+	//     "Mon Jan 2 15:04:05 -0700 MST 2006".
+	//
+	expectedTimeFormat := "2006-01-02T15:04:05.999999999Z"
+
+	// Note that time.Parse() assumes a UTC time.
+	_, err = time.Parse(expectedTimeFormat, timeFound)
+	assert.NoError(err)
+
+	// time.Parse() is "clever" but also doesn't check anything more
+	// granular than a second, so let's be completely paranoid and check
+	// via regular expression too.
+	expectedPattern :=
+		// YYYY-MM-DD
+		`\d{4}-\d{2}-\d{2}` +
+			// time separator
+			`T` +
+			// HH:MM:SS
+			`\d{2}:\d{2}:\d{2}` +
+			// high-precision separator
+			`.` +
+			// nano-seconds
+			`\d{9}` +
+			// UTC timezone specifier
+			`Z`
+
+	expectedRE := regexp.MustCompile(expectedPattern)
+	matched := expectedRE.FindAllStringSubmatch(timeFound, -1)
+	assert.NotNil(matched, "expected time in format %q, got %q", expectedPattern, timeFound)
 }


### PR DESCRIPTION
PR #790 (specifically commit f98e61976904b8972b15345dc26cc38833104ffa)
regressed the logger by dropping the nanosecond timestamps that we used
to have in the global log.

Re-introduce nanosecond timestamps and add a new unit test to avoid
this re-regressing.

Fixes #1014.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>