### PR TITLE
CI: Add varcheck and unconvert linters

### DIFF
--- a/.ci/go-static-checks.sh
+++ b/.ci/go-static-checks.sh
@@ -70,8 +70,10 @@ install_package github.com/client9/misspell/cmd/misspell
 install_package github.com/golang/lint/golint
 install_package github.com/gordonklaus/ineffassign
 install_package github.com/opennota/check/cmd/structcheck
+install_package github.com/opennota/check/cmd/varcheck
 install_package honnef.co/go/tools/cmd/unused
 install_package honnef.co/go/tools/cmd/staticcheck
+install_package github.com/mdempsky/unconvert
 
 echo Doing go static checks on packages: $go_packages
 
@@ -104,7 +106,7 @@ for p in $go_packages; do golint -set_exit_status $p; done
 echo "Running ineffassign..."
 go list -f '{{.Dir}}' $go_packages | xargs -L 1 ineffassign
 
-for tool in structcheck unused staticcheck
+for tool in structcheck varcheck unused staticcheck unconvert
 do
 	echo "Running ${tool}..."
 	eval "$tool" "$go_packages"

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,6 @@ SHAREDIR := $(PREFIX)/share
 DEFAULTSDIR := $(SHAREDIR)/defaults
 
 PKGDATADIR := $(SHAREDIR)/$(PROJECT_DIR)
-PKGLIBDIR := $(LOCALSTATEDIR)/lib/$(PROJECT_DIR)
 PKGRUNDIR := $(LOCALSTATEDIR)/run/$(PROJECT_DIR)
 PKGLIBEXECDIR := $(LIBEXECDIR)/$(PROJECT_DIR)
 
@@ -275,7 +274,6 @@ USER_VARS += KERNELPARAMS
 USER_VARS += LIBEXECDIR
 USER_VARS += LOCALSTATEDIR
 USER_VARS += PKGDATADIR
-USER_VARS += PKGLIBDIR
 USER_VARS += PKGLIBEXECDIR
 USER_VARS += PKGRUNDIR
 USER_VARS += PREFIX
@@ -396,8 +394,6 @@ var defaultShimPath = "$(SHIMPATH)"
 const defaultKernelParams = "$(KERNELPARAMS)"
 const defaultMachineType = "$(MACHINETYPE)"
 const defaultRootDirectory = "$(PKGRUNDIR)"
-const defaultRuntimeLib = "$(PKGLIBDIR)"
-const defaultRuntimeRun = "$(PKGRUNDIR)"
 
 const defaultVCPUCount uint32 = $(DEFVCPUS)
 const defaultMemSize uint32 = $(DEFMEMSZ) // MiB


### PR DESCRIPTION
Add two additional linters, `varcheck` and `unconvert`, that check for
unused globals and unnecessary conversions respectively.

Fixes #1066.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
