### PR TITLE
vendor: update virtcontainers to pull in latest kata gRPC updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
     "pkg/uuid",
     "pkg/vcMock"
   ]
-  revision = "7d4e2f13a04aa73e0d876cdd7f1cf018d15e50bd"
+  revision = "6bccdf63e8c47e294c9e320aaa1c7b30e35350ca"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -102,7 +102,7 @@
     "protocols/client",
     "protocols/grpc"
   ]
-  revision = "3f6f6da6d469c31364aac417f336ec0d16772095"
+  revision = "11f8b0ad0a3bb5771b88cbccd0a9c7dca5fd8e56"
 
 [[projects]]
   name = "github.com/kubernetes-incubator/cri-o"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "88d909cca0b9930191219a931d164e1e5110a6b5ca1956d45d99dbc5a0fe3a33"
+  inputs-digest = "032b1bb9f90dff62d5349c63347fdd732199130dc7eaedd26625e0cfa02861d4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "7d4e2f13a04aa73e0d876cdd7f1cf018d15e50bd"
+  revision = "6bccdf63e8c47e294c9e320aaa1c7b30e35350ca"
 
 [prune]
   non-go = true

--- a/vendor/github.com/containers/virtcontainers/device.go
+++ b/vendor/github.com/containers/virtcontainers/device.go
@@ -340,7 +340,11 @@ type BlockDevice struct {
 	DeviceType string
 	DeviceInfo DeviceInfo
 
-	// Path at which the device appears inside the VM, outside of the container mount namespace.
+	// SCSI Address of the block device, in case the device is attached using SCSI driver
+	// SCSI address is in the format SCSI-Id:LUN
+	SCSIAddr string
+
+	// Path at which the device appears inside the VM, outside of the container mount namespace
 	VirtPath string
 }
 
@@ -359,12 +363,6 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 
 	device.DeviceInfo.ID = hex.EncodeToString(randBytes)
 
-	drive := Drive{
-		File:   device.DeviceInfo.HostPath,
-		Format: "raw",
-		ID:     makeNameID("drive", device.DeviceInfo.ID),
-	}
-
 	// Increment the block index for the pod. This is used to determine the name
 	// for the block device in the case where the block device is used as container
 	// rootfs and the predicted block device name needs to be provided to the agent.
@@ -380,6 +378,13 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 		return err
 	}
 
+	drive := Drive{
+		File:   device.DeviceInfo.HostPath,
+		Format: "raw",
+		ID:     makeNameID("drive", device.DeviceInfo.ID),
+		Index:  index,
+	}
+
 	driveName, err := getVirtDriveName(index)
 	if err != nil {
 		return err
@@ -393,7 +398,17 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 
 	device.DeviceInfo.Hotplugged = true
 
-	device.VirtPath = filepath.Join("/dev", driveName)
+	if c.pod.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
+		device.VirtPath = filepath.Join("/dev", driveName)
+	} else {
+		scsiAddr, err := getSCSIAddress(index)
+		if err != nil {
+			return err
+		}
+
+		device.SCSIAddr = scsiAddr
+	}
+
 	return nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -47,6 +47,8 @@ const (
 	defaultMemSzMiB = 2048
 
 	defaultBridges = 1
+
+	defaultBlockDriver = VirtioSCSI
 )
 
 // deviceType describes a virtualized device type.
@@ -155,6 +157,10 @@ type HypervisorConfig struct {
 	// DisableBlockDeviceUse disallows a block device from being used.
 	DisableBlockDeviceUse bool
 
+	// BlockDeviceDriver specifies the driver to be used for block device
+	// either VirtioSCSI or VirtioBlock with the default driver being defaultBlockDriver
+	BlockDeviceDriver string
+
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 
@@ -225,6 +231,10 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 
 	if conf.DefaultBridges == 0 {
 		conf.DefaultBridges = defaultBridges
+	}
+
+	if conf.BlockDeviceDriver == "" {
+		conf.BlockDeviceDriver = defaultBlockDriver
 	}
 
 	return true, nil

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -133,6 +133,7 @@ type FsmapDescriptor struct {
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
 	AbsolutePath bool   `json:"absolutePath"`
+	SCSIAddr     string `json:"scsiAddr"`
 }
 
 // EnvironmentVar holds an environment variable and its value.
@@ -207,7 +208,7 @@ type Container struct {
 	Rootfs           string              `json:"rootfs"`
 	Fstype           string              `json:"fstype,omitempty"`
 	Image            string              `json:"image"`
-	Addr             string              `json:"addr,omitempty"`
+	SCSIAddr         string              `json:"scsiAddr,omitempty"`
 	Volumes          []*VolumeDescriptor `json:"volumes,omitempty"`
 	Fsmap            []*FsmapDescriptor  `json:"fsmap,omitempty"`
 	Sysctl           map[string]string   `json:"sysctl,omitempty"`

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -76,6 +76,10 @@ const (
 	removeDevice
 )
 
+const (
+	scsiControllerID = "scsi0"
+)
+
 type qmpLogger struct {
 	logger *logrus.Entry
 }
@@ -328,7 +332,6 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 
 	devices = q.arch.append9PVolumes(devices, podConfig.Volumes)
 	devices = q.arch.appendConsole(devices, q.getPodConsole(podConfig.ID))
-	devices = q.arch.appendBridges(devices, q.state.Bridges)
 
 	imagePath, err := q.config.ImageAssetPath()
 	if err != nil {
@@ -338,6 +341,15 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 	devices, err = q.arch.appendImage(devices, imagePath)
 	if err != nil {
 		return err
+	}
+
+	if q.config.BlockDeviceDriver == VirtioBlock {
+		devices = q.arch.appendBridges(devices, q.state.Bridges)
+		if err != nil {
+			return err
+		}
+	} else {
+		devices = q.arch.appendSCSIController(devices)
 	}
 
 	cpuModel := q.arch.cpuModel()
@@ -578,22 +590,30 @@ func (q *qemu) hotplugBlockDevice(drive Drive, op operation) error {
 			return err
 		}
 
-		driver := "virtio-blk-pci"
+		if q.config.BlockDeviceDriver == VirtioBlock {
+			driver := "virtio-blk-pci"
+			addr, bus, err := q.addDeviceToBridge(drive.ID)
 
-		addr, bus, err := q.addDeviceToBridge(drive.ID)
-		if err != nil {
-			return err
+			if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bus); err != nil {
+				return err
+			}
+		} else {
+			driver := "scsi-hd"
+
+			// Bus exposed by the SCSI Controller
+			bus := scsiControllerID + ".0"
+
+			// Get SCSI-id and LUN based on the order of attaching drives.
+			scsiID, lun, err := getSCSIIdLun(drive.Index)
+			if err != nil {
+				return err
+			}
+
+			if err = q.qmpMonitorCh.qmp.ExecuteSCSIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, bus, scsiID, lun); err != nil {
+				return err
+			}
 		}
-
-		if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bus); err != nil {
-			return err
-		}
-
 	} else {
-		if err := q.removeDeviceFromBridge(drive.ID); err != nil {
-			return err
-		}
-
 		if err := q.qmpMonitorCh.qmp.ExecuteDeviceDel(q.qmpMonitorCh.ctx, devID); err != nil {
 			return err
 		}

--- a/vendor/github.com/containers/virtcontainers/qemu_arch_base.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_arch_base.go
@@ -65,6 +65,9 @@ type qemuArch interface {
 	// appendImage appends an image to devices
 	appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
 
+	// appendSCSIController appens a SCSI controller to devices
+	appendSCSIController(devices []govmmQemu.Device) []govmmQemu.Device
+
 	// appendBridges appends bridges to devices
 	appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device
 
@@ -105,6 +108,14 @@ const (
 	defaultCPUModel         = "host"
 	defaultBridgeBus        = "pcie.0"
 	maxDevIDSize            = 31
+)
+
+const (
+	// VirtioBlock means use virtio-blk for hotplugging drives
+	VirtioBlock = "virtio-blk"
+
+	// VirtioSCSI means use virtio-scsi for hotplugging drives
+	VirtioSCSI = "virtio-scsi"
 )
 
 const (
@@ -275,6 +286,16 @@ func (q *qemuArchBase) appendImage(devices []govmmQemu.Device, path string) ([]g
 	}
 
 	return q.appendBlockDevice(devices, drive), nil
+}
+
+func (q *qemuArchBase) appendSCSIController(devices []govmmQemu.Device) []govmmQemu.Device {
+	scsiController := govmmQemu.SCSIController{
+		ID: scsiControllerID,
+	}
+
+	devices = append(devices, scsiController)
+
+	return devices
 }
 
 // appendBridges appends to devices the given bridges

--- a/vendor/github.com/kata-containers/agent/protocols/client/client.go
+++ b/vendor/github.com/kata-containers/agent/protocols/client/client.go
@@ -7,6 +7,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -46,9 +47,12 @@ func NewAgentClient(sock string) (*AgentClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(dialTimeout)}
+	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
 	dialOpts = append(dialOpts, grpc.WithDialer(agentDialer(parsedAddr)))
-	conn, err := grpc.Dial(grpcAddr, dialOpts...)
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, grpcAddr, dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/agent.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/agent.pb.go
@@ -28,10 +28,11 @@
 		IPAddress
 		Interface
 		Route
+		Routes
+		UpdateInterfaceRequest
 		AddInterfaceRequest
 		RemoveInterfaceRequest
-		UpdateInterfaceRequest
-		RouteRequest
+		UpdateRoutesRequest
 		OnlineCPUMemRequest
 		Storage
 		StringUser
@@ -113,36 +114,6 @@ func (x IPFamily) String() string {
 	return proto.EnumName(IPFamily_name, int32(x))
 }
 func (IPFamily) EnumDescriptor() ([]byte, []int) { return fileDescriptorAgent, []int{0} }
-
-type UpdateType int32
-
-const (
-	UpdateType_None     UpdateType = 0
-	UpdateType_AddIP    UpdateType = 1
-	UpdateType_RemoveIP UpdateType = 2
-	UpdateType_Name     UpdateType = 4
-	UpdateType_MTU      UpdateType = 8
-)
-
-var UpdateType_name = map[int32]string{
-	0: "None",
-	1: "AddIP",
-	2: "RemoveIP",
-	4: "Name",
-	8: "MTU",
-}
-var UpdateType_value = map[string]int32{
-	"None":     0,
-	"AddIP":    1,
-	"RemoveIP": 2,
-	"Name":     4,
-	"MTU":      8,
-}
-
-func (x UpdateType) String() string {
-	return proto.EnumName(UpdateType_name, int32(x))
-}
-func (UpdateType) EnumDescriptor() ([]byte, []int) { return fileDescriptorAgent, []int{1} }
 
 type CreateContainerRequest struct {
 	ContainerId string      `protobuf:"bytes,1,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
@@ -595,7 +566,7 @@ func (m *IPAddress) GetMask() string {
 type Interface struct {
 	Device      string       `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
 	Name        string       `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	IpAddresses []*IPAddress `protobuf:"bytes,3,rep,name=ipAddresses" json:"ipAddresses,omitempty"`
+	IPAddresses []*IPAddress `protobuf:"bytes,3,rep,name=IPAddresses" json:"IPAddresses,omitempty"`
 	Mtu         uint64       `protobuf:"varint,4,opt,name=mtu,proto3" json:"mtu,omitempty"`
 	HwAddr      string       `protobuf:"bytes,5,opt,name=hwAddr,proto3" json:"hwAddr,omitempty"`
 }
@@ -619,9 +590,9 @@ func (m *Interface) GetName() string {
 	return ""
 }
 
-func (m *Interface) GetIpAddresses() []*IPAddress {
+func (m *Interface) GetIPAddresses() []*IPAddress {
 	if m != nil {
-		return m.IpAddresses
+		return m.IPAddresses
 	}
 	return nil
 }
@@ -644,6 +615,8 @@ type Route struct {
 	Dest    string `protobuf:"bytes,1,opt,name=dest,proto3" json:"dest,omitempty"`
 	Gateway string `protobuf:"bytes,2,opt,name=gateway,proto3" json:"gateway,omitempty"`
 	Device  string `protobuf:"bytes,3,opt,name=device,proto3" json:"device,omitempty"`
+	Source  string `protobuf:"bytes,4,opt,name=source,proto3" json:"source,omitempty"`
+	Scope   uint32 `protobuf:"varint,5,opt,name=scope,proto3" json:"scope,omitempty"`
 }
 
 func (m *Route) Reset()                    { *m = Route{} }
@@ -672,6 +645,52 @@ func (m *Route) GetDevice() string {
 	return ""
 }
 
+func (m *Route) GetSource() string {
+	if m != nil {
+		return m.Source
+	}
+	return ""
+}
+
+func (m *Route) GetScope() uint32 {
+	if m != nil {
+		return m.Scope
+	}
+	return 0
+}
+
+type Routes struct {
+	Routes []*Route `protobuf:"bytes,1,rep,name=Routes" json:"Routes,omitempty"`
+}
+
+func (m *Routes) Reset()                    { *m = Routes{} }
+func (m *Routes) String() string            { return proto.CompactTextString(m) }
+func (*Routes) ProtoMessage()               {}
+func (*Routes) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{18} }
+
+func (m *Routes) GetRoutes() []*Route {
+	if m != nil {
+		return m.Routes
+	}
+	return nil
+}
+
+type UpdateInterfaceRequest struct {
+	Interface *Interface `protobuf:"bytes,1,opt,name=interface" json:"interface,omitempty"`
+}
+
+func (m *UpdateInterfaceRequest) Reset()                    { *m = UpdateInterfaceRequest{} }
+func (m *UpdateInterfaceRequest) String() string            { return proto.CompactTextString(m) }
+func (*UpdateInterfaceRequest) ProtoMessage()               {}
+func (*UpdateInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{19} }
+
+func (m *UpdateInterfaceRequest) GetInterface() *Interface {
+	if m != nil {
+		return m.Interface
+	}
+	return nil
+}
+
 type AddInterfaceRequest struct {
 	Interface *Interface `protobuf:"bytes,1,opt,name=interface" json:"interface,omitempty"`
 }
@@ -679,7 +698,7 @@ type AddInterfaceRequest struct {
 func (m *AddInterfaceRequest) Reset()                    { *m = AddInterfaceRequest{} }
 func (m *AddInterfaceRequest) String() string            { return proto.CompactTextString(m) }
 func (*AddInterfaceRequest) ProtoMessage()               {}
-func (*AddInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{18} }
+func (*AddInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{20} }
 
 func (m *AddInterfaceRequest) GetInterface() *Interface {
 	if m != nil {
@@ -689,57 +708,33 @@ func (m *AddInterfaceRequest) GetInterface() *Interface {
 }
 
 type RemoveInterfaceRequest struct {
-	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Interface *Interface `protobuf:"bytes,1,opt,name=interface" json:"interface,omitempty"`
 }
 
 func (m *RemoveInterfaceRequest) Reset()                    { *m = RemoveInterfaceRequest{} }
 func (m *RemoveInterfaceRequest) String() string            { return proto.CompactTextString(m) }
 func (*RemoveInterfaceRequest) ProtoMessage()               {}
-func (*RemoveInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{19} }
+func (*RemoveInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{21} }
 
-func (m *RemoveInterfaceRequest) GetName() string {
-	if m != nil {
-		return m.Name
-	}
-	return ""
-}
-
-type UpdateInterfaceRequest struct {
-	Type      UpdateType `protobuf:"varint,1,opt,name=type,proto3,enum=grpc.UpdateType" json:"type,omitempty"`
-	Interface *Interface `protobuf:"bytes,2,opt,name=interface" json:"interface,omitempty"`
-}
-
-func (m *UpdateInterfaceRequest) Reset()                    { *m = UpdateInterfaceRequest{} }
-func (m *UpdateInterfaceRequest) String() string            { return proto.CompactTextString(m) }
-func (*UpdateInterfaceRequest) ProtoMessage()               {}
-func (*UpdateInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{20} }
-
-func (m *UpdateInterfaceRequest) GetType() UpdateType {
-	if m != nil {
-		return m.Type
-	}
-	return UpdateType_None
-}
-
-func (m *UpdateInterfaceRequest) GetInterface() *Interface {
+func (m *RemoveInterfaceRequest) GetInterface() *Interface {
 	if m != nil {
 		return m.Interface
 	}
 	return nil
 }
 
-type RouteRequest struct {
-	Route *Route `protobuf:"bytes,1,opt,name=route" json:"route,omitempty"`
+type UpdateRoutesRequest struct {
+	Routes *Routes `protobuf:"bytes,1,opt,name=routes" json:"routes,omitempty"`
 }
 
-func (m *RouteRequest) Reset()                    { *m = RouteRequest{} }
-func (m *RouteRequest) String() string            { return proto.CompactTextString(m) }
-func (*RouteRequest) ProtoMessage()               {}
-func (*RouteRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{21} }
+func (m *UpdateRoutesRequest) Reset()                    { *m = UpdateRoutesRequest{} }
+func (m *UpdateRoutesRequest) String() string            { return proto.CompactTextString(m) }
+func (*UpdateRoutesRequest) ProtoMessage()               {}
+func (*UpdateRoutesRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{22} }
 
-func (m *RouteRequest) GetRoute() *Route {
+func (m *UpdateRoutesRequest) GetRoutes() *Routes {
 	if m != nil {
-		return m.Route
+		return m.Routes
 	}
 	return nil
 }
@@ -750,7 +745,7 @@ type OnlineCPUMemRequest struct {
 func (m *OnlineCPUMemRequest) Reset()                    { *m = OnlineCPUMemRequest{} }
 func (m *OnlineCPUMemRequest) String() string            { return proto.CompactTextString(m) }
 func (*OnlineCPUMemRequest) ProtoMessage()               {}
-func (*OnlineCPUMemRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{22} }
+func (*OnlineCPUMemRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{23} }
 
 type Storage struct {
 	Driver     string   `protobuf:"bytes,1,opt,name=driver,proto3" json:"driver,omitempty"`
@@ -763,7 +758,7 @@ type Storage struct {
 func (m *Storage) Reset()                    { *m = Storage{} }
 func (m *Storage) String() string            { return proto.CompactTextString(m) }
 func (*Storage) ProtoMessage()               {}
-func (*Storage) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{23} }
+func (*Storage) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{24} }
 
 func (m *Storage) GetDriver() string {
 	if m != nil {
@@ -809,7 +804,7 @@ type StringUser struct {
 func (m *StringUser) Reset()                    { *m = StringUser{} }
 func (m *StringUser) String() string            { return proto.CompactTextString(m) }
 func (*StringUser) ProtoMessage()               {}
-func (*StringUser) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{24} }
+func (*StringUser) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{25} }
 
 func (m *StringUser) GetUid() string {
 	if m != nil {
@@ -851,15 +846,15 @@ func init() {
 	proto.RegisterType((*IPAddress)(nil), "grpc.IPAddress")
 	proto.RegisterType((*Interface)(nil), "grpc.Interface")
 	proto.RegisterType((*Route)(nil), "grpc.Route")
+	proto.RegisterType((*Routes)(nil), "grpc.Routes")
+	proto.RegisterType((*UpdateInterfaceRequest)(nil), "grpc.UpdateInterfaceRequest")
 	proto.RegisterType((*AddInterfaceRequest)(nil), "grpc.AddInterfaceRequest")
 	proto.RegisterType((*RemoveInterfaceRequest)(nil), "grpc.RemoveInterfaceRequest")
-	proto.RegisterType((*UpdateInterfaceRequest)(nil), "grpc.UpdateInterfaceRequest")
-	proto.RegisterType((*RouteRequest)(nil), "grpc.RouteRequest")
+	proto.RegisterType((*UpdateRoutesRequest)(nil), "grpc.UpdateRoutesRequest")
 	proto.RegisterType((*OnlineCPUMemRequest)(nil), "grpc.OnlineCPUMemRequest")
 	proto.RegisterType((*Storage)(nil), "grpc.Storage")
 	proto.RegisterType((*StringUser)(nil), "grpc.StringUser")
 	proto.RegisterEnum("grpc.IPFamily", IPFamily_name, IPFamily_value)
-	proto.RegisterEnum("grpc.UpdateType", UpdateType_name, UpdateType_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -893,11 +888,10 @@ type AgentServiceClient interface {
 	CloseStdin(ctx context.Context, in *CloseStdinRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	TtyWinResize(ctx context.Context, in *TtyWinResizeRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	// networking
-	AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	AddRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	RemoveRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
+	AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error)
+	UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error)
+	RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error)
+	UpdateRoutes(ctx context.Context, in *UpdateRoutesRequest, opts ...grpc1.CallOption) (*Routes, error)
 	// misc (TODO: some rpcs can be replaced by hyperstart-exec)
 	CreateSandbox(ctx context.Context, in *CreateSandboxRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	DestroySandbox(ctx context.Context, in *DestroySandboxRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
@@ -1011,8 +1005,8 @@ func (c *agentServiceClient) TtyWinResize(ctx context.Context, in *TtyWinResizeR
 	return out, nil
 }
 
-func (c *agentServiceClient) AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
+func (c *agentServiceClient) AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error) {
+	out := new(Interface)
 	err := grpc1.Invoke(ctx, "/grpc.AgentService/AddInterface", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -1020,17 +1014,8 @@ func (c *agentServiceClient) AddInterface(ctx context.Context, in *AddInterfaceR
 	return out, nil
 }
 
-func (c *agentServiceClient) RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
-	err := grpc1.Invoke(ctx, "/grpc.AgentService/RemoveInterface", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *agentServiceClient) UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
+func (c *agentServiceClient) UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error) {
+	out := new(Interface)
 	err := grpc1.Invoke(ctx, "/grpc.AgentService/UpdateInterface", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -1038,18 +1023,18 @@ func (c *agentServiceClient) UpdateInterface(ctx context.Context, in *UpdateInte
 	return out, nil
 }
 
-func (c *agentServiceClient) AddRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
-	err := grpc1.Invoke(ctx, "/grpc.AgentService/AddRoute", in, out, c.cc, opts...)
+func (c *agentServiceClient) RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error) {
+	out := new(Interface)
+	err := grpc1.Invoke(ctx, "/grpc.AgentService/RemoveInterface", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *agentServiceClient) RemoveRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
-	err := grpc1.Invoke(ctx, "/grpc.AgentService/RemoveRoute", in, out, c.cc, opts...)
+func (c *agentServiceClient) UpdateRoutes(ctx context.Context, in *UpdateRoutesRequest, opts ...grpc1.CallOption) (*Routes, error) {
+	out := new(Routes)
+	err := grpc1.Invoke(ctx, "/grpc.AgentService/UpdateRoutes", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1106,11 +1091,10 @@ type AgentServiceServer interface {
 	CloseStdin(context.Context, *CloseStdinRequest) (*google_protobuf2.Empty, error)
 	TtyWinResize(context.Context, *TtyWinResizeRequest) (*google_protobuf2.Empty, error)
 	// networking
-	AddInterface(context.Context, *AddInterfaceRequest) (*google_protobuf2.Empty, error)
-	RemoveInterface(context.Context, *RemoveInterfaceRequest) (*google_protobuf2.Empty, error)
-	UpdateInterface(context.Context, *UpdateInterfaceRequest) (*google_protobuf2.Empty, error)
-	AddRoute(context.Context, *RouteRequest) (*google_protobuf2.Empty, error)
-	RemoveRoute(context.Context, *RouteRequest) (*google_protobuf2.Empty, error)
+	AddInterface(context.Context, *AddInterfaceRequest) (*Interface, error)
+	UpdateInterface(context.Context, *UpdateInterfaceRequest) (*Interface, error)
+	RemoveInterface(context.Context, *RemoveInterfaceRequest) (*Interface, error)
+	UpdateRoutes(context.Context, *UpdateRoutesRequest) (*Routes, error)
 	// misc (TODO: some rpcs can be replaced by hyperstart-exec)
 	CreateSandbox(context.Context, *CreateSandboxRequest) (*google_protobuf2.Empty, error)
 	DestroySandbox(context.Context, *DestroySandboxRequest) (*google_protobuf2.Empty, error)
@@ -1337,24 +1321,6 @@ func _AgentService_AddInterface_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
-func _AgentService_RemoveInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RemoveInterfaceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(AgentServiceServer).RemoveInterface(ctx, in)
-	}
-	info := &grpc1.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/grpc.AgentService/RemoveInterface",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentServiceServer).RemoveInterface(ctx, req.(*RemoveInterfaceRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _AgentService_UpdateInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UpdateInterfaceRequest)
 	if err := dec(in); err != nil {
@@ -1373,38 +1339,38 @@ func _AgentService_UpdateInterface_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
-func _AgentService_AddRoute_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RouteRequest)
+func _AgentService_RemoveInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RemoveInterfaceRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(AgentServiceServer).AddRoute(ctx, in)
+		return srv.(AgentServiceServer).RemoveInterface(ctx, in)
 	}
 	info := &grpc1.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.AgentService/AddRoute",
+		FullMethod: "/grpc.AgentService/RemoveInterface",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentServiceServer).AddRoute(ctx, req.(*RouteRequest))
+		return srv.(AgentServiceServer).RemoveInterface(ctx, req.(*RemoveInterfaceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _AgentService_RemoveRoute_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RouteRequest)
+func _AgentService_UpdateRoutes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateRoutesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(AgentServiceServer).RemoveRoute(ctx, in)
+		return srv.(AgentServiceServer).UpdateRoutes(ctx, in)
 	}
 	info := &grpc1.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.AgentService/RemoveRoute",
+		FullMethod: "/grpc.AgentService/UpdateRoutes",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentServiceServer).RemoveRoute(ctx, req.(*RouteRequest))
+		return srv.(AgentServiceServer).UpdateRoutes(ctx, req.(*UpdateRoutesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1516,20 +1482,16 @@ var _AgentService_serviceDesc = grpc1.ServiceDesc{
 			Handler:    _AgentService_AddInterface_Handler,
 		},
 		{
-			MethodName: "RemoveInterface",
-			Handler:    _AgentService_RemoveInterface_Handler,
-		},
-		{
 			MethodName: "UpdateInterface",
 			Handler:    _AgentService_UpdateInterface_Handler,
 		},
 		{
-			MethodName: "AddRoute",
-			Handler:    _AgentService_AddRoute_Handler,
+			MethodName: "RemoveInterface",
+			Handler:    _AgentService_RemoveInterface_Handler,
 		},
 		{
-			MethodName: "RemoveRoute",
-			Handler:    _AgentService_RemoveRoute_Handler,
+			MethodName: "UpdateRoutes",
+			Handler:    _AgentService_UpdateRoutes_Handler,
 		},
 		{
 			MethodName: "CreateSandbox",
@@ -2130,8 +2092,8 @@ func (m *Interface) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintAgent(dAtA, i, uint64(len(m.Name)))
 		i += copy(dAtA[i:], m.Name)
 	}
-	if len(m.IpAddresses) > 0 {
-		for _, msg := range m.IpAddresses {
+	if len(m.IPAddresses) > 0 {
+		for _, msg := range m.IPAddresses {
 			dAtA[i] = 0x1a
 			i++
 			i = encodeVarintAgent(dAtA, i, uint64(msg.Size()))
@@ -2189,6 +2151,75 @@ func (m *Route) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintAgent(dAtA, i, uint64(len(m.Device)))
 		i += copy(dAtA[i:], m.Device)
 	}
+	if len(m.Source) > 0 {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(len(m.Source)))
+		i += copy(dAtA[i:], m.Source)
+	}
+	if m.Scope != 0 {
+		dAtA[i] = 0x28
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(m.Scope))
+	}
+	return i, nil
+}
+
+func (m *Routes) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Routes) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Routes) > 0 {
+		for _, msg := range m.Routes {
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintAgent(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
+func (m *UpdateInterfaceRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Interface != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(m.Interface.Size()))
+		n5, err := m.Interface.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
 	return i, nil
 }
 
@@ -2211,11 +2242,11 @@ func (m *AddInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintAgent(dAtA, i, uint64(m.Interface.Size()))
-		n5, err := m.Interface.MarshalTo(dAtA[i:])
+		n6, err := m.Interface.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n5
+		i += n6
 	}
 	return i, nil
 }
@@ -2235,72 +2266,43 @@ func (m *RemoveInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAgent(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	return i, nil
-}
-
-func (m *UpdateInterfaceRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *UpdateInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.Type != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintAgent(dAtA, i, uint64(m.Type))
-	}
 	if m.Interface != nil {
-		dAtA[i] = 0x12
+		dAtA[i] = 0xa
 		i++
 		i = encodeVarintAgent(dAtA, i, uint64(m.Interface.Size()))
-		n6, err := m.Interface.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n6
-	}
-	return i, nil
-}
-
-func (m *RouteRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *RouteRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.Route != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAgent(dAtA, i, uint64(m.Route.Size()))
-		n7, err := m.Route.MarshalTo(dAtA[i:])
+		n7, err := m.Interface.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n7
+	}
+	return i, nil
+}
+
+func (m *UpdateRoutesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateRoutesRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Routes != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(m.Routes.Size()))
+		n8, err := m.Routes.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n8
 	}
 	return i, nil
 }
@@ -2694,8 +2696,8 @@ func (m *Interface) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovAgent(uint64(l))
 	}
-	if len(m.IpAddresses) > 0 {
-		for _, e := range m.IpAddresses {
+	if len(m.IPAddresses) > 0 {
+		for _, e := range m.IPAddresses {
 			l = e.Size()
 			n += 1 + l + sovAgent(uint64(l))
 		}
@@ -2725,6 +2727,35 @@ func (m *Route) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovAgent(uint64(l))
 	}
+	l = len(m.Source)
+	if l > 0 {
+		n += 1 + l + sovAgent(uint64(l))
+	}
+	if m.Scope != 0 {
+		n += 1 + sovAgent(uint64(m.Scope))
+	}
+	return n
+}
+
+func (m *Routes) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Routes) > 0 {
+		for _, e := range m.Routes {
+			l = e.Size()
+			n += 1 + l + sovAgent(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *UpdateInterfaceRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.Interface != nil {
+		l = m.Interface.Size()
+		n += 1 + l + sovAgent(uint64(l))
+	}
 	return n
 }
 
@@ -2741,19 +2772,6 @@ func (m *AddInterfaceRequest) Size() (n int) {
 func (m *RemoveInterfaceRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = len(m.Name)
-	if l > 0 {
-		n += 1 + l + sovAgent(uint64(l))
-	}
-	return n
-}
-
-func (m *UpdateInterfaceRequest) Size() (n int) {
-	var l int
-	_ = l
-	if m.Type != 0 {
-		n += 1 + sovAgent(uint64(m.Type))
-	}
 	if m.Interface != nil {
 		l = m.Interface.Size()
 		n += 1 + l + sovAgent(uint64(l))
@@ -2761,11 +2779,11 @@ func (m *UpdateInterfaceRequest) Size() (n int) {
 	return n
 }
 
-func (m *RouteRequest) Size() (n int) {
+func (m *UpdateRoutesRequest) Size() (n int) {
 	var l int
 	_ = l
-	if m.Route != nil {
-		l = m.Route.Size()
+	if m.Routes != nil {
+		l = m.Routes.Size()
 		n += 1 + l + sovAgent(uint64(l))
 	}
 	return n
@@ -4793,7 +4811,7 @@ func (m *Interface) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IpAddresses", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field IPAddresses", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -4817,8 +4835,8 @@ func (m *Interface) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.IpAddresses = append(m.IpAddresses, &IPAddress{})
-			if err := m.IpAddresses[len(m.IpAddresses)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.IPAddresses = append(m.IPAddresses, &IPAddress{})
+			if err := m.IPAddresses[len(m.IPAddresses)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -5007,6 +5025,218 @@ func (m *Route) Unmarshal(dAtA []byte) error {
 			}
 			m.Device = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Source", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAgent
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Source = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Scope", wireType)
+			}
+			m.Scope = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Scope |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAgent(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAgent
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Routes) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAgent
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Routes: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Routes: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Routes", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAgent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Routes = append(m.Routes, &Route{})
+			if err := m.Routes[len(m.Routes)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAgent(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAgent
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UpdateInterfaceRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAgent
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UpdateInterfaceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UpdateInterfaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Interface", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAgent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Interface == nil {
+				m.Interface = &Interface{}
+			}
+			if err := m.Interface.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipAgent(dAtA[iNdEx:])
@@ -5142,104 +5372,6 @@ func (m *RemoveInterfaceRequest) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowAgent
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthAgent
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Name = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipAgent(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthAgent
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *UpdateInterfaceRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowAgent
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: UpdateInterfaceRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: UpdateInterfaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
-			}
-			m.Type = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowAgent
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.Type |= (UpdateType(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Interface", wireType)
 			}
 			var msglen int
@@ -5292,7 +5424,7 @@ func (m *UpdateInterfaceRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *RouteRequest) Unmarshal(dAtA []byte) error {
+func (m *UpdateRoutesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -5315,15 +5447,15 @@ func (m *RouteRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: RouteRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: UpdateRoutesRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: RouteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: UpdateRoutesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Route", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Routes", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -5347,10 +5479,10 @@ func (m *RouteRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Route == nil {
-				m.Route = &Route{}
+			if m.Routes == nil {
+				m.Routes = &Routes{}
 			}
-			if err := m.Route.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.Routes.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -5865,81 +5997,80 @@ var (
 func init() { proto.RegisterFile("agent.proto", fileDescriptorAgent) }
 
 var fileDescriptorAgent = []byte{
-	// 1213 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x56, 0xef, 0x4e, 0x1b, 0x47,
-	0x10, 0xcf, 0x61, 0x03, 0xf6, 0xd8, 0x26, 0xce, 0x12, 0xc0, 0x75, 0x22, 0x4a, 0xaf, 0x55, 0x42,
-	0xa3, 0xc6, 0x51, 0x68, 0x15, 0xa9, 0x95, 0xaa, 0xc8, 0x38, 0x14, 0xf9, 0x03, 0xc5, 0x5a, 0x83,
-	0xe8, 0x37, 0xb4, 0xf8, 0x16, 0xe7, 0x5a, 0xdf, 0xed, 0x75, 0x77, 0x0f, 0x70, 0xfb, 0x0a, 0x95,
-	0xfa, 0xa5, 0x8f, 0xd1, 0x07, 0xe9, 0xc7, 0x3c, 0x42, 0xc5, 0x93, 0x54, 0xbb, 0xb7, 0x7b, 0xb6,
-	0xf1, 0x19, 0x14, 0x64, 0xa9, 0x9f, 0xbc, 0x33, 0xb3, 0xfe, 0xed, 0x6f, 0xfe, 0xdc, 0xcc, 0x40,
-	0x89, 0xf4, 0x69, 0x28, 0x1b, 0x11, 0x67, 0x92, 0xa1, 0x7c, 0x9f, 0x47, 0xbd, 0x7a, 0x91, 0xf5,
-	0xfc, 0x44, 0x51, 0x7f, 0xd2, 0x67, 0xac, 0x3f, 0xa0, 0xaf, 0xb4, 0x74, 0x16, 0x9f, 0xbf, 0xa2,
-	0x41, 0x24, 0x87, 0x89, 0xd1, 0xfd, 0xe0, 0xc0, 0x7a, 0x8b, 0x53, 0x22, 0x69, 0x8b, 0x85, 0x92,
-	0xf8, 0x21, 0xe5, 0x98, 0xfe, 0x1a, 0x53, 0x21, 0xd1, 0x67, 0x50, 0xee, 0x59, 0xdd, 0xa9, 0xef,
-	0xd5, 0x9c, 0x2d, 0x67, 0xbb, 0x88, 0x4b, 0xa9, 0xae, 0xed, 0xa1, 0x0d, 0x58, 0xa6, 0x57, 0xb4,
-	0xa7, 0xac, 0x0b, 0xda, 0xba, 0xa4, 0xc4, 0xb6, 0x87, 0x5e, 0x43, 0x49, 0x48, 0xee, 0x87, 0xfd,
-	0xd3, 0x58, 0x50, 0x5e, 0xcb, 0x6d, 0x39, 0xdb, 0xa5, 0x9d, 0x6a, 0x43, 0x51, 0x6b, 0x74, 0xb5,
-	0xe1, 0x58, 0x50, 0x8e, 0x41, 0xa4, 0x67, 0xf4, 0x25, 0x14, 0x84, 0x64, 0x9c, 0xf4, 0xa9, 0xa8,
-	0xe5, 0xb7, 0x72, 0xdb, 0xa5, 0x9d, 0x8a, 0xbd, 0xaf, 0xb5, 0x38, 0x35, 0xa3, 0xa7, 0x90, 0x3b,
-	0x6c, 0xb5, 0x6b, 0x8b, 0x1a, 0x15, 0xcc, 0xad, 0x88, 0xf6, 0xb0, 0x52, 0xbb, 0xdf, 0xc1, 0x5a,
-	0x57, 0x12, 0x2e, 0xef, 0xe1, 0x90, 0x7b, 0x0c, 0xeb, 0x98, 0x06, 0xec, 0xe2, 0x5e, 0xd1, 0xa8,
-	0xc1, 0xb2, 0xf4, 0x03, 0xca, 0x62, 0xa9, 0xa3, 0x51, 0xc1, 0x56, 0x74, 0xff, 0x76, 0x00, 0xed,
-	0x5d, 0xd1, 0x5e, 0x87, 0xb3, 0x1e, 0x15, 0xe2, 0x7f, 0x8a, 0xf0, 0x73, 0x58, 0x8e, 0x12, 0x02,
-	0xb5, 0xbc, 0xbe, 0x6e, 0x02, 0x6c, 0x59, 0x59, 0xab, 0xfb, 0x33, 0x3c, 0xee, 0xfa, 0xfd, 0x90,
-	0x0c, 0xe6, 0xc8, 0x77, 0x1d, 0x96, 0x84, 0xc6, 0xd4, 0x54, 0x2b, 0xd8, 0x48, 0x6e, 0x07, 0xd0,
-	0x09, 0xf1, 0xe5, 0xfc, 0x5e, 0x72, 0x5f, 0xc2, 0xea, 0x04, 0xa2, 0x88, 0x58, 0x28, 0xa8, 0x26,
-	0x20, 0x89, 0x8c, 0x85, 0x06, 0x5b, 0xc4, 0x46, 0x72, 0x3d, 0x40, 0x27, 0xdc, 0x97, 0xb4, 0x2b,
-	0x39, 0x25, 0xc1, 0x3c, 0x5c, 0x45, 0x90, 0xf7, 0x88, 0x24, 0xda, 0xd1, 0x32, 0xd6, 0x67, 0xf7,
-	0x39, 0xac, 0x4e, 0xbc, 0x62, 0x48, 0x55, 0x21, 0x37, 0xa0, 0xa1, 0x46, 0xaf, 0x60, 0x75, 0x74,
-	0x09, 0x3c, 0xc2, 0x94, 0x78, 0xf3, 0x63, 0x63, 0x9e, 0xc8, 0x8d, 0x9e, 0xd8, 0x06, 0x34, 0xfe,
-	0x84, 0xa1, 0x62, 0x59, 0x3b, 0x63, 0xac, 0x0f, 0xe1, 0x51, 0x6b, 0xc0, 0x04, 0xed, 0x4a, 0xcf,
-	0x0f, 0xe7, 0x91, 0x9b, 0xdf, 0x61, 0xf5, 0x48, 0x0e, 0x4f, 0x14, 0x98, 0xf0, 0x7f, 0xa3, 0x73,
-	0xf2, 0x8f, 0xb3, 0x4b, 0xeb, 0x1f, 0x67, 0x97, 0x2a, 0xd3, 0x3d, 0x36, 0x88, 0x83, 0x50, 0x97,
-	0x79, 0x05, 0x1b, 0xc9, 0xfd, 0xcb, 0x81, 0xc7, 0x49, 0xaf, 0xeb, 0x92, 0xd0, 0x3b, 0x63, 0x57,
-	0xf6, 0xf9, 0x3a, 0x14, 0xde, 0x33, 0x21, 0x43, 0x12, 0x50, 0xf3, 0x74, 0x2a, 0x2b, 0x78, 0x2f,
-	0x14, 0xb5, 0x85, 0xad, 0xdc, 0x76, 0x11, 0xab, 0xe3, 0x44, 0xa3, 0xca, 0xdd, 0xde, 0xa8, 0x3e,
-	0x87, 0x8a, 0x48, 0x9e, 0x3a, 0x8d, 0x7c, 0x05, 0xa3, 0x08, 0x15, 0x70, 0xd9, 0x28, 0x3b, 0x4a,
-	0xe7, 0x6e, 0xc0, 0xda, 0x3b, 0x2a, 0x24, 0x67, 0xc3, 0x49, 0x5a, 0x2e, 0x81, 0x62, 0xbb, 0xd3,
-	0xf4, 0x3c, 0x4e, 0x85, 0x40, 0xcf, 0x60, 0xe9, 0x9c, 0x04, 0xfe, 0x60, 0xa8, 0x19, 0xae, 0xec,
-	0xac, 0x24, 0x6f, 0xb6, 0x3b, 0x3f, 0x68, 0x2d, 0x36, 0x56, 0xd5, 0x84, 0x48, 0xf2, 0x17, 0x13,
-	0x27, 0x2b, 0xaa, 0x04, 0x07, 0x44, 0xfc, 0xa2, 0x23, 0x55, 0xc4, 0xfa, 0xac, 0x42, 0x52, 0x6c,
-	0x87, 0x92, 0xf2, 0x73, 0xd2, 0xd3, 0x9f, 0x88, 0x47, 0x2f, 0xfc, 0x9e, 0x8d, 0x82, 0x91, 0xd4,
-	0x3f, 0x75, 0x6c, 0x12, 0x40, 0x7d, 0x56, 0xfd, 0xc7, 0x8f, 0x0c, 0xb9, 0x34, 0x10, 0x0f, 0x2d,
-	0x29, 0x63, 0xc0, 0xe3, 0x77, 0x54, 0x28, 0x03, 0x19, 0xeb, 0x18, 0xe4, 0xb1, 0x3a, 0xaa, 0x07,
-	0xdf, 0x5f, 0xaa, 0x0b, 0xba, 0x97, 0x17, 0xb1, 0x91, 0xdc, 0x03, 0x58, 0xc4, 0x2c, 0x96, 0x49,
-	0x51, 0x52, 0x21, 0x0d, 0x1f, 0x7d, 0x56, 0x1e, 0xf6, 0x89, 0xa4, 0x97, 0x64, 0x68, 0x3d, 0x34,
-	0xe2, 0x18, 0xff, 0xdc, 0x38, 0x7f, 0xf7, 0x1d, 0xac, 0x36, 0x3d, 0x2f, 0xf5, 0xd3, 0xa6, 0xfd,
-	0x25, 0x14, 0x7d, 0xab, 0xd3, 0x2f, 0x8c, 0x1c, 0x48, 0xaf, 0x8e, 0x6e, 0xb8, 0x5f, 0xd9, 0xd9,
-	0x30, 0x05, 0x64, 0xe3, 0xe3, 0x8c, 0xe2, 0xe3, 0x06, 0xb0, 0x7e, 0x1c, 0x79, 0x44, 0x4e, 0xdf,
-	0xfe, 0x02, 0xf2, 0x72, 0x18, 0x51, 0x93, 0x47, 0xd3, 0xb2, 0x93, 0xbb, 0x47, 0xc3, 0x88, 0x62,
-	0x6d, 0x9d, 0x24, 0xb7, 0x70, 0x27, 0xb9, 0xd7, 0x50, 0xd6, 0x11, 0x1b, 0x7d, 0x51, 0x8b, 0x5c,
-	0xc9, 0xc6, 0xaf, 0x52, 0xf2, 0xd7, 0xe4, 0x4a, 0x62, 0x71, 0xd7, 0x60, 0xf5, 0x30, 0x1c, 0xf8,
-	0x21, 0x6d, 0x75, 0x8e, 0x0f, 0xa8, 0xed, 0x35, 0xee, 0x1f, 0x0e, 0x2c, 0x9b, 0x4a, 0xd6, 0x01,
-	0xe5, 0xfe, 0x05, 0xe5, 0x69, 0x41, 0x68, 0x49, 0xf7, 0x52, 0x16, 0xf3, 0x9e, 0x2d, 0x09, 0x23,
-	0x29, 0xfd, 0xb9, 0xd0, 0xce, 0x99, 0x04, 0x24, 0x92, 0x4a, 0x19, 0x8b, 0xa4, 0xcf, 0xc2, 0x64,
-	0xb4, 0x17, 0xb1, 0x15, 0xd1, 0xa7, 0x50, 0x0a, 0x58, 0x1c, 0xca, 0xd3, 0x88, 0xf9, 0xa1, 0x34,
-	0x65, 0x00, 0x5a, 0xd5, 0x51, 0x1a, 0xf7, 0x27, 0x80, 0xd1, 0x38, 0x53, 0x25, 0x14, 0xa7, 0xfd,
-	0x41, 0x1d, 0x95, 0xa6, 0x9f, 0xf6, 0x04, 0x75, 0x44, 0xcf, 0x60, 0x85, 0x78, 0x9e, 0xaf, 0xf0,
-	0xc9, 0x60, 0xdf, 0xf7, 0x92, 0xe2, 0x2c, 0xe2, 0x1b, 0xda, 0x17, 0x75, 0x28, 0xd8, 0xaf, 0x07,
-	0x2d, 0xc1, 0xc2, 0xc5, 0x37, 0xd5, 0x07, 0xfa, 0xf7, 0x4d, 0xd5, 0x79, 0xb1, 0x0b, 0x30, 0xca,
-	0x08, 0x2a, 0x40, 0xfe, 0x47, 0x16, 0xd2, 0xea, 0x03, 0x54, 0x84, 0x45, 0x55, 0x49, 0x9d, 0xaa,
-	0x83, 0xca, 0x50, 0x30, 0xe5, 0xd0, 0xa9, 0x2e, 0xe8, 0x2b, 0x24, 0xa0, 0xd5, 0x3c, 0x5a, 0x86,
-	0xdc, 0xc1, 0xd1, 0x71, 0xb5, 0xb0, 0xf3, 0x27, 0x40, 0xb9, 0xa9, 0x16, 0xb3, 0x2e, 0xe5, 0xfa,
-	0x33, 0xda, 0x87, 0x87, 0x37, 0x56, 0x2d, 0xf4, 0x34, 0xc9, 0x4b, 0xf6, 0x06, 0x56, 0x5f, 0x6f,
-	0x24, 0xab, 0x5b, 0xc3, 0xae, 0x6e, 0x8d, 0x3d, 0xb5, 0xba, 0xa1, 0x3d, 0x58, 0x99, 0xdc, 0x70,
-	0xd0, 0x13, 0xdb, 0x81, 0x32, 0xf6, 0x9e, 0x99, 0x30, 0xfb, 0xf0, 0xf0, 0xc6, 0xb2, 0x63, 0xf9,
-	0x64, 0xef, 0x40, 0x33, 0x81, 0xde, 0x42, 0x69, 0x6c, 0xbb, 0x41, 0xb5, 0x04, 0x64, 0x7a, 0xe1,
-	0x99, 0x09, 0xd0, 0x82, 0xca, 0xc4, 0xc2, 0x81, 0xea, 0xc6, 0x9f, 0x8c, 0x2d, 0x64, 0x26, 0xc8,
-	0x2e, 0x94, 0xc6, 0xe6, 0xbe, 0x65, 0x31, 0xbd, 0x5c, 0xd4, 0x3f, 0xc9, 0xb0, 0x98, 0x21, 0xd8,
-	0x04, 0x30, 0x63, 0xda, 0xf3, 0xc3, 0x14, 0x62, 0x6a, 0x3d, 0x48, 0x21, 0x32, 0x46, 0xfa, 0x5b,
-	0x80, 0x64, 0xba, 0x7a, 0x2c, 0x96, 0x68, 0xc3, 0x06, 0xf4, 0xc6, 0x48, 0xaf, 0xd7, 0xa6, 0x0d,
-	0x53, 0x00, 0x94, 0xf3, 0xfb, 0x00, 0x7c, 0x0f, 0x30, 0x9a, 0xda, 0x16, 0x60, 0x6a, 0x8e, 0xcf,
-	0x8c, 0x63, 0x13, 0xca, 0xe3, 0x33, 0x1a, 0x19, 0x5f, 0x33, 0xe6, 0xf6, 0x6d, 0x10, 0xe3, 0x0d,
-	0xd7, 0x42, 0x64, 0x34, 0xe1, 0xbb, 0x8b, 0x73, 0x84, 0x32, 0x51, 0x9c, 0x1f, 0x03, 0x74, 0xa3,
-	0x11, 0x5b, 0xa0, 0xec, 0xfe, 0x3c, 0x13, 0xe8, 0x0d, 0x14, 0x9a, 0x9e, 0x67, 0xe6, 0xd2, 0x78,
-	0x3f, 0xbd, 0xe3, 0x7f, 0xdf, 0x42, 0x29, 0xa1, 0xfc, 0xf1, 0x7f, 0x6d, 0x41, 0x65, 0x62, 0x61,
-	0xb1, 0xdf, 0x45, 0xd6, 0x16, 0x73, 0x5b, 0xb7, 0x98, 0xdc, 0x2f, 0x6c, 0xb7, 0xc8, 0xdc, 0x3a,
-	0x6e, 0xcb, 0xe9, 0xf8, 0xb8, 0xb0, 0x39, 0xcd, 0x18, 0x21, 0xb3, 0x20, 0x76, 0xcb, 0xff, 0x5c,
-	0x6f, 0x3a, 0x1f, 0xae, 0x37, 0x9d, 0x7f, 0xaf, 0x37, 0x9d, 0xb3, 0x25, 0x6d, 0xfd, 0xfa, 0xbf,
-	0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x72, 0x31, 0x5f, 0xbe, 0x0e, 0x00, 0x00,
+	// 1186 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x56, 0xdf, 0x6e, 0x1b, 0x45,
+	0x17, 0xff, 0x36, 0x4e, 0x9c, 0xec, 0xb1, 0x9d, 0xa4, 0xe3, 0xd6, 0xf5, 0xe7, 0x56, 0x25, 0x2c,
+	0xa8, 0x0d, 0x48, 0x75, 0x45, 0x40, 0x20, 0x15, 0xa1, 0x92, 0xba, 0x25, 0xf2, 0x05, 0x8a, 0x35,
+	0x26, 0x0a, 0x77, 0xd1, 0x64, 0x77, 0xe2, 0x2e, 0xd8, 0x3b, 0xcb, 0xcc, 0x6c, 0x12, 0xd3, 0x57,
+	0xe0, 0x92, 0xc7, 0xe0, 0x21, 0xb8, 0xe4, 0xb2, 0x8f, 0x80, 0xf2, 0x24, 0x68, 0x66, 0x67, 0x36,
+	0xbb, 0xf6, 0x3a, 0x48, 0xa9, 0x25, 0xae, 0x3c, 0xe7, 0x9c, 0xf1, 0xef, 0xfc, 0x99, 0xb3, 0xe7,
+	0xfc, 0xa0, 0x46, 0x46, 0x34, 0x92, 0xdd, 0x98, 0x33, 0xc9, 0xd0, 0xea, 0x88, 0xc7, 0x7e, 0xc7,
+	0x65, 0x7e, 0x98, 0x2a, 0x3a, 0x0f, 0x46, 0x8c, 0x8d, 0xc6, 0xf4, 0x99, 0x96, 0x4e, 0x93, 0xb3,
+	0x67, 0x74, 0x12, 0xcb, 0x69, 0x6a, 0xf4, 0xde, 0x39, 0xd0, 0xea, 0x71, 0x4a, 0x24, 0xed, 0xb1,
+	0x48, 0x92, 0x30, 0xa2, 0x1c, 0xd3, 0x5f, 0x12, 0x2a, 0x24, 0xfa, 0x10, 0xea, 0xbe, 0xd5, 0x9d,
+	0x84, 0x41, 0xdb, 0xd9, 0x71, 0x76, 0x5d, 0x5c, 0xcb, 0x74, 0xfd, 0x00, 0xdd, 0x87, 0x75, 0x7a,
+	0x49, 0x7d, 0x65, 0x5d, 0xd1, 0xd6, 0xaa, 0x12, 0xfb, 0x01, 0xfa, 0x0c, 0x6a, 0x42, 0xf2, 0x30,
+	0x1a, 0x9d, 0x24, 0x82, 0xf2, 0x76, 0x65, 0xc7, 0xd9, 0xad, 0xed, 0x6d, 0x77, 0x55, 0x68, 0xdd,
+	0xa1, 0x36, 0x1c, 0x09, 0xca, 0x31, 0x88, 0xec, 0x8c, 0x3e, 0x81, 0x0d, 0x21, 0x19, 0x27, 0x23,
+	0x2a, 0xda, 0xab, 0x3b, 0x95, 0xdd, 0xda, 0x5e, 0xc3, 0xde, 0xd7, 0x5a, 0x9c, 0x99, 0xd1, 0x43,
+	0xa8, 0x1c, 0xf6, 0xfa, 0xed, 0x35, 0x8d, 0x0a, 0xe6, 0x56, 0x4c, 0x7d, 0xac, 0xd4, 0xde, 0x73,
+	0xb8, 0x37, 0x94, 0x84, 0xcb, 0x5b, 0x24, 0xe4, 0x1d, 0x41, 0x0b, 0xd3, 0x09, 0x3b, 0xbf, 0x55,
+	0x35, 0xda, 0xb0, 0x2e, 0xc3, 0x09, 0x65, 0x89, 0xd4, 0xd5, 0x68, 0x60, 0x2b, 0x7a, 0x7f, 0x38,
+	0x80, 0x5e, 0x5f, 0x52, 0x7f, 0xc0, 0x99, 0x4f, 0x85, 0xf8, 0x8f, 0x2a, 0xfc, 0x04, 0xd6, 0xe3,
+	0x34, 0x80, 0xf6, 0xaa, 0xbe, 0x6e, 0x0a, 0x6c, 0xa3, 0xb2, 0x56, 0xef, 0x27, 0xb8, 0x3b, 0x0c,
+	0x47, 0x11, 0x19, 0x2f, 0x31, 0xde, 0x16, 0x54, 0x85, 0xc6, 0xd4, 0xa1, 0x36, 0xb0, 0x91, 0xbc,
+	0x01, 0xa0, 0x63, 0x12, 0xca, 0xe5, 0x79, 0xf2, 0x9e, 0x42, 0xb3, 0x80, 0x28, 0x62, 0x16, 0x09,
+	0xaa, 0x03, 0x90, 0x44, 0x26, 0x42, 0x83, 0xad, 0x61, 0x23, 0x79, 0x01, 0xa0, 0x63, 0x1e, 0x4a,
+	0x3a, 0x94, 0x9c, 0x92, 0xc9, 0x32, 0x52, 0x45, 0xb0, 0x1a, 0x10, 0x49, 0x74, 0xa2, 0x75, 0xac,
+	0xcf, 0xde, 0x13, 0x68, 0x16, 0xbc, 0x98, 0xa0, 0xb6, 0xa1, 0x32, 0xa6, 0x91, 0x46, 0x6f, 0x60,
+	0x75, 0xf4, 0x08, 0xdc, 0xc1, 0x94, 0x04, 0xcb, 0x8b, 0xc6, 0xb8, 0xa8, 0x5c, 0xbb, 0xd8, 0x05,
+	0x94, 0x77, 0x61, 0x42, 0xb1, 0x51, 0x3b, 0xb9, 0xa8, 0x0f, 0xe1, 0x4e, 0x6f, 0xcc, 0x04, 0x1d,
+	0xca, 0x20, 0x8c, 0x96, 0xf1, 0x36, 0x6f, 0xa1, 0xf9, 0x83, 0x9c, 0x1e, 0x2b, 0x30, 0x11, 0xfe,
+	0x4a, 0x97, 0x94, 0x1f, 0x67, 0x17, 0x36, 0x3f, 0xce, 0x2e, 0xd4, 0x4b, 0xfb, 0x6c, 0x9c, 0x4c,
+	0x22, 0xdd, 0xe6, 0x0d, 0x6c, 0x24, 0xef, 0x77, 0x07, 0xee, 0xa6, 0xb3, 0x6e, 0x48, 0xa2, 0xe0,
+	0x94, 0x5d, 0x5a, 0xf7, 0x1d, 0xd8, 0x78, 0xc3, 0x84, 0x8c, 0xc8, 0x84, 0x1a, 0xd7, 0x99, 0xac,
+	0xe0, 0x83, 0x48, 0xb4, 0x57, 0x76, 0x2a, 0xbb, 0x2e, 0x56, 0xc7, 0xc2, 0xa0, 0xaa, 0xdc, 0x3c,
+	0xa8, 0x3e, 0x82, 0x86, 0x48, 0x5d, 0x9d, 0xc4, 0xa1, 0x82, 0x51, 0x01, 0x6d, 0xe0, 0xba, 0x51,
+	0x0e, 0x94, 0xce, 0xbb, 0x0f, 0xf7, 0x5e, 0x51, 0x21, 0x39, 0x9b, 0x16, 0xc3, 0xf2, 0x08, 0xb8,
+	0xfd, 0xc1, 0x7e, 0x10, 0x70, 0x2a, 0x04, 0x7a, 0x0c, 0xd5, 0x33, 0x32, 0x09, 0xc7, 0x53, 0x1d,
+	0xe1, 0xe6, 0xde, 0x66, 0xea, 0xb3, 0x3f, 0xf8, 0x4e, 0x6b, 0xb1, 0xb1, 0xaa, 0x21, 0x44, 0xd2,
+	0xbf, 0x98, 0x3a, 0x59, 0x51, 0x3d, 0xf0, 0x84, 0x88, 0x9f, 0x75, 0xa5, 0x5c, 0xac, 0xcf, 0xaa,
+	0x24, 0x6e, 0x3f, 0x92, 0x94, 0x9f, 0x11, 0x5f, 0x7f, 0x22, 0x01, 0x3d, 0x0f, 0x7d, 0x5b, 0x05,
+	0x23, 0xa9, 0x7f, 0xea, 0xda, 0xa4, 0x80, 0xfa, 0xac, 0xe6, 0x4f, 0x16, 0x5c, 0x56, 0x88, 0x2d,
+	0x1b, 0x94, 0x31, 0xe0, 0xfc, 0x1d, 0x55, 0xca, 0x89, 0x4c, 0x74, 0x0d, 0x56, 0xb1, 0x3a, 0x2a,
+	0x87, 0x6f, 0x2e, 0xd4, 0x05, 0x3d, 0xcb, 0x5d, 0x6c, 0x24, 0xef, 0x2d, 0xac, 0x61, 0x96, 0xc8,
+	0xb4, 0x29, 0xa9, 0x90, 0x26, 0x1e, 0x7d, 0x56, 0x19, 0x8e, 0x88, 0xa4, 0x17, 0x64, 0x6a, 0x33,
+	0x34, 0x62, 0x2e, 0xfe, 0x4a, 0x21, 0x7e, 0xf5, 0xe9, 0xb3, 0x84, 0xfb, 0x54, 0xfb, 0x76, 0xb1,
+	0x91, 0xd0, 0x5d, 0x58, 0x13, 0x3e, 0x8b, 0xa9, 0xf6, 0xde, 0xc0, 0xa9, 0xe0, 0x3d, 0x85, 0xaa,
+	0x76, 0xae, 0x9e, 0xcf, 0x9c, 0xda, 0x8e, 0x4e, 0xaf, 0x96, 0xa6, 0xa7, 0x75, 0xd8, 0x98, 0xbc,
+	0x03, 0x68, 0x1d, 0xc5, 0x01, 0x91, 0x34, 0xab, 0xa3, 0x6d, 0xab, 0xa7, 0xe0, 0x86, 0x56, 0xa7,
+	0x33, 0xb8, 0x2e, 0x50, 0x76, 0xf5, 0xfa, 0x86, 0xf7, 0x0a, 0x9a, 0xfb, 0x41, 0xf0, 0xbe, 0x28,
+	0x07, 0x76, 0x83, 0xbd, 0x2f, 0xd0, 0xd7, 0xd0, 0x4c, 0xf3, 0x4a, 0xf3, 0xb4, 0x28, 0x1f, 0x43,
+	0x95, 0xdb, 0x9a, 0x28, 0x88, 0x7a, 0xae, 0x26, 0x02, 0x1b, 0x9b, 0x77, 0x0f, 0x9a, 0x87, 0xd1,
+	0x38, 0x8c, 0x68, 0x6f, 0x70, 0xf4, 0x3d, 0xb5, 0x73, 0xcc, 0xfb, 0xcd, 0x81, 0x75, 0xf3, 0x95,
+	0xe8, 0xc7, 0xe2, 0xe1, 0x39, 0xe5, 0x59, 0xb3, 0x69, 0x29, 0xf7, 0x58, 0x2b, 0x85, 0xc7, 0x6a,
+	0x41, 0xf5, 0x4c, 0xc8, 0x69, 0x9c, 0x3d, 0x6e, 0x2a, 0xa9, 0x76, 0x60, 0xb1, 0x0c, 0x59, 0x94,
+	0xd2, 0x06, 0x17, 0x5b, 0x11, 0x7d, 0x00, 0xb5, 0x09, 0x4b, 0x22, 0x79, 0x12, 0xb3, 0x30, 0x92,
+	0xa6, 0xc5, 0x40, 0xab, 0x06, 0x4a, 0xe3, 0xfd, 0x08, 0x70, 0xbd, 0x2a, 0x55, 0x7b, 0x26, 0xd9,
+	0xec, 0x51, 0x47, 0xa5, 0x19, 0x65, 0xf3, 0x46, 0x1d, 0xd1, 0x63, 0xd8, 0x24, 0x41, 0x10, 0x2a,
+	0x7c, 0x32, 0x3e, 0x08, 0x83, 0xb4, 0xf1, 0x5d, 0x3c, 0xa3, 0xfd, 0xb4, 0x03, 0x1b, 0xf6, 0xcb,
+	0x44, 0x55, 0x58, 0x39, 0xff, 0x62, 0xfb, 0x7f, 0xfa, 0xf7, 0xcb, 0x6d, 0x67, 0xef, 0x4f, 0x17,
+	0xea, 0xfb, 0x8a, 0xb0, 0x0d, 0x29, 0xd7, 0xed, 0x79, 0x00, 0x5b, 0x33, 0x14, 0x0c, 0x3d, 0x4c,
+	0xab, 0x5a, 0xce, 0xcc, 0x3a, 0xad, 0x6e, 0x4a, 0xe9, 0xba, 0x96, 0xd2, 0x75, 0x5f, 0x2b, 0x4a,
+	0x87, 0x5e, 0xc3, 0x66, 0x91, 0xf9, 0xa0, 0x07, 0x76, 0x32, 0x95, 0xf0, 0xa1, 0x85, 0x30, 0x07,
+	0xb0, 0x35, 0x43, 0x82, 0x6c, 0x3c, 0xe5, 0xdc, 0x68, 0x21, 0xd0, 0x0b, 0xa8, 0xe5, 0x58, 0x0f,
+	0x6a, 0xa7, 0x20, 0xf3, 0x44, 0x68, 0x21, 0x40, 0x0f, 0x1a, 0x05, 0x22, 0x82, 0x3a, 0x26, 0x9f,
+	0x12, 0x76, 0xb2, 0x10, 0xe4, 0x25, 0xd4, 0x72, 0x7c, 0xc0, 0x46, 0x31, 0x4f, 0x3a, 0x3a, 0xff,
+	0x2f, 0xb1, 0x98, 0xe5, 0xb8, 0x0f, 0x60, 0xd6, 0x77, 0x10, 0x46, 0x19, 0xc4, 0x1c, 0x6d, 0xc8,
+	0x20, 0x4a, 0x56, 0xfd, 0x0b, 0x80, 0x74, 0xeb, 0x06, 0x2c, 0x91, 0xe8, 0xbe, 0x2d, 0xe8, 0xcc,
+	0xaa, 0xef, 0xb4, 0xe7, 0x0d, 0x73, 0x00, 0x94, 0xf3, 0xdb, 0x00, 0x7c, 0x03, 0x70, 0xbd, 0xcd,
+	0x2d, 0xc0, 0xdc, 0x7e, 0x5f, 0x58, 0xc7, 0x7d, 0xa8, 0xe7, 0x77, 0x37, 0x32, 0xb9, 0x96, 0xec,
+	0xf3, 0x85, 0x10, 0xcf, 0xa1, 0x9e, 0x1f, 0x71, 0x16, 0xa2, 0x64, 0xec, 0x75, 0x66, 0x47, 0x13,
+	0xfa, 0x16, 0xb6, 0x66, 0xe6, 0xac, 0xed, 0xca, 0xf2, 0xf1, 0x5b, 0x8a, 0x30, 0x33, 0x1a, 0x8b,
+	0x7d, 0xfd, 0xef, 0x08, 0x5f, 0x41, 0x3d, 0x3f, 0x13, 0x6d, 0xfc, 0x25, 0x73, 0xb2, 0x53, 0x98,
+	0x8b, 0xaa, 0x91, 0x0b, 0xcc, 0xc3, 0x36, 0x72, 0x19, 0x1d, 0xb9, 0xe9, 0xf3, 0x2e, 0x12, 0x05,
+	0xfb, 0x79, 0x97, 0xd2, 0x87, 0x9b, 0xde, 0x31, 0x3f, 0x9b, 0x6d, 0x12, 0x25, 0xf3, 0x7a, 0x11,
+	0xc4, 0xcb, 0xfa, 0x5f, 0x57, 0x8f, 0x9c, 0x77, 0x57, 0x8f, 0x9c, 0xbf, 0xaf, 0x1e, 0x39, 0xa7,
+	0x55, 0x6d, 0xfd, 0xfc, 0x9f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x84, 0x77, 0x3e, 0x87, 0x0e,
+	0x00, 0x00,
 }

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/health.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/health.pb.go
@@ -108,10 +108,7 @@ func init() {
 }
 func (this *CheckRequest) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*CheckRequest)
@@ -124,10 +121,7 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -138,10 +132,7 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 }
 func (this *HealthCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*HealthCheckResponse)
@@ -154,10 +145,7 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -168,10 +156,7 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 }
 func (this *VersionCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*VersionCheckResponse)
@@ -184,10 +169,7 @@ func (this *VersionCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/oci.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/oci.pb.go
@@ -1499,10 +1499,7 @@ func init() {
 }
 func (this *Spec) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Spec)
@@ -1515,10 +1512,7 @@ func (this *Spec) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1566,10 +1560,7 @@ func (this *Spec) Equal(that interface{}) bool {
 }
 func (this *Process) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Process)
@@ -1582,10 +1573,7 @@ func (this *Process) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1644,10 +1632,7 @@ func (this *Process) Equal(that interface{}) bool {
 }
 func (this *Box) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Box)
@@ -1660,10 +1645,7 @@ func (this *Box) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1677,10 +1659,7 @@ func (this *Box) Equal(that interface{}) bool {
 }
 func (this *User) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*User)
@@ -1693,10 +1672,7 @@ func (this *User) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1721,10 +1697,7 @@ func (this *User) Equal(that interface{}) bool {
 }
 func (this *LinuxCapabilities) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxCapabilities)
@@ -1737,10 +1710,7 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1788,10 +1758,7 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 }
 func (this *POSIXRlimit) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*POSIXRlimit)
@@ -1804,10 +1771,7 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1824,10 +1788,7 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 }
 func (this *Mount) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Mount)
@@ -1840,10 +1801,7 @@ func (this *Mount) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1868,10 +1826,7 @@ func (this *Mount) Equal(that interface{}) bool {
 }
 func (this *Root) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Root)
@@ -1884,10 +1839,7 @@ func (this *Root) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1901,10 +1853,7 @@ func (this *Root) Equal(that interface{}) bool {
 }
 func (this *Hooks) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Hooks)
@@ -1917,10 +1866,7 @@ func (this *Hooks) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1952,10 +1898,7 @@ func (this *Hooks) Equal(that interface{}) bool {
 }
 func (this *Hook) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Hook)
@@ -1968,10 +1911,7 @@ func (this *Hook) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2001,10 +1941,7 @@ func (this *Hook) Equal(that interface{}) bool {
 }
 func (this *Linux) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Linux)
@@ -2017,10 +1954,7 @@ func (this *Linux) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2102,10 +2036,7 @@ func (this *Linux) Equal(that interface{}) bool {
 }
 func (this *Windows) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Windows)
@@ -2118,10 +2049,7 @@ func (this *Windows) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2132,10 +2060,7 @@ func (this *Windows) Equal(that interface{}) bool {
 }
 func (this *Solaris) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Solaris)
@@ -2148,10 +2073,7 @@ func (this *Solaris) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2162,10 +2084,7 @@ func (this *Solaris) Equal(that interface{}) bool {
 }
 func (this *LinuxIDMapping) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxIDMapping)
@@ -2178,10 +2097,7 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2198,10 +2114,7 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 }
 func (this *LinuxNamespace) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxNamespace)
@@ -2214,10 +2127,7 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2231,10 +2141,7 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 }
 func (this *LinuxDevice) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxDevice)
@@ -2247,10 +2154,7 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2279,10 +2183,7 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxResources) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxResources)
@@ -2295,10 +2196,7 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2337,10 +2235,7 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 }
 func (this *LinuxMemory) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxMemory)
@@ -2353,10 +2248,7 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2385,10 +2277,7 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 }
 func (this *LinuxCPU) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxCPU)
@@ -2401,10 +2290,7 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2433,10 +2319,7 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 }
 func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxWeightDevice)
@@ -2449,10 +2332,7 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2472,10 +2352,7 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxThrottleDevice)
@@ -2488,10 +2365,7 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2508,10 +2382,7 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxBlockIO) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxBlockIO)
@@ -2524,10 +2395,7 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2581,10 +2449,7 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 }
 func (this *LinuxPids) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxPids)
@@ -2597,10 +2462,7 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2611,10 +2473,7 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 }
 func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxDeviceCgroup)
@@ -2627,10 +2486,7 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2653,10 +2509,7 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 }
 func (this *LinuxNetwork) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxNetwork)
@@ -2669,10 +2522,7 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2691,10 +2541,7 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 }
 func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxHugepageLimit)
@@ -2707,10 +2554,7 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2724,10 +2568,7 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 }
 func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxInterfacePriority)
@@ -2740,10 +2581,7 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2757,10 +2595,7 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccomp) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxSeccomp)
@@ -2773,10 +2608,7 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2803,10 +2635,7 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxSeccompArg)
@@ -2819,10 +2648,7 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2842,10 +2668,7 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 }
 func (this *LinuxSyscall) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxSyscall)
@@ -2858,10 +2681,7 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2888,10 +2708,7 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 }
 func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxIntelRdt)
@@ -2904,10 +2721,7 @@ func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/utils.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/utils.go
@@ -33,38 +33,38 @@ func copyValue(to, from reflect.Value) error {
 		to.Set(reflect.New(to.Type().Elem()))
 		if fromKind == reflect.Ptr {
 			return copyValue(to.Elem(), from.Elem())
-		} else {
-			return copyValue(to.Elem(), from)
-		}
-	} else {
-		// Here the destination is not a pointer.
-		// Let's check what's the origin.
-		if fromKind == reflect.Ptr {
-			return copyValue(to, from.Elem())
 		}
 
-		switch toKind {
-		case reflect.Struct:
-			return copyStructValue(to, from)
-		case reflect.Slice:
-			return copySliceValue(to, from)
-		case reflect.Map:
-			return copyMapValue(to, from)
-		default:
-			// We now are copying non pointers scalar.
-			// This is the leaf of the recursion.
-			if from.Type() != to.Type() {
-				if from.Type().ConvertibleTo(to.Type()) {
-					to.Set(from.Convert(to.Type()))
-					return nil
-				} else {
-					return fmt.Errorf("Can not convert %v to %v", from.Type(), to.Type())
-				}
-			} else {
-				to.Set(from)
+		return copyValue(to.Elem(), from)
+	}
+
+	// Here the destination is not a pointer.
+	// Let's check what's the origin.
+	if fromKind == reflect.Ptr {
+		return copyValue(to, from.Elem())
+	}
+
+	switch toKind {
+	case reflect.Struct:
+		return copyStructValue(to, from)
+	case reflect.Slice:
+		return copySliceValue(to, from)
+	case reflect.Map:
+		return copyMapValue(to, from)
+	default:
+		// We now are copying non pointers scalar.
+		// This is the leaf of the recursion.
+		if from.Type() != to.Type() {
+			if from.Type().ConvertibleTo(to.Type()) {
+				to.Set(from.Convert(to.Type()))
 				return nil
 			}
+
+			return fmt.Errorf("Can not convert %v to %v", from.Type(), to.Type())
 		}
+
+		to.Set(from)
+		return nil
 	}
 }
 
@@ -228,6 +228,7 @@ func copyStruct(to interface{}, from interface{}) (err error) {
 	return copyStructValue(toVal, fromVal)
 }
 
+// OCItoGRPC converts an OCI specification to its gRPC representation
 func OCItoGRPC(ociSpec *specs.Spec) (*Spec, error) {
 	s := &Spec{}
 
@@ -236,6 +237,7 @@ func OCItoGRPC(ociSpec *specs.Spec) (*Spec, error) {
 	return s, err
 }
 
+// GRPCtoOCI converts a gRPC specification back into an OCI representation
 func GRPCtoOCI(grpcSpec *Spec) (*specs.Spec, error) {
 	s := &specs.Spec{}
 
@@ -244,6 +246,8 @@ func GRPCtoOCI(grpcSpec *Spec) (*specs.Spec, error) {
 	return s, err
 }
 
+// ProcessOCItoGRPC converts an OCI process specification into its gRPC
+// representation
 func ProcessOCItoGRPC(ociProcess *specs.Process) (*Process, error) {
 	s := &Process{}
 
@@ -252,6 +256,8 @@ func ProcessOCItoGRPC(ociProcess *specs.Process) (*Process, error) {
 	return s, err
 }
 
+// ProcessGRPCtoOCI converts a gRPC specification back into an OCI
+// representation
 func ProcessGRPCtoOCI(grpcProcess *Process) (*specs.Process, error) {
 	s := &specs.Process{}
 

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/version.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/version.go
@@ -6,4 +6,6 @@
 
 package grpc
 
+// APIVersion specifies the version of the gRPC communications protocol used
+// by Kata Containers.
 const APIVersion = "0.0.1"


### PR DESCRIPTION
We have added support for passing network details to the agent in
virtcontainers' kata-agent.  Revendor to pull this in.

Shortlog:
    43c9ed3 kata-agent: add initial test for kata-agent networking
    082ec3f kata-agent: add network gRPC support
    4b30262 setup: #!/bin/bash in the wrong place
    8b7fddf vendor: re-vendor kata-containers agent
    07c2c88 test: Modify block device test to test for SCSI as well
    a1a569a scsi: Add SCSI support for volumes as well
    3c038f1 scsi: Pass SCSI address to hyperstart agent
    80bdc50 tests: Fix tests to take into account default driver for block devices
    7df3f45 scsi: Add support for scsi driver for hotplugging drives
    10e2349 1.0.7 release
    10d462c block: Fix disabling block device use
    fd6f6ed pod: Factorize network creation and removal into pod functions
    2fec63f pod: StartVM() does not need any parameter
    0dd84be container: Remove the container from pod structure on deletion
    b852d93 api: Stop the VM when stopping the pod
    17065de pod: Simplify pod stop
    bcb8643 pod: Delete containers when deleting the pod

Signed-off-by: Eric Ernst <eric.ernst@intel.com>