### PR TITLE
CI: Add maligned linter

### DIFF
--- a/.ci/go-static-checks.sh
+++ b/.ci/go-static-checks.sh
@@ -74,6 +74,7 @@ install_package github.com/opennota/check/cmd/varcheck
 install_package honnef.co/go/tools/cmd/unused
 install_package honnef.co/go/tools/cmd/staticcheck
 install_package github.com/mdempsky/unconvert
+install_package github.com/mdempsky/maligned
 
 echo Doing go static checks on packages: $go_packages
 
@@ -106,7 +107,7 @@ for p in $go_packages; do golint -set_exit_status $p; done
 echo "Running ineffassign..."
 go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
 
-for tool in structcheck varcheck unused staticcheck unconvert
+for tool in structcheck varcheck unused staticcheck unconvert maligned
 do
 	echo "Running ${tool}..."
 	eval "$tool" "$go_packages"

--- a/exec.go
+++ b/exec.go
@@ -34,9 +34,9 @@ type execParams struct {
 	pidFile      string
 	console      string
 	consoleSock  string
-	detach       bool
 	processLabel string
 	noSubreaper  bool
+	detach       bool
 }
 
 var execCLICommand = cli.Command{


### PR DESCRIPTION
Run the `maligned` linter to minimise struct space.

Includes the single fix required to pass the `maligned` tests.

Fixes #1064.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>