### PR TITLE
cc-check: Use nanosecond timestamps when stderr is redirected

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	goruntime "runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
@@ -159,6 +160,9 @@ func init() {
 	// config file parsing, it is prudent to operate in verbose mode.
 	originalLoggerLevel = ccLog.Logger.Level
 	ccLog.Logger.Level = logrus.DebugLevel
+	ccLog.Logger.Formatter = &logrus.TextFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
 }
 
 func setupSignalHandler() {


### PR DESCRIPTION
For consistency with all other timestamps, change `cc-check` to use
nanosecond timestamps when `stderr` is not a terminal.

Fixes #1074.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>