### PR TITLE
vendor: Update covertool for go1.10

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,7 +45,7 @@
 [[projects]]
   name = "github.com/dlespiau/covertool"
   packages = ["pkg/cover"]
-  revision = "b82616d290e628437bc08b858b5ecb3d7fe9ea53"
+  revision = "b0c4c6d0583aae4e3b5d12b6ec47767670548cc4"
 
 [[projects]]
   name = "github.com/go-ini/ini"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "972c797d90dcfc31732ccdaf4b8543c47d17db65601d291a6b40e0fd658c18e0"
+  inputs-digest = "88eda943d624cec7dc154191b57ef1804ed7fff82a125e8377ea8b1f5e6b7f93"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/dlespiau/covertool"
-  revision = "b82616d290e628437bc08b858b5ecb3d7fe9ea53"
+  revision = "b0c4c6d0583aae4e3b5d12b6ec47767670548cc4"
 
 [[constraint]]
   name = "github.com/opencontainers/runc"

--- a/vendor/github.com/dlespiau/covertool/pkg/cover/cover.go
+++ b/vendor/github.com/dlespiau/covertool/pkg/cover/cover.go
@@ -47,6 +47,8 @@ type dummyTestDeps func(pat, str string) (bool, error)
 func (d dummyTestDeps) MatchString(pat, str string) (bool, error)   { return false, nil }
 func (d dummyTestDeps) StartCPUProfile(io.Writer) error             { return nil }
 func (d dummyTestDeps) StopCPUProfile()                             {}
+func (f dummyTestDeps) StartTestLog(w io.Writer)                    {}
+func (f dummyTestDeps) StopTestLog() error                          { return nil }
 func (d dummyTestDeps) WriteHeapProfile(io.Writer) error            { return nil }
 func (d dummyTestDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
 func (f dummyTestDeps) ImportPath() string                          { return "" }


### PR DESCRIPTION
Re-vendor covertool to work with golang 1.10.

Changes:

    5072b09 CI: Update travis for go1.10
    7cf24e2 cover: Fix build for 1.10
    d45792f command; Factor out a WriteProfilesToFile function
    012b32c profile: Factor out WriteProfiles to its own file
    a61bda3 merge: Rename WriteProfile to WriteProfiles for consitency
    449c650 merge: Remove unused type
    77573e5 merge: Remove spurious 'profile' in help text
    e0e4815 travis: Add go 1.9 to the test matrix
    df49b48 README: Add a new covertool section and more context for instrumented binaries
    a89ec05 examples: Fix an "instrumented" typo

Fixes #1072.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>