### PR TITLE
logger: Fix nanosecond timestamp test

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -150,8 +150,10 @@ func TestNewSystemLogHook(t *testing.T) {
 			`\d{2}:\d{2}:\d{2}` +
 			// high-precision separator
 			`.` +
-			// nano-seconds
-			`\d{9}` +
+			// nano-seconds. Note that the quantifier range is
+			// required because the time.RFC3339Nano format
+			// trunctates trailing zeros.
+			`\d{1,9}` +
 			// UTC timezone specifier
 			`Z`
 


### PR DESCRIPTION
`TestNewSystemLogHook()` checks to ensure a nanonsecond timestamp is
generated. However, the `time.RFC3339Nano` time format truncates
trailing zeros meaning a nanosecond timestamp won't always have nine
digits.

Fixes #1017.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>