### PR TITLE
fedora-installation-guide: update Fedora versions supported

### DIFF
--- a/docs/fedora-installation-guide.md
+++ b/docs/fedora-installation-guide.md
@@ -5,7 +5,7 @@ Note:
 If you are installing on a system that already has Clear Containers 2.x
 installed, first read [the upgrading document](upgrading.md).
 
-Clear Containers **3.0** is available for Fedora\* versions **24** , **25** and **26**.
+Clear Containers **3.0** is available for Fedora\* versions **26** and **27**.
 
 This step is only required in case Docker is not installed on the system.
 1. Install the latest version of Docker with the following commands:


### PR DESCRIPTION
Update the versions of Fedora that are supported by Clear
Containers 3.0 to Fedora 26 and 27. These are the only Fedora
versions currently available in OpenSUSE OBS repo
(http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>