### PR TITLE
logging: Add CLI command to logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,6 +202,13 @@ func beforeSubcommands(context *cli.Context) error {
 
 	ignoreLogging := false
 
+	// Add the name of the sub-command to each log entry for easier
+	// debugging.
+	name := context.Args().First()
+	if context.App.Command(name) != nil {
+		ccLog = ccLog.WithField("command", name)
+	}
+
 	if context.NArg() == 1 && context.Args()[0] == envCmd {
 		// simply report the logging setup
 		ignoreLogging = true


### PR DESCRIPTION
Since the runtime is called multiple times by the container manager, add
the command-line sub-command name to all log entries to make it clear
which command was running when a particular log message was produced.

Note that CLI arguments are already logged once at runtime startup. This
change is more useful for the scenarios where only a log excerpt is
available (for example when running `cc-collect-data.sh` which only
extracts error logs).

Fixes #1024.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>