### PR TITLE
versions: Add supported cri-containerd version

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -23,6 +23,9 @@ docker_swarm_version=1.12.1
 # Supported CRI-O version
 crio_version=v1.9.10
 
+# Supported cri-containerd version
+cri_containerd_version="v1.0.0-rc.0"
+
 # Runc version compatible with crio_version
 runc_version=v1.0.0-rc5
 


### PR DESCRIPTION
Add suported cri-containerd version.
cri-containerd now supports trusted and untrusted runtimes.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>