### PR TITLE
Logging fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,8 @@ var savedCLIVersionPrinter = cli.VersionPrinter
 var savedCLIErrWriter = cli.ErrWriter
 
 func init() {
-	ccLog = logrus.WithField(logrus.Fields{
+	ccLog = logrus.WithFields(logrus.Fields{
+		"name":   name,
 		"source": "runtime",
 		"pid":    os.Getpid(),
 	})
@@ -207,9 +208,9 @@ func beforeSubcommands(context *cli.Context) error {
 
 	// Add the name of the sub-command to each log entry for easier
 	// debugging.
-	name := context.Args().First()
-	if context.App.Command(name) != nil {
-		ccLog = ccLog.WithField("command", name)
+	cmdName := context.Args().First()
+	if context.App.Command(cmdName) != nil {
+		ccLog = ccLog.WithField("command", cmdName)
 	}
 
 	if context.NArg() == 1 && context.Args()[0] == envCmd {
@@ -225,7 +226,6 @@ func beforeSubcommands(context *cli.Context) error {
 	args := strings.Join(context.Args(), " ")
 
 	fields := logrus.Fields{
-		"name":      name,
 		"version":   version,
 		"commit":    commit,
 		"arguments": `"` + args + `"`,

--- a/main.go
+++ b/main.go
@@ -141,7 +141,10 @@ var savedCLIVersionPrinter = cli.VersionPrinter
 var savedCLIErrWriter = cli.ErrWriter
 
 func init() {
-	ccLog = logrus.WithField("source", "runtime")
+	ccLog = logrus.WithField(logrus.Fields{
+		"source": "runtime",
+		"pid":    os.Getpid(),
+	})
 
 	// Save the original log level and then set to debug level to ensure
 	// that any problems detected before the config file is parsed are


### PR DESCRIPTION
logging: Add name to all log calls

Fixed a bug whereby PR #1025 created a `name` variable that masked the
main variable of the same name (containing the program name). Changed
the logic slightly so that all log entries now include the program name.

logging: Add PID field to logs

Add process ID to log entries.

Fixes #1030.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>