### PR TITLE
ci: Add update vendoring script.

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script will clone `clearcontainers/tests` repository and 
-# will use the CI scripts that live in that repository to create 
+# This script will clone `clearcontainers/tests` repository and
+# will use the CI scripts that live in that repository to create
 # a proper environment (Installing dependencies and building the
-# components) to test the Clear Containers project 
+# components) to test the Clear Containers project
 
 set -e
+
+cidir=$(dirname "$0")
 
 test_repo="github.com/clearcontainers/tests"
 
@@ -38,6 +40,12 @@ checkcommits \
 	--subject-length 75 \
 	--ignore-fixes-for-subsystem "release" \
 	--verbose
+
+# This will update virtcontainers if there is a change in kata-containers/runtime/virtcontainers
+if [ "${ghprbGhRepository}" = "kata-containers/runtime" ]; then
+	echo "Update virtcontainers vendoring"
+	bash -c "${cidir}/update-vendoring.sh"
+fi
 
 # Setup environment and build components.
 cd "${test_repo_dir}"

--- a/.ci/update-vendoring.sh
+++ b/.ci/update-vendoring.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will allow to vendor kata-containers/runtime/virtcontainers
+
+set -e
+
+virtcontainers_repo="github.com/kata-containers/runtime"
+clearcontainers_runtime_repo="github.com/clearcontainers/runtime"
+
+function get_repo(){
+	go get -u ${virtcontainers_repo} || true
+}
+
+function install_dep(){
+	go get -u github.com/golang/dep/cmd/dep
+}
+
+function update_repo(){
+	if [ "${ghprbAuthorRepoGitUrl}" ] && [ "${ghprbActualCommit}" ]
+	then
+		repo="$1"
+		if [ ! -d "${GOPATH}/src/${repo}" ]; then
+			go get -d "$repo" || true
+		fi
+
+		pushd "${GOPATH}/src/${repo}"
+
+		# Update Gopkg.toml
+		cat >> Gopkg.toml <<EOF
+
+[[override]]
+  name = "${virtcontainers_repo}"
+  source = "${ghprbAuthorRepoGitUrl}"
+  revision = "${ghprbActualCommit}"
+EOF
+
+		# Update the whole vendoring
+		dep ensure && dep ensure -update "${virtcontainers_repo}" && dep prune
+
+		popd
+	fi
+}
+
+get_repo
+install_dep
+update_repo "${clearcontainers_runtime_repo}"


### PR DESCRIPTION
Add update vendoring script in the CI which will
allows to vendor kata-runtime.

Fixes #1070

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>