### PR TITLE
config: Don't use VMConfig.VCPUs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
     "pkg/uuid",
     "pkg/vcMock"
   ]
-  revision = "1dce29db26331bb48be149ef6a1254483128aa89"
+  revision = "4fb2dacea4ab8b15807fa982e695487c9a20dc46"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e36a22c9fa6bbb0ad20dd93f678582fc06253f5c82c8d23654ac5c50e53f7d34"
+  inputs-digest = "eac859455568d17a23cb3dbb7ebff8ce6706d1e0d7ebb8c34b962be38842a51b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "1dce29db26331bb48be149ef6a1254483128aa89"
+  revision = "4fb2dacea4ab8b15807fa982e695487c9a20dc46"
 
 [prune]
   non-go = true

--- a/config.go
+++ b/config.go
@@ -328,7 +328,6 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 				return fmt.Errorf("%v: %v", configPath, err)
 			}
 
-			config.VMConfig.VCPUs = uint(hConfig.DefaultVCPUs)
 			config.VMConfig.Memory = uint(hConfig.DefaultMemSz)
 
 			config.HypervisorConfig = hConfig

--- a/config_test.go
+++ b/config_test.go
@@ -166,7 +166,6 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		ShimConfig: shimConfig,
 
 		VMConfig: vc.Resources{
-			VCPUs:  uint(defaultVCPUCount),
 			Memory: uint(defaultMemSize),
 		},
 	}
@@ -1026,7 +1025,6 @@ func TestUpdateRuntimeConfigurationVMConfig(t *testing.T) {
 
 	config := oci.RuntimeConfig{}
 	expectedVMConfig := vc.Resources{
-		VCPUs:  vcpus,
 		Memory: mem,
 	}
 

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -182,7 +182,6 @@ type HypervisorConfig struct {
 	Debug bool
 
 	// DefaultVCPUs specifies default number of vCPUs for the VM.
-	// Pod configuration VMConfig.VCPUs overwrites this.
 	DefaultVCPUs uint32
 
 	//DefaultMaxVCPUs specifies the maximum number of vCPUs for the VM.

--- a/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/oci/utils.go
@@ -440,23 +440,6 @@ func vmConfig(ocispec CompatOCISpec, config RuntimeConfig) (vc.Resources, error)
 		resources.Memory = uint((memBytes + (1024*1024 - 1)) / (1024 * 1024))
 	}
 
-	if ocispec.Linux.Resources.CPU != nil &&
-		ocispec.Linux.Resources.CPU.Quota != nil &&
-		ocispec.Linux.Resources.CPU.Period != nil {
-		quota := *ocispec.Linux.Resources.CPU.Quota
-		period := *ocispec.Linux.Resources.CPU.Period
-
-		if quota <= 0 {
-			return vc.Resources{}, fmt.Errorf("Invalid OCI cpu quota %d", quota)
-		}
-
-		if period == 0 {
-			return vc.Resources{}, fmt.Errorf("Invalid OCI cpu period %d", period)
-		}
-
-		resources.VCPUs = vc.ConstraintsToVCPUs(quota, period)
-	}
-
 	return resources, nil
 }
 

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -313,9 +313,6 @@ type Cmd struct {
 
 // Resources describes VM resources configuration.
 type Resources struct {
-	// VCPUs is the number of available virtual CPUs.
-	VCPUs uint
-
 	// Memory is the amount of available memory in MiB.
 	Memory uint
 }

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -204,13 +204,8 @@ func (q *qemu) init(pod *Pod) error {
 	return nil
 }
 
-func (q *qemu) cpuTopology(podConfig PodConfig) govmmQemu.SMP {
-	vcpus := q.config.DefaultVCPUs
-	if podConfig.VMConfig.VCPUs > 0 {
-		vcpus = uint32(podConfig.VMConfig.VCPUs)
-	}
-
-	return q.arch.cpuTopology(vcpus)
+func (q *qemu) cpuTopology() govmmQemu.SMP {
+	return q.arch.cpuTopology(q.config.DefaultVCPUs)
 }
 
 func (q *qemu) memoryTopology(podConfig PodConfig) (govmmQemu.Memory, error) {
@@ -266,7 +261,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		machine.Options += accelerators
 	}
 
-	smp := q.cpuTopology(podConfig)
+	smp := q.cpuTopology()
 
 	memory, err := q.memoryTopology(podConfig)
 	if err != nil {


### PR DESCRIPTION
VMConfig.VCPUs is no more part of the virtcontainer API.
virtcontainer starts the VM with the number of vCPUs specified
by DefaulVCPUs (default_vcpus).

fixes #1047

Signed-off-by: Julio Montes <julio.montes@intel.com>