### PR TITLE
main: stacktrace/coredump on error

### DIFF
--- a/config.go
+++ b/config.go
@@ -447,11 +447,14 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		return "", config, err
 	}
 
-	if !tomlConf.Runtime.Debug {
+	if tomlConf.Runtime.Debug {
+		crashOnError = true
+	} else {
 		// If debug is not required, switch back to the original
 		// default log priority, otherwise continue in debug mode.
 		ccLog.Logger.Level = originalLoggerLevel
 	}
+
 	if tomlConf.Runtime.InterNetworkModel != "" {
 		err = config.InterNetworkModel.SetModel(tomlConf.Runtime.InterNetworkModel)
 		if err != nil {

--- a/fatal.go
+++ b/fatal.go
@@ -1,0 +1,80 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
+	"syscall"
+)
+
+// List of fatal signals
+var sigFatal = map[syscall.Signal]bool{
+	syscall.SIGABRT:   true,
+	syscall.SIGBUS:    true,
+	syscall.SIGILL:    true,
+	syscall.SIGQUIT:   true,
+	syscall.SIGSEGV:   true,
+	syscall.SIGSTKFLT: true,
+	syscall.SIGSYS:    true,
+	syscall.SIGTRAP:   true,
+}
+
+func handlePanic() {
+	r := recover()
+
+	if r != nil {
+		msg := fmt.Sprintf("%s", r)
+		ccLog.WithField("panic", msg).Error("fatal error")
+
+		die()
+	}
+}
+
+func backtrace() {
+	profiles := pprof.Profiles()
+
+	buf := &bytes.Buffer{}
+
+	for _, p := range profiles {
+		// The magic number requests a full stacktrace. See
+		// https://golang.org/pkg/runtime/pprof/#Profile.WriteTo.
+		pprof.Lookup(p.Name()).WriteTo(buf, 2)
+	}
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		ccLog.Error(line)
+	}
+}
+
+func fatalSignal(sig syscall.Signal) bool {
+	return sigFatal[sig]
+}
+
+func fatalSignals() []syscall.Signal {
+	var signals []syscall.Signal
+
+	for sig := range sigFatal {
+		signals = append(signals, sig)
+
+	}
+
+	return signals
+}
+
+func die() {
+	backtrace()
+
+	if crashOnError {
+		signal.Reset(syscall.SIGABRT)
+		syscall.Kill(0, syscall.SIGABRT)
+	}
+
+	exit(1)
+}


### PR DESCRIPTION
If the runtime detects an internal error or if it receives
a fatal signal, write a stack trace to the log and exit.

If debug is enabled also dump core.

Note: This replaces the previous `debug.SetTraceback()` call which
logs to `stderr`, which is not desirable.

Fixes #1053.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>