### PR TITLE
config: don't exceed the number of physical cores

### DIFF
--- a/config.go
+++ b/config.go
@@ -185,14 +185,13 @@ func (h hypervisor) machineType() string {
 }
 
 func (h hypervisor) defaultVCPUs() uint32 {
-	if h.DefaultVCPUs < 0 {
-		return uint32(goruntime.NumCPU())
+	numCPUs := goruntime.NumCPU()
+
+	if h.DefaultVCPUs < 0 || h.DefaultVCPUs > int32(numCPUs) {
+		return uint32(numCPUs)
 	}
 	if h.DefaultVCPUs == 0 { // or unspecified
 		return defaultVCPUCount
-	}
-	if h.DefaultVCPUs > 255 { // qemu supports max 255
-		return 255
 	}
 
 	return uint32(h.DefaultVCPUs)

--- a/config/configuration.toml.in
+++ b/config/configuration.toml.in
@@ -33,10 +33,10 @@ firmware = "@FIRMWAREPATH@"
 machine_accelerators="@MACHINEACCELERATORS@"
 
 # Default number of vCPUs per POD/VM:
-# unspecified or 0 --> will be set to @DEFVCPUS@
-# < 0              --> will be set to the actual number of physical cores
-# > 0 <= 255       --> will be set to the specified number
-# > 255            --> will be set to 255
+# unspecified or 0                --> will be set to @DEFVCPUS@
+# < 0                             --> will be set to the actual number of physical cores
+# > 0 <= number of physical cores --> will be set to the specified number
+# > number of physical cores      --> will be set to the actual number of physical cores
 default_vcpus = -1
 
 

--- a/config_test.go
+++ b/config_test.go
@@ -668,9 +668,9 @@ func TestHypervisorDefaults(t *testing.T) {
 	h.DefaultVCPUs = 2
 	assert.Equal(h.defaultVCPUs(), uint32(2), "default vCPU number is wrong")
 
-	// qemu supports max 255
-	h.DefaultVCPUs = 8086
-	assert.Equal(h.defaultVCPUs(), uint32(255), "default vCPU number is wrong")
+	numCPUs := goruntime.NumCPU()
+	h.DefaultVCPUs = int32(numCPUs) + 1
+	assert.Equal(h.defaultVCPUs(), uint32(numCPUs), "default vCPU number is wrong")
 
 	h.DefaultMemSz = 1024
 	assert.Equal(h.defaultMemSz(), uint32(1024), "default memory size is wrong")
@@ -1017,7 +1017,7 @@ func TestUpdateRuntimeConfiguration(t *testing.T) {
 func TestUpdateRuntimeConfigurationVMConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	vcpus := uint(8)
+	vcpus := uint(2)
 	mem := uint(2048)
 
 	config := oci.RuntimeConfig{}


### PR DESCRIPTION
the maximum number of vCPUs per VM shouldn't not exceed
the number of physical cores, otherwise we could face issues
with KVM and other architectures

fixes #1028

Signed-off-by: Julio Montes <julio.montes@intel.com>