### PR TITLE
vendor: Re-vendor virtcontainers to bring ARM support.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
     "pkg/uuid",
     "pkg/vcMock"
   ]
-  revision = "000e6860d188dfc7a5be972ec0c2c386a09acf6f"
+  revision = "7d4e2f13a04aa73e0d876cdd7f1cf018d15e50bd"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cd4649104e7076a2c0cf3601b104d08afae043fd5d76a500253af65f96903c47"
+  inputs-digest = "88d909cca0b9930191219a931d164e1e5110a6b5ca1956d45d99dbc5a0fe3a33"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "000e6860d188dfc7a5be972ec0c2c386a09acf6f"
+  revision = "7d4e2f13a04aa73e0d876cdd7f1cf018d15e50bd"
 
 [prune]
   non-go = true

--- a/vendor/github.com/containers/virtcontainers/api.go
+++ b/vendor/github.com/containers/virtcontainers/api.go
@@ -32,7 +32,12 @@ var virtLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for virtcontainers package.
 func SetLogger(logger logrus.FieldLogger) {
-	virtLog = logger.WithField("source", "virtcontainers")
+	fields := logrus.Fields{
+		"source": "virtcontainers",
+		"arch":   runtime.GOARCH,
+	}
+
+	virtLog = logger.WithFields(fields)
 }
 
 // CreatePod is the virtcontainers pod creation entry point.
@@ -63,13 +68,13 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 	}
 
 	// Add the network
-	networkNS, err := p.network.add(*p, p.config.NetworkConfig, netNsPath, netNsCreated)
+	p.networkNS, err = p.network.add(*p, p.config.NetworkConfig, netNsPath, netNsCreated)
 	if err != nil {
 		return nil, err
 	}
 
 	// Store the network
-	err = p.storage.storePodNetwork(p.id, networkNS)
+	err = p.storage.storePodNetwork(p.id, p.networkNS)
 	if err != nil {
 		return nil, err
 	}
@@ -112,12 +117,6 @@ func DeletePod(podID string) (VCPod, error) {
 		return nil, err
 	}
 
-	// Fetch the network config
-	networkNS, err := p.storage.fetchPodNetwork(podID)
-	if err != nil {
-		return nil, err
-	}
-
 	// Stop shims
 	if err := p.stopShims(); err != nil {
 		return nil, err
@@ -130,8 +129,8 @@ func DeletePod(podID string) (VCPod, error) {
 	}
 
 	// Remove the network
-	if networkNS.NetNsCreated {
-		if err := p.network.remove(*p, networkNS); err != nil {
+	if p.networkNS.NetNsCreated {
+		if err := p.network.remove(*p, p.networkNS); err != nil {
 			return nil, err
 		}
 	}

--- a/vendor/github.com/containers/virtcontainers/bridge.go
+++ b/vendor/github.com/containers/virtcontainers/bridge.go
@@ -39,33 +39,6 @@ type Bridge struct {
 	ID string
 }
 
-// NewBridges creates n new pci(e) bridges depending of the machine type
-func NewBridges(n uint32, machine string) []Bridge {
-	var bridges []Bridge
-	var bt bridgeType
-
-	switch machine {
-	case QemuQ35:
-		// currently only pci bridges are supported
-		// qemu-2.10 will introduce pcie bridges
-		fallthrough
-	case QemuPC:
-		bt = pciBridge
-	default:
-		return nil
-	}
-
-	for i := uint32(0); i < n; i++ {
-		bridges = append(bridges, Bridge{
-			Type:    bt,
-			ID:      fmt.Sprintf("%s-bridge-%d", bt, i),
-			Address: make(map[uint32]string),
-		})
-	}
-
-	return bridges
-}
-
 // addDevice on success adds the device ID to the bridge and return the address
 // where the device was added, otherwise an error is returned
 func (b *Bridge) addDevice(ID string) (uint32, error) {

--- a/vendor/github.com/containers/virtcontainers/hyperstart_agent.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart_agent.go
@@ -171,18 +171,13 @@ func (h *hyper) processHyperRoute(route netlink.Route, deviceName string) *hyper
 }
 
 func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIface, []hyperstart.Route, error) {
-	networkNS, err := pod.storage.fetchPodNetwork(pod.id)
-	if err != nil {
-		return []hyperstart.NetworkIface{}, []hyperstart.Route{}, err
-	}
-
-	if networkNS.NetNsPath == "" {
+	if pod.networkNS.NetNsPath == "" {
 		return []hyperstart.NetworkIface{}, []hyperstart.Route{}, nil
 	}
 
 	var ifaces []hyperstart.NetworkIface
 	var routes []hyperstart.Route
-	for _, endpoint := range networkNS.Endpoints {
+	for _, endpoint := range pod.networkNS.Endpoints {
 		var ipAddresses []hyperstart.IPAddress
 		for _, addr := range endpoint.Properties().Addrs {
 			// Skip IPv6 because not supported by hyperstart.

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -414,6 +415,11 @@ func getHostMemorySizeKb(memInfoPath string) (uint64, error) {
 
 // RunningOnVMM checks if the system is running inside a VM.
 func RunningOnVMM(cpuInfoPath string) (bool, error) {
+	if runtime.GOARCH == "arm64" {
+		virtLog.Debugf("Unable to know if the system is running inside a VM")
+		return false, nil
+	}
+
 	flagsField := "flags"
 
 	f, err := os.Open(cpuInfoPath)
@@ -469,5 +475,4 @@ type hypervisor interface {
 	hotplugRemoveDevice(devInfo interface{}, devType deviceType) error
 	getPodConsole(podID string) string
 	capabilities() capabilities
-	getState() interface{}
 }

--- a/vendor/github.com/containers/virtcontainers/mock_hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/mock_hypervisor.go
@@ -71,7 +71,3 @@ func (m *mockHypervisor) hotplugRemoveDevice(devInfo interface{}, devType device
 func (m *mockHypervisor) getPodConsole(podID string) string {
 	return ""
 }
-
-func (m *mockHypervisor) getState() interface{} {
-	return nil
-}

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -464,6 +464,8 @@ type Pod struct {
 
 	state State
 
+	networkNS NetworkNamespace
+
 	lockFile *os.File
 
 	annotationsLock *sync.RWMutex
@@ -573,6 +575,12 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 	p, err := newPod(podConfig)
 	if err != nil {
 		return nil, err
+	}
+
+	// Fetch pod network to be able to access it from the pod structure.
+	networkNS, err := p.storage.fetchPodNetwork(p.id)
+	if err == nil {
+		p.networkNS = networkNS
 	}
 
 	// We first try to fetch the pod state from storage.

--- a/vendor/github.com/containers/virtcontainers/qemu_amd64.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_amd64.go
@@ -1,0 +1,214 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+)
+
+type qemuAmd64 struct {
+	// inherit from qemuArchBase, overwrite methods if needed
+	qemuArchBase
+}
+
+const defaultQemuPath = "/usr/bin/qemu-system-x86_64"
+
+const defaultQemuMachineType = QemuPC
+
+const defaultQemuMachineOptions = "accel=kvm,kernel_irqchip,nvdimm"
+
+const defaultPCBridgeBus = "pci.0"
+
+var qemuPaths = map[string]string{
+	QemuPCLite: "/usr/bin/qemu-lite-system-x86_64",
+	QemuPC:     defaultQemuPath,
+	QemuQ35:    defaultQemuPath,
+}
+
+var kernelParams = []Param{
+	{"root", "/dev/pmem0p1"},
+	{"rootflags", "dax,data=ordered,errors=remount-ro rw"},
+	{"rootfstype", "ext4"},
+	{"tsc", "reliable"},
+	{"no_timer_check", ""},
+	{"rcupdate.rcu_expedited", "1"},
+	{"i8042.direct", "1"},
+	{"i8042.dumbkbd", "1"},
+	{"i8042.nopnp", "1"},
+	{"i8042.noaux", "1"},
+	{"noreplace-smp", ""},
+	{"reboot", "k"},
+	{"console", "hvc0"},
+	{"console", "hvc1"},
+	{"iommu", "off"},
+	{"cryptomgr.notests", ""},
+	{"net.ifnames", "0"},
+	{"pci", "lastbus=0"},
+}
+
+var supportedQemuMachines = []govmmQemu.Machine{
+	{
+		Type:    QemuPCLite,
+		Options: defaultQemuMachineOptions,
+	},
+	{
+		Type:    QemuPC,
+		Options: defaultQemuMachineOptions,
+	},
+	{
+		Type:    QemuQ35,
+		Options: defaultQemuMachineOptions,
+	},
+}
+
+func newQemuArch(machineType string) qemuArch {
+	if machineType == "" {
+		machineType = defaultQemuMachineType
+	}
+
+	return &qemuAmd64{
+		qemuArchBase{
+			machineType:           machineType,
+			qemuPaths:             qemuPaths,
+			supportedQemuMachines: supportedQemuMachines,
+			kernelParamsNonDebug:  kernelParamsNonDebug,
+			kernelParamsDebug:     kernelParamsDebug,
+			kernelParams:          kernelParams,
+		},
+	}
+}
+
+func (q *qemuAmd64) capabilities() capabilities {
+	var caps capabilities
+
+	// Only pc machine type supports hotplugging drives
+	if q.machineType == QemuPC {
+		caps.setBlockDeviceHotplugSupport()
+	}
+
+	return caps
+}
+
+func (q *qemuAmd64) bridges(number uint32) []Bridge {
+	var bridges []Bridge
+	var bt bridgeType
+
+	switch q.machineType {
+	case QemuQ35:
+		// currently only pci bridges are supported
+		// qemu-2.10 will introduce pcie bridges
+		fallthrough
+	case QemuPC:
+		bt = pciBridge
+	default:
+		return nil
+	}
+
+	for i := uint32(0); i < number; i++ {
+		bridges = append(bridges, Bridge{
+			Type:    bt,
+			ID:      fmt.Sprintf("%s-bridge-%d", bt, i),
+			Address: make(map[uint32]string),
+		})
+	}
+
+	return bridges
+}
+
+func (q *qemuAmd64) cpuModel() string {
+	cpuModel := defaultCPUModel
+	if q.nestedRun {
+		cpuModel += ",pmu=off"
+	}
+	return cpuModel
+}
+
+func (q *qemuAmd64) memoryTopology(memoryMb, hostMemoryMb uint64) govmmQemu.Memory {
+	// NVDIMM device needs memory space 1024MB
+	// See https://github.com/clearcontainers/runtime/issues/380
+	memoryOffset := 1024
+
+	// add 1G memory space for nvdimm device (vm guest image)
+	memMax := fmt.Sprintf("%dM", hostMemoryMb+uint64(memoryOffset))
+
+	mem := fmt.Sprintf("%dM", memoryMb)
+
+	memory := govmmQemu.Memory{
+		Size:   mem,
+		Slots:  defaultMemSlots,
+		MaxMem: memMax,
+	}
+
+	return memory
+}
+
+func (q *qemuAmd64) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+	imageFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = imageFile.Close() }()
+
+	imageStat, err := imageFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	object := govmmQemu.Object{
+		Driver:   govmmQemu.NVDIMM,
+		Type:     govmmQemu.MemoryBackendFile,
+		DeviceID: "nv0",
+		ID:       "mem0",
+		MemPath:  path,
+		Size:     (uint64)(imageStat.Size()),
+	}
+
+	devices = append(devices, object)
+
+	return devices, nil
+}
+
+// appendBridges appends to devices the given bridges
+func (q *qemuAmd64) appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device {
+	bus := defaultPCBridgeBus
+	if q.machineType == QemuQ35 {
+		bus = defaultBridgeBus
+	}
+
+	for idx, b := range bridges {
+		t := govmmQemu.PCIBridge
+		if b.Type == pcieBridge {
+			t = govmmQemu.PCIEBridge
+		}
+
+		devices = append(devices,
+			govmmQemu.BridgeDevice{
+				Type: t,
+				Bus:  bus,
+				ID:   b.ID,
+				// Each bridge is required to be assigned a unique chassis id > 0
+				Chassis: (idx + 1),
+				SHPC:    true,
+			},
+		)
+	}
+
+	return devices
+}

--- a/vendor/github.com/containers/virtcontainers/qemu_arch_base.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_arch_base.go
@@ -1,0 +1,446 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+)
+
+type qemuArch interface {
+	// enableNestingChecks nesting checks will be honoured
+	enableNestingChecks()
+
+	// disableNestingChecks nesting checks will be ignored
+	disableNestingChecks()
+
+	// machine returns the machine type
+	machine() (govmmQemu.Machine, error)
+
+	// qemuPath returns the path to the QEMU binary
+	qemuPath() (string, error)
+
+	// kernelParameters returns the kernel parameters
+	// if debug is true then kernel debug parameters are included
+	kernelParameters(debug bool) []Param
+
+	//capabilities returns the capabilities supported by QEMU
+	capabilities() capabilities
+
+	// bridges returns the number bridges for the machine type
+	bridges(number uint32) []Bridge
+
+	// cpuTopology returns the CPU topology for the given amount of vcpus
+	cpuTopology(vcpus uint32) govmmQemu.SMP
+
+	// cpuModel returns the CPU model for the machine type
+	cpuModel() string
+
+	// memoryTopology returns the memory topology using the given amount of memoryMb and hostMemoryMb
+	memoryTopology(memoryMb, hostMemoryMb uint64) govmmQemu.Memory
+
+	// append9PVolumes appends volumes to devices
+	append9PVolumes(devices []govmmQemu.Device, volumes []Volume) []govmmQemu.Device
+
+	// appendConsole appends a console to devices
+	appendConsole(devices []govmmQemu.Device, path string) []govmmQemu.Device
+
+	// appendImage appends an image to devices
+	appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
+
+	// appendBridges appends bridges to devices
+	appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device
+
+	// append9PVolume appends a 9P volume to devices
+	append9PVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device
+
+	// appendSocket appends a socket to devices
+	appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device
+
+	// appendNetwork appends a endpoint device to devices
+	appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device
+
+	// appendBlockDevice appends a block drive to devices
+	appendBlockDevice(devices []govmmQemu.Device, drive Drive) []govmmQemu.Device
+
+	// appendVhostUserDevice appends a vhost user device to devices
+	appendVhostUserDevice(devices []govmmQemu.Device, vhostUserDevice VhostUserDevice) []govmmQemu.Device
+
+	// appendVFIODevice appends a VFIO device to devices
+	appendVFIODevice(devices []govmmQemu.Device, vfioDevice VFIODevice) []govmmQemu.Device
+}
+
+type qemuArchBase struct {
+	machineType           string
+	nestedRun             bool
+	networkIndex          int
+	qemuPaths             map[string]string
+	supportedQemuMachines []govmmQemu.Machine
+	kernelParamsNonDebug  []Param
+	kernelParamsDebug     []Param
+	kernelParams          []Param
+}
+
+const (
+	defaultCores     uint32 = 1
+	defaultThreads   uint32 = 1
+	defaultMemSlots  uint8  = 2
+	defaultCPUModel         = "host"
+	defaultBridgeBus        = "pcie.0"
+	maxDevIDSize            = 31
+)
+
+const (
+	// QemuPCLite is the QEMU pc-lite machine type for amd64
+	QemuPCLite = "pc-lite"
+
+	// QemuPC is the QEMU pc machine type for amd64
+	QemuPC = "pc"
+
+	// QemuQ35 is the QEMU Q35 machine type for amd64
+	QemuQ35 = "q35"
+
+	// QemuVirt is the QEMU virt machine type for aarch64
+	QemuVirt = "virt"
+)
+
+// kernelParamsNonDebug is a list of the default kernel
+// parameters that will be used in standard (non-debug) mode.
+var kernelParamsNonDebug = []Param{
+	{"quiet", ""},
+	{"systemd.show_status", "false"},
+}
+
+// kernelParamsDebug is a list of the default kernel
+// parameters that will be used in debug mode (as much boot output as
+// possible).
+var kernelParamsDebug = []Param{
+	{"debug", ""},
+	{"systemd.show_status", "true"},
+	{"systemd.log_level", "debug"},
+}
+
+func (q *qemuArchBase) enableNestingChecks() {
+	q.nestedRun = true
+}
+
+func (q *qemuArchBase) disableNestingChecks() {
+	q.nestedRun = false
+}
+
+func (q *qemuArchBase) machine() (govmmQemu.Machine, error) {
+	for _, m := range q.supportedQemuMachines {
+		if m.Type == q.machineType {
+			return m, nil
+		}
+	}
+
+	return govmmQemu.Machine{}, fmt.Errorf("unrecognised machine type: %v", q.machineType)
+}
+
+func (q *qemuArchBase) qemuPath() (string, error) {
+	p, ok := q.qemuPaths[q.machineType]
+	if !ok {
+		return "", fmt.Errorf("Unknown machine type: %s", q.machineType)
+	}
+
+	return p, nil
+}
+
+func (q *qemuArchBase) kernelParameters(debug bool) []Param {
+	params := q.kernelParams
+
+	if debug {
+		params = append(params, q.kernelParamsDebug...)
+	} else {
+		params = append(params, q.kernelParamsNonDebug...)
+	}
+
+	return params
+}
+
+func (q *qemuArchBase) capabilities() capabilities {
+	var caps capabilities
+	caps.setBlockDeviceHotplugSupport()
+	return caps
+}
+
+func (q *qemuArchBase) bridges(number uint32) []Bridge {
+	var bridges []Bridge
+
+	for i := uint32(0); i < number; i++ {
+		bridges = append(bridges, Bridge{
+			Type:    pciBridge,
+			ID:      fmt.Sprintf("%s-bridge-%d", pciBridge, i),
+			Address: make(map[uint32]string),
+		})
+	}
+
+	return bridges
+}
+
+func (q *qemuArchBase) cpuTopology(vcpus uint32) govmmQemu.SMP {
+	smp := govmmQemu.SMP{
+		CPUs:    vcpus,
+		Sockets: vcpus,
+		Cores:   defaultCores,
+		Threads: defaultThreads,
+	}
+
+	return smp
+}
+
+func (q *qemuArchBase) cpuModel() string {
+	return defaultCPUModel
+}
+
+func (q *qemuArchBase) memoryTopology(memoryMb, hostMemoryMb uint64) govmmQemu.Memory {
+	memMax := fmt.Sprintf("%dM", hostMemoryMb)
+	mem := fmt.Sprintf("%dM", memoryMb)
+	memory := govmmQemu.Memory{
+		Size:   mem,
+		Slots:  defaultMemSlots,
+		MaxMem: memMax,
+	}
+
+	return memory
+}
+
+func (q *qemuArchBase) append9PVolumes(devices []govmmQemu.Device, volumes []Volume) []govmmQemu.Device {
+	// Add the shared volumes
+	for _, v := range volumes {
+		devices = q.append9PVolume(devices, v)
+	}
+
+	return devices
+}
+
+func (q *qemuArchBase) appendConsole(devices []govmmQemu.Device, path string) []govmmQemu.Device {
+	serial := govmmQemu.SerialDevice{
+		Driver:        govmmQemu.VirtioSerial,
+		ID:            "serial0",
+		DisableModern: q.nestedRun,
+	}
+
+	devices = append(devices, serial)
+
+	var console govmmQemu.CharDevice
+
+	console = govmmQemu.CharDevice{
+		Driver:   govmmQemu.Console,
+		Backend:  govmmQemu.Socket,
+		DeviceID: "console0",
+		ID:       "charconsole0",
+		Path:     path,
+	}
+
+	devices = append(devices, console)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, err
+	}
+
+	randBytes, err := generateRandomBytes(8)
+	if err != nil {
+		return nil, err
+	}
+
+	id := makeNameID("image", hex.EncodeToString(randBytes))
+
+	drive := Drive{
+		File:   path,
+		Format: "raw",
+		ID:     id,
+	}
+
+	return q.appendBlockDevice(devices, drive), nil
+}
+
+// appendBridges appends to devices the given bridges
+func (q *qemuArchBase) appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device {
+	for idx, b := range bridges {
+		t := govmmQemu.PCIBridge
+		if b.Type == pcieBridge {
+			t = govmmQemu.PCIEBridge
+		}
+
+		devices = append(devices,
+			govmmQemu.BridgeDevice{
+				Type: t,
+				Bus:  defaultBridgeBus,
+				ID:   b.ID,
+				// Each bridge is required to be assigned a unique chassis id > 0
+				Chassis: (idx + 1),
+				SHPC:    true,
+			},
+		)
+	}
+
+	return devices
+}
+
+func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device {
+	if volume.MountTag == "" || volume.HostPath == "" {
+		return devices
+	}
+
+	devID := fmt.Sprintf("extra-9p-%s", volume.MountTag)
+	if len(devID) > maxDevIDSize {
+		devID = devID[:maxDevIDSize]
+	}
+
+	devices = append(devices,
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
+			ID:            devID,
+			Path:          volume.HostPath,
+			MountTag:      volume.MountTag,
+			SecurityModel: govmmQemu.None,
+			DisableModern: q.nestedRun,
+		},
+	)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device {
+	devID := socket.ID
+	if len(devID) > maxDevIDSize {
+		devID = devID[:maxDevIDSize]
+	}
+
+	devices = append(devices,
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.VirtioSerialPort,
+			Backend:  govmmQemu.Socket,
+			DeviceID: socket.DeviceID,
+			ID:       devID,
+			Path:     socket.HostPath,
+			Name:     socket.Name,
+		},
+	)
+
+	return devices
+}
+
+func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType {
+	switch model {
+	case NetXConnectBridgedModel:
+		return govmmQemu.MACVTAP //TODO: We should rename MACVTAP to .NET_FD
+	case NetXConnectMacVtapModel:
+		return govmmQemu.MACVTAP
+	//case ModelEnlightened:
+	// Here the Network plugin will create a VM native interface
+	// which could be MacVtap, IpVtap, SRIOV, veth-tap, vhost-user
+	// In these cases we will determine the interface type here
+	// and pass in the native interface through
+	default:
+		//TAP should work for most other cases
+		return govmmQemu.TAP
+	}
+}
+
+func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device {
+	switch ep := endpoint.(type) {
+	case *VirtualEndpoint:
+		devices = append(devices,
+			govmmQemu.NetDevice{
+				Type:          networkModelToQemuType(ep.NetPair.NetInterworkingModel),
+				Driver:        govmmQemu.VirtioNetPCI,
+				ID:            fmt.Sprintf("network-%d", q.networkIndex),
+				IFName:        ep.NetPair.TAPIface.Name,
+				MACAddress:    ep.NetPair.TAPIface.HardAddr,
+				DownScript:    "no",
+				Script:        "no",
+				VHost:         true,
+				DisableModern: q.nestedRun,
+				FDs:           ep.NetPair.VMFds,
+				VhostFDs:      ep.NetPair.VhostFds,
+			},
+		)
+		q.networkIndex++
+	}
+
+	return devices
+}
+
+func (q *qemuArchBase) appendBlockDevice(devices []govmmQemu.Device, drive Drive) []govmmQemu.Device {
+	if drive.File == "" || drive.ID == "" || drive.Format == "" {
+		return devices
+	}
+
+	if len(drive.ID) > maxDevIDSize {
+		drive.ID = drive.ID[:maxDevIDSize]
+	}
+
+	devices = append(devices,
+		govmmQemu.BlockDevice{
+			Driver:        govmmQemu.VirtioBlock,
+			ID:            drive.ID,
+			File:          drive.File,
+			AIO:           govmmQemu.Threads,
+			Format:        govmmQemu.BlockDeviceFormat(drive.Format),
+			Interface:     "none",
+			DisableModern: q.nestedRun,
+		},
+	)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendVhostUserDevice(devices []govmmQemu.Device, vhostUserDevice VhostUserDevice) []govmmQemu.Device {
+	qemuVhostUserDevice := govmmQemu.VhostUserDevice{}
+
+	switch vhostUserDevice := vhostUserDevice.(type) {
+	case *VhostUserNetDevice:
+		qemuVhostUserDevice.TypeDevID = makeNameID("net", vhostUserDevice.ID)
+		qemuVhostUserDevice.Address = vhostUserDevice.MacAddress
+	case *VhostUserSCSIDevice:
+		qemuVhostUserDevice.TypeDevID = makeNameID("scsi", vhostUserDevice.ID)
+	case *VhostUserBlkDevice:
+	}
+
+	qemuVhostUserDevice.VhostUserType = govmmQemu.VhostUserDeviceType(vhostUserDevice.Type())
+	qemuVhostUserDevice.SocketPath = vhostUserDevice.Attrs().SocketPath
+	qemuVhostUserDevice.CharDevID = makeNameID("char", vhostUserDevice.Attrs().ID)
+
+	devices = append(devices, qemuVhostUserDevice)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDevice VFIODevice) []govmmQemu.Device {
+	if vfioDevice.BDF == "" {
+		return devices
+	}
+
+	devices = append(devices,
+		govmmQemu.VFIODevice{
+			BDF: vfioDevice.BDF,
+		},
+	)
+
+	return devices
+}

--- a/vendor/github.com/containers/virtcontainers/qemu_arm64.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_arm64.go
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import govmmQemu "github.com/intel/govmm/qemu"
+
+type qemuArm64 struct {
+	// inherit from qemuArchBase, overwrite methods if needed
+	qemuArchBase
+}
+
+const defaultQemuPath = "/usr/bin/qemu-system-aarch64"
+
+const defaultQemuMachineType = QemuVirt
+
+const defaultQemuMachineOptions = "gic-version=host,usb=off,accel=kvm"
+
+var qemuPaths = map[string]string{
+	QemuVirt: defaultQemuPath,
+}
+
+var kernelParams = []Param{
+	{"root", "/dev/vda1"},
+	{"console", "ttyAMA0"},
+	{"iommu.passthrough", "0"},
+}
+
+var supportedQemuMachines = []govmmQemu.Machine{
+	{
+		Type:    QemuVirt,
+		Options: defaultQemuMachineOptions,
+	},
+}
+
+func newQemuArch(machineType string) qemuArch {
+	if machineType == "" {
+		machineType = defaultQemuMachineType
+	}
+
+	return &qemuArm64{
+		qemuArchBase{
+			machineType:           machineType,
+			qemuPaths:             qemuPaths,
+			supportedQemuMachines: supportedQemuMachines,
+			kernelParamsNonDebug:  kernelParamsNonDebug,
+			kernelParamsDebug:     kernelParamsDebug,
+			kernelParams:          kernelParams,
+		},
+	}
+}

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -166,17 +166,11 @@ func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (
 		Detach:    cmd.Detach,
 	}
 
-	netNS, err := pod.storage.fetchPodNetwork(pod.ID())
-	if err != nil {
-		return nil, err
-	}
-
 	var pid int
-	err = pod.network.run(netNS.NetNsPath, func() (shimErr error) {
+	if err := pod.network.run(pod.networkNS.NetNsPath, func() (shimErr error) {
 		pid, shimErr = shim.start(*pod, shimParams)
 		return
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This will add ARM support into the runtime.

5236b92 documentation: Add API usage example
77c41ca documentation: Add short container 1.0 API description
0fbae82 documentation: Add short pod 1.0 API description
5a2d207 documentation: Document the 1.0 API
1ccb3a4  pod: Fetch pod network only from createPod()
563c175 qemu: change function names
d8a6dd3 qemu: update qemu init
b877182 qemu: add support for ARM
485b51b hypervisor: remove getState function

Fixes #1019

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>